### PR TITLE
feat(paymaster-proxy): add healthcheck/readiness routes and simple docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ RUN pnpm deploy --filter=paymaster-proxy --prod /prod/paymaster-proxy
 FROM base AS paymaster-proxy
 COPY --from=builder /prod/paymaster-proxy /prod/paymaster-proxy
 WORKDIR /prod/paymaster-proxy
-EXPOSE 3000
+EXPOSE 7310
 CMD [ "pnpm", "start" ]

--- a/apps/paymaster-proxy/docker-compose.yml
+++ b/apps/paymaster-proxy/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: Dockerfile
       target: paymaster-proxy
     environment:
-      - HOST=0.0.0.0
       - PORT=7310
     ports:
       - 7310:7310

--- a/apps/paymaster-proxy/docker-compose.yml
+++ b/apps/paymaster-proxy/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  paymaster-proxy:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      target: paymaster-proxy
+    environment:
+      - HOST=0.0.0.0
+      - PORT=7310
+    ports:
+      - 7310:7310
+    healthcheck:
+      test: wget localhost:7310/healthz -q -O - > /dev/null 2>&1

--- a/apps/paymaster-proxy/example.env
+++ b/apps/paymaster-proxy/example.env
@@ -2,7 +2,3 @@
 
 # Port to listen on
 PORT=
-
-# Hostname for server binding
-# default: 0.0.0.0
-# HOST=

--- a/apps/paymaster-proxy/src/app.ts
+++ b/apps/paymaster-proxy/src/app.ts
@@ -4,8 +4,13 @@ import { envVars } from '@/envVars'
 
 const app = express()
 
-app.get('/', (req, res) => {
-  res.send('Hello World!')
+app.get('/healthz', (req, res) => {
+  res.json({ ok: true })
+})
+
+app.get('/ready', (req, res) => {
+  // TODO: add check for whether underlying services are ready
+  res.json({ ok: true })
 })
 
 app.listen(envVars.PORT, envVars.HOST, () => {

--- a/apps/paymaster-proxy/src/app.ts
+++ b/apps/paymaster-proxy/src/app.ts
@@ -2,6 +2,8 @@ import express from 'express'
 
 import { envVars } from '@/envVars'
 
+const HOST = '0.0.0.0'
+
 const app = express()
 
 app.get('/healthz', (req, res) => {
@@ -13,6 +15,6 @@ app.get('/ready', (req, res) => {
   res.json({ ok: true })
 })
 
-app.listen(envVars.PORT, envVars.HOST, () => {
-  console.log(`Server listening at http://${envVars.HOST}:${envVars.PORT}`)
+app.listen(envVars.PORT, HOST, () => {
+  console.log(`Server listening at http://${HOST}:${envVars.PORT}`)
 })

--- a/apps/paymaster-proxy/src/envVarsSchema.ts
+++ b/apps/paymaster-proxy/src/envVarsSchema.ts
@@ -2,5 +2,4 @@ import { z } from 'zod'
 
 export const envVarsSchema = z.object({
   PORT: z.coerce.number().describe('Port to listen on'),
-  HOST: z.string().default('0.0.0.0').describe('Hostname for server binding'),
 })


### PR DESCRIPTION
- adds a docker-compose for testing docker build 
- adds `/healthz` and `/ready` route for k8s
- hardcodes HOST in the code instead of relying on envvar