### PR TITLE
Fixes incorrect vitest test pool env var

### DIFF
--- a/packages/op-app/src/test-utils/chains.ts
+++ b/packages/op-app/src/test-utils/chains.ts
@@ -6,7 +6,7 @@ import { L1_PORT, L2_PORT } from './constants'
 
 const [mainnet, opMainnet] = networkPairsByGroup.op.mainnet
 
-const vitestPool = process.env.VITEST_vitestPool_ID ?? 1
+const vitestPool = process.env.VITEST_POOL_ID ?? 1
 
 export const l1ForkURL = mainnet.rpcUrls.default.http[0]
 export const l2ForkURL = optimism.rpcUrls.default.http[0]


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The environment variable we were using to figure out the vitest test pool was incorrect looks like its from a bad find and replace. This PR just fixes it to be `VITEST_POOL_ID` like expected, otherwise we are always defaulting to `1` which might not always exist
