### PR TITLE
swap run-many to affected

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,10 +12,19 @@ runs:
         registry-url: https://registry.npmjs.org
         cache: pnpm
 
+    - name: set nx base and head ref
+      uses: nrwl/nx-set-shas@v4
+
+    - name: log nx base and head ref
+      run: |
+        echo "BASE: ${{ env.NX_BASE }}"
+        echo "HEAD: ${{ env.NX_HEAD }}"
+      shell: bash
+
     - name: pnpm install node modules
       run: pnpm i --frozen-lockfile
       shell: bash
 
     - name: pnpm build
-      run: pnpm nx run-many --target=build
+      run: pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=build
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,34 +22,40 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run TypeChecker
         run: |
-          pnpm nx run-many --target=typecheck
+          pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=typecheck
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run Linters
         run: |
-          pnpm nx run-many --target=lint
+          pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint
 
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run Tests
         run: |
-          pnpm nx run-many --target=test
+          pnpm nx affected --base=$NX_BASE --head=$NX_HEAD --target=test


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Updates the entire build to swap from `run-many` to `affected`. This will now only `build`, `lint`, `test`, `typecheck` only packages that have a change inside of them. We'll need to verify this is working correctly when building on the `main`, I tested out changes to `op-app` to see if it would build both `op-app` and `bridge-app` since they are part of the same tree and all looked good. We won't notice any real speed gains initially since we don't have much in the repo but starting this type of logic early will help keep this running smooth in the long run

Nx docs https://nx.dev/ci/features/affected 
