### PR TITLE
Implement console header section

### DIFF
--- a/apps/dapp-console/app/console/components/ProjectIconLinks.tsx
+++ b/apps/dapp-console/app/console/components/ProjectIconLinks.tsx
@@ -70,6 +70,7 @@ const IconLink = ({ logo, label, href, key, style }: IconLinkProps) => {
       href={href}
       target="_blank"
       key={key}
+      rel="noreferrer noopener"
       className="rounded-full overflow-hidden border border-gray-200 -ml-2"
       style={{ ...style, position: 'relative' }}
     >

--- a/apps/dapp-console/app/console/components/ProjectIconLinks.tsx
+++ b/apps/dapp-console/app/console/components/ProjectIconLinks.tsx
@@ -1,0 +1,81 @@
+import { externalRoutes } from '@/app/constants'
+import Image from 'next/image'
+
+const linkItems = [
+  {
+    ...externalRoutes.ETH_DOCS,
+    logo: '/logos/eth-logo.png',
+  },
+  {
+    ...externalRoutes.BASE_DOCS,
+    logo: '/logos/base-logo.png',
+  },
+  {
+    ...externalRoutes.FRAX_DOCS,
+    logo: '/logos/frax-logo.png',
+  },
+  {
+    ...externalRoutes.LISK_DOCS,
+    logo: '/logos/lisk-logo.png',
+  },
+  {
+    ...externalRoutes.MODE_DOCS,
+    logo: '/logos/mode-logo.png',
+  },
+  {
+    ...externalRoutes.OPTIMISM_DOCS,
+    logo: '/logos/op-logo.svg',
+  },
+  {
+    ...externalRoutes.REDSTONE_DOCS,
+    logo: '/logos/redstone-logo.png',
+  },
+  {
+    ...externalRoutes.ZORA_DOCS,
+    logo: '/logos/zora-logo.png',
+  },
+]
+
+const ProjectIconLinks = () => {
+  return (
+    <div className="flex items-center relative">
+      {linkItems.map((item, index) => {
+        // Calculate z-index in reverse order, so leftmost has the highest z-index
+        const zIndex = linkItems.length - index
+        return (
+          <IconLink
+            logo={item.logo}
+            label={item.label}
+            href={item.path}
+            key={item.logo}
+            style={{ zIndex }}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+type IconLinkProps = {
+  logo: string
+  label: string
+  href: string
+  key: string
+  style: React.CSSProperties
+}
+
+const IconLink = ({ logo, label, href, key, style }: IconLinkProps) => {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      key={key}
+      className="rounded-full overflow-hidden border border-gray-200 -ml-2"
+      style={{ ...style, position: 'relative' }}
+    >
+      <Image src={logo} alt={`${label} logo`} height={40} width={40} />
+    </a>
+  )
+}
+
+export { ProjectIconLinks }

--- a/apps/dapp-console/app/page.tsx
+++ b/apps/dapp-console/app/page.tsx
@@ -1,3 +1,41 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@eth-optimism/ui-components/src/components/ui/card'
+
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import { ProjectIconLinks } from '@/app/console/components/ProjectIconLinks'
+
 export default function Page() {
-  return <main>This is the dapp console home page</main>
+  return (
+    <main className="flex justify-center relative">
+      <Banner />
+      <Card className="max-w-7xl w-full mt-36 mx-8 z-10">
+        <CardHeader>
+          <CardTitle>
+            <Text as="span" className="text-4xl mb-2">
+              Dapp Developer Console
+            </Text>
+          </CardTitle>
+          <CardDescription>
+            <Text as="span" className="text-base mb-6">
+              Tools to help you build, launch, and grow your dapp on the{' '}
+              <b className="text-accent-foreground">Superchain</b>
+            </Text>
+          </CardDescription>
+          <div className="pt-6">
+            <ProjectIconLinks />
+          </div>
+        </CardHeader>
+        <CardContent>hey</CardContent>
+      </Card>
+    </main>
+  )
+}
+
+const Banner = () => {
+  return <div className="absolute -inset-x-0 w-full h-80 bg-red-200" />
 }

--- a/packages/ui-components/src/components/ui/card.tsx
+++ b/packages/ui-components/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border bg-card text-card-foreground shadow-sm',
+      'rounded-lg border border-border bg-card text-card-foreground shadow-sm',
       className,
     )}
     {...props}


### PR DESCRIPTION
### Description
Implementation of the header section for the console page.
Image background still is a placeholder until we get the finalized image from the brand team.


<img width="1036" alt="Screenshot 2024-02-05 at 11 14 18 AM" src="https://github.com/ethereum-optimism/ecosystem/assets/10838132/7a6ba02c-10f5-4593-a200-bd32decaed58">