### PR TITLE
feat(paymaster-proxy): add envVars and example.env generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ packages/*/.env
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/apps/paymaster-proxy/README.md
+++ b/apps/paymaster-proxy/README.md
@@ -1,3 +1,17 @@
 # Paymaster Proxy Service
 
 A simple RPC proxy with rate limiting that routes requests to a Paymaster service provider.
+
+## Getting started
+
+#### 1. Create `.env` file and fill in empty values
+
+```bash
+cp example.env .env
+```
+
+#### 2. Start dev server
+
+```bash
+pnpm run dev
+```

--- a/apps/paymaster-proxy/example.env
+++ b/apps/paymaster-proxy/example.env
@@ -1,0 +1,8 @@
+# Environment Variables Schema (generated) 
+
+# Port to listen on
+PORT=
+
+# Hostname for server binding
+# default: 0.0.0.0
+# HOST=

--- a/apps/paymaster-proxy/package.json
+++ b/apps/paymaster-proxy/package.json
@@ -8,19 +8,24 @@
     "build": "tsup src/app.ts",
     "start": "node dist/app.js",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
-    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn"
+    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn",
+    "generate-example-env": "ts-node scripts/generateExampleEnv.ts"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",
     "prettier": "^3.1.0",
+    "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "dotenv": "^16.4.1",
+    "express": "^4.18.2",
+    "zod": "^3.22.4"
   },
   "files": [
     "dist"

--- a/apps/paymaster-proxy/scripts/generateExampleEnv.ts
+++ b/apps/paymaster-proxy/scripts/generateExampleEnv.ts
@@ -1,0 +1,38 @@
+import fs from 'fs'
+import path from 'path'
+
+import { envVarsSchema } from '../src/envVarsSchema'
+
+// generates an example.env file based on envVarsSchema
+const generateExampleEnv = () => {
+  const output = envVarsSchema
+    .keyof()
+    .options.map((envVarKey) => {
+      const validator = envVarsSchema.shape[envVarKey]
+      const defaultValueParse = validator.safeParse(undefined)
+
+      // if default value exists
+      //     # default: 0.0.0.0
+      //     # HOST=
+      // if default value does not exist
+      //     HOST=
+      return [
+        validator.description ? `# ${validator.description}` : undefined,
+        defaultValueParse.success
+          ? `# default: ${defaultValueParse.data}\n# ${envVarKey}=`
+          : `${envVarKey}=`,
+        // add newline
+        '',
+      ]
+    })
+    .flat()
+    .filter((x) => x !== undefined)
+    .join('\n')
+
+  return `# Environment Variables Schema (generated) \n\n${output}`
+}
+
+fs.writeFileSync(
+  path.join(__dirname, '..', 'example.env'),
+  generateExampleEnv(),
+)

--- a/apps/paymaster-proxy/src/app.ts
+++ b/apps/paymaster-proxy/src/app.ts
@@ -1,10 +1,13 @@
 import express from 'express'
 
+import { envVars } from '@/envVars'
+
 const app = express()
-const port = 3000
+
 app.get('/', (req, res) => {
   res.send('Hello World!')
 })
-app.listen(port, () => {
-  console.log(`Server listening at http://localhost:${port}`)
+
+app.listen(envVars.PORT, envVars.HOST, () => {
+  console.log(`Server listening at http://${envVars.HOST}:${envVars.PORT}`)
 })

--- a/apps/paymaster-proxy/src/envVars.ts
+++ b/apps/paymaster-proxy/src/envVars.ts
@@ -1,0 +1,5 @@
+import 'dotenv/config'
+
+import { envVarsSchema } from '@/envVarsSchema'
+
+export const envVars = envVarsSchema.parse(process.env)

--- a/apps/paymaster-proxy/src/envVarsSchema.ts
+++ b/apps/paymaster-proxy/src/envVarsSchema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const envVarsSchema = z.object({
+  PORT: z.coerce.number().describe('Port to listen on'),
+  HOST: z.string().default('0.0.0.0').describe('Hostname for server binding'),
+})

--- a/apps/paymaster-proxy/tsconfig.json
+++ b/apps/paymaster-proxy/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
+  "include": ["src", "scripts"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,13 +175,22 @@ importers:
 
   apps/paymaster-proxy:
     dependencies:
+      dotenv:
+        specifier: ^16.4.1
+        version: 16.4.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.10.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.10.0
         version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.56.0)(typescript@5.3.2)
@@ -194,6 +203,9 @@ importers:
       prettier:
         specifier: ^3.1.0
         version: 3.1.0
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@20.10.0)(typescript@5.3.2)
       tsup:
         specifier: ^8.0.1
         version: 8.0.1(ts-node@10.9.1)(typescript@5.3.2)
@@ -7212,14 +7224,9 @@ packages:
       acorn: 8.11.2
     dev: true
 
-  /acorn-walk@8.3.0:
-    resolution: {integrity: sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==}
-    engines: {node: '>=0.4.0'}
-
   /acorn-walk@8.3.1:
     resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
@@ -8644,6 +8651,11 @@ packages:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
     dev: true
+
+  /dotenv@16.4.1:
+    resolution: {integrity: sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -14161,7 +14173,7 @@ packages:
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.10.0
       acorn: 8.11.2
-      acorn-walk: 8.3.0
+      acorn-walk: 8.3.1
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2


### PR DESCRIPTION
- adds a script to generateExampleEnv that uses the envVarsSchema to generate a `example.env` file - this existed while back in the previous repo
- adds a basic envVars file with `HOST` and `PORT` that will be used for express server
- updated README.md file with minimal getting started instructions