### PR TITLE
ci(paymaster-proxy): add GitHub workflow to build and push image to Docker Hub

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,43 @@
+name: Build and push docker images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push-to-docker-hub:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    environment: dockerhub
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Get metadata for Docker image tags
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ethereumoptimism/paymaster-proxy
+          tags: |
+            type=sha
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN_SECRET }}
+
+      - name: Build and push paymaster-proxy image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          target: paymaster-proxy
+          push: true
+          tags: ${{ steps.docker-meta.outputs.tags }}


### PR DESCRIPTION
Adds a GitHub workflow that builds and pushes the `paymaster-proxy` app image to DockerHub. Triggered on every merge to `main` or can be manually triggered.

TODO: need to add new repository secrets for Docker hub credentials.