### PR TITLE
fix(ci): update machine to docker executor to use layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
   docker-build:
     environment:
       DOCKER_BUILDKIT: 1
-    machine:
-      image: ubuntu-2204:2022.07.1
+    docker:
+      - image: cimg/base:2024.01
     parameters:
       docker_name:
         description: Docker image name


### PR DESCRIPTION
setup_remote_docker job is only available on docker executor
