### PR TITLE
build(paymaster-proxy): pull in certs in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ npm-debug.log*
 **/storybook-static/
 
 # cert files
-
 *.crt
 *.pem
 *.key

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,11 @@ packages/*/.env
 
 npm-debug.log*
 
-#storybook
+# storybook
 **/storybook-static/
+
+# cert files
+
+*.crt
+*.pem
+*.key

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/node_modules
 /.pnp
 packages/*/.env
+app/*/.env
 .npmrc
 
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,11 @@ RUN pnpm deploy --filter=paymaster-proxy --prod /prod/paymaster-proxy
 ########################################
 
 FROM base AS paymaster-proxy
+
 COPY --from=builder /prod/paymaster-proxy /prod/paymaster-proxy
 WORKDIR /prod/paymaster-proxy
 
-# setup certs for internal services
-RUN update-ca-certificates
-
-ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/extra-ca-certificates.crt
 
 EXPOSE 7310
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,12 @@ RUN pnpm deploy --filter=paymaster-proxy --prod /prod/paymaster-proxy
 FROM base AS paymaster-proxy
 COPY --from=builder /prod/paymaster-proxy /prod/paymaster-proxy
 WORKDIR /prod/paymaster-proxy
+
+# setup certs for internal services
+RUN update-ca-certificates
+
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 EXPOSE 7310
+
 CMD [ "pnpm", "start" ]

--- a/apps/paymaster-proxy/docker-compose.yml
+++ b/apps/paymaster-proxy/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       - 7310:7310
     healthcheck:
       test: wget localhost:7310/healthz -q -O - > /dev/null 2>&1
+    volumes:
+      - ../../certs/extra-ca-certificates.crt:/usr/local/share/ca-certificates/extra-ca-certificates.crt

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,0 +1,6 @@
+*.crt
+*.pem
+
+*
+!README.md
+!.gitignore

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,6 +1,3 @@
-*.crt
-*.pem
-
 *
 !README.md
 !.gitignore

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,3 @@
+# Certificates
+
+Add any certificates needed local development here. All files inside this folder (except the `README.md`) will be gitignored.


### PR DESCRIPTION
- mounts extra-ca-certificates.cert to `usr/local/share/ca-certificates/extra-ca-certificates.crt`
- passes the extra certificates path to env so node picks it up
- fine if the file doesn't exist, app still runs as errors are ignored (warning is emitted though like the following)

```
Warning: Ignoring extra certs from `/usr/local/share/ca-certificates/extra-ca-certificates.crt`, load failed: error:80000002:system library::No such file or directory
```