### PR TITLE
Implement Build + Launch & Grow modals

### DIFF
--- a/apps/dapp-console/app/console/components/BuildSection.tsx
+++ b/apps/dapp-console/app/console/components/BuildSection.tsx
@@ -1,38 +1,71 @@
 'use client'
 
 import { Tile, TileGrid } from '@/app/components/Tile/Tile'
+import { externalRoutes } from '@/app/constants'
 import { Badge } from '@eth-optimism/ui-components/src/components/ui/badge'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from '@eth-optimism/ui-components/src/components/ui/dialog'
+import { useState } from 'react'
+import { useDialogContent } from '@/app/console/useDialogContent'
 
 const BuildSection = () => {
+  const [dialogContent, setDialogContent] = useState<React.ReactNode>()
+  const { testnetPaymasterContent, uxReviewContent, superchainSafeContent } =
+    useDialogContent()
+
   return (
     <div>
       <Text as="h3" className="text-2xl font-semibold mb-4">
         Build
       </Text>
-      <TileGrid>
-        <Tile
-          title="Superchain Faucet"
-          description="Get test ETH tokens to build your dapp on the Superchain."
-          onClick={() => {}}
-        />
-        <Tile
-          title="Testnet Paymaster"
-          description="Get your testnet transactions sponsored to remove friction from your dapp experience."
-          onClick={() => {}}
-        />
-        <Tile
-          title="UX Review"
-          description="Get actionable feedback from Superchain pros to get your dapp ready for launch."
-          onClick={() => {}}
-          badge={<Badge>Featured</Badge>}
-        />
-        <Tile
-          title="Superchain Safe"
-          description="Get multisig support on any OP Chain in the Superchain."
-          onClick={() => {}}
-        />
-      </TileGrid>
+      <Dialog>
+        <TileGrid>
+          <Tile
+            title="Superchain Faucet"
+            description="Get test ETH tokens to build your dapp on the Superchain."
+            onClick={() => {
+              window.open(
+                externalRoutes.SUPERCHAIN_FAUCET.path,
+                '_blank',
+                'noopener noreferrer',
+              )
+            }}
+          />
+          <DialogTrigger asChild>
+            <Tile
+              title="Testnet Paymaster"
+              description="Get your testnet transactions sponsored to remove friction from your dapp experience."
+              onClick={() => {
+                setDialogContent(testnetPaymasterContent)
+              }}
+            />
+          </DialogTrigger>
+          <DialogTrigger asChild>
+            <Tile
+              title="UX Review"
+              description="Get actionable feedback from Superchain pros to get your dapp ready for launch."
+              onClick={() => {
+                setDialogContent(uxReviewContent)
+              }}
+              badge={<Badge>Featured</Badge>}
+            />
+          </DialogTrigger>
+          <DialogTrigger asChild>
+            <Tile
+              title="Superchain Safe"
+              description="Get multisig support on any OP Chain in the Superchain."
+              onClick={() => {
+                setDialogContent(superchainSafeContent)
+              }}
+            />
+          </DialogTrigger>
+        </TileGrid>
+        <DialogContent className="w-[448px]">{dialogContent}</DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/apps/dapp-console/app/console/components/LaunchSection.tsx
+++ b/apps/dapp-console/app/console/components/LaunchSection.tsx
@@ -2,43 +2,83 @@
 
 import { Tile, TileGrid } from '@/app/components/Tile/Tile'
 import { Badge } from '@eth-optimism/ui-components/src/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from '@eth-optimism/ui-components/src/components/ui/dialog'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import { useState } from 'react'
+import { useDialogContent } from '@/app/console/useDialogContent'
+import { externalRoutes } from '@/app/constants'
 
 const LaunchSection = () => {
+  const [dialogContent, setDialogContent] = useState<React.ReactNode>()
+  const {
+    deploymentRebateContent,
+    mainnetPaymasterContent,
+    megaphoneContent,
+    userFeedbackContent,
+  } = useDialogContent()
   return (
     <div>
       <Text as="h3" className="text-2xl font-semibold mb-4">
         Launch & Grow
       </Text>
-      <TileGrid>
-        <Tile
-          title="Deployment Rebate"
-          description="Launch on the Superchain and get your deployment costs covered up to $200."
-          onClick={() => {}}
-          badge={<Badge>Featured</Badge>}
-        />
-        <Tile
-          title="Paymaster"
-          description="Get up to $500 in free gas for your users when you use the Superchain Paymaster."
-          onClick={() => {}}
-          badge={<Badge variant="secondary">Join waitlist</Badge>}
-        />
-        <Tile
-          title="Megaphone"
-          description="Amplify your launch through Superchain marketing channels."
-          onClick={() => {}}
-        />
-        <Tile
-          title="User Feedback"
-          description="Get actionable feedback from Superchain contributors to improve your app."
-          onClick={() => {}}
-        />
-        <Tile
-          title="RetroPGF"
-          description="Get funded for adding value to the Superchain ecosystem."
-          onClick={() => {}}
-        />
-      </TileGrid>
+      <Dialog>
+        <TileGrid>
+          <DialogTrigger asChild>
+            <Tile
+              title="Deployment Rebate"
+              description="Launch on the Superchain and get your deployment costs covered up to $200."
+              onClick={() => {
+                setDialogContent(deploymentRebateContent)
+              }}
+              badge={<Badge>Featured</Badge>}
+            />
+          </DialogTrigger>
+          <DialogTrigger asChild>
+            <Tile
+              title="Paymaster"
+              description="Get up to $500 in free gas for your users when you use the Superchain Paymaster."
+              onClick={() => {
+                setDialogContent(mainnetPaymasterContent)
+              }}
+              badge={<Badge variant="secondary">Join waitlist</Badge>}
+            />
+          </DialogTrigger>
+          <DialogTrigger asChild>
+            <Tile
+              title="Megaphone"
+              description="Amplify your launch through Superchain marketing channels."
+              onClick={() => {
+                setDialogContent(megaphoneContent)
+              }}
+            />
+          </DialogTrigger>
+          <DialogTrigger asChild>
+            <Tile
+              title="User Feedback"
+              description="Get actionable feedback from Superchain contributors to improve your app."
+              onClick={() => {
+                setDialogContent(userFeedbackContent)
+              }}
+            />
+          </DialogTrigger>
+          <Tile
+            title="RetroPGF"
+            description="Get funded for adding value to the Superchain ecosystem."
+            onClick={() => {
+              window.open(
+                externalRoutes.RETRO_PGF.path,
+                '_blank',
+                'noopener noreferrer',
+              )
+            }}
+          />
+        </TileGrid>
+        <DialogContent className="w-[448px]">{dialogContent}</DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/apps/dapp-console/app/console/constants.tsx
+++ b/apps/dapp-console/app/console/constants.tsx
@@ -1,0 +1,127 @@
+import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import { DialogMetadata } from '@/app/console/useDialogContent'
+
+export const testnetPaymasterMetadata: DialogMetadata = {
+  label: 'Testnet Paymaster',
+  title:
+    'Get your testnet transactions sponsored to remove friction from your dapp experience',
+  description:
+    'Continue to Github for information on how to setup and use the Testnet Paymaster.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">View on Github</Text>
+      </a>
+    </Button>
+  ),
+  secondaryButton: (
+    <Button asChild variant="secondary">
+      <a href="">
+        <Text as="span">Learn about paymasters</Text>
+      </a>
+    </Button>
+  ),
+}
+
+export const uxReviewMetadata: DialogMetadata = {
+  label: 'UX Review',
+  title:
+    'Get actionable feedback from Superchain pros to get your dapp ready for launch',
+  description:
+    'Technical builders from Superchain teams are standing by to review your dapp. Whether you’re building DeFi, DeSo, Infra, or anything else, we’ll connect you with people who get it.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">Apply</Text>
+      </a>
+    </Button>
+  ),
+}
+
+export const superchainSafeMetadata: DialogMetadata = {
+  label: 'Superchain Safe',
+  title: 'Get multisig support on any OP Chain in the Superchain with Safe',
+  description:
+    'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">Get safe for Base or Optimism</Text>
+      </a>
+    </Button>
+  ),
+  secondaryButton: (
+    <Button asChild variant="secondary">
+      <a href="">
+        <Text as="span">Get safe for any other chain</Text>
+      </a>
+    </Button>
+  ),
+}
+
+export const deploymentRebateMetadata: DialogMetadata = {
+  label: 'Deployment Rebate',
+  title:
+    'Launch on the Superchain and get your deployment costs covered up to $200',
+  description:
+    'Get your app up and running without having to worry about deployment fees.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">Apply</Text>
+      </a>
+    </Button>
+  ),
+}
+
+export const mainnetPaymasterMetadata: DialogMetadata = {
+  label: 'Paymaster',
+  title:
+    'Get up to $500 in free gas for your users when you use the Superchain Paymaster',
+  description:
+    'Optimism will sponsor your mainnet transactions to help you attract users and grow your product.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">Join waitlist</Text>
+      </a>
+    </Button>
+  ),
+  secondaryButton: (
+    <Button asChild variant="secondary">
+      <a href="">
+        <Text as="span">Learn about paymasters</Text>
+      </a>
+    </Button>
+  ),
+}
+
+export const megaphoneMetadata: DialogMetadata = {
+  label: 'Megaphone',
+  title: 'Amplify your launch through Superchain marketing channels',
+  description:
+    'When you’re ready, Superchain teams will communicate your launch to audiences across X, Farcaster, and other marketing channels.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">Apply</Text>
+      </a>
+    </Button>
+  ),
+}
+
+export const userFeedbackMetadata: DialogMetadata = {
+  label: 'User Feedback',
+  title:
+    'Get actionable feedback from Superchain contributors to improve your app',
+  description:
+    'Passionate contributors from Superchain communities, like Base and Optimism, are standing by to provide feedback on any topic.',
+  primaryButton: (
+    <Button asChild>
+      <a href="">
+        <Text as="span">Apply</Text>
+      </a>
+    </Button>
+  ),
+}

--- a/apps/dapp-console/app/console/useDialogContent.tsx
+++ b/apps/dapp-console/app/console/useDialogContent.tsx
@@ -1,0 +1,128 @@
+import { Badge } from '@eth-optimism/ui-components/src/components/ui/badge'
+import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import { usePrivy } from '@privy-io/react-auth'
+import { useMemo } from 'react'
+import {
+  testnetPaymasterMetadata,
+  uxReviewMetadata,
+  superchainSafeMetadata,
+  deploymentRebateMetadata,
+  mainnetPaymasterMetadata,
+  megaphoneMetadata,
+  userFeedbackMetadata,
+} from '@/app/console/constants'
+import { DialogClose } from '@eth-optimism/ui-components/src/components/ui/dialog'
+
+export type DialogMetadata = {
+  label: string
+  title: string
+  description: string
+  primaryButton: React.ReactNode
+  secondaryButton?: React.ReactNode
+}
+
+const useDialogContent = () => {
+  const { authenticated, login } = usePrivy()
+
+  const loginButton = (label: string) => {
+    return (
+      <DialogClose asChild>
+        <Button onClick={login}>
+          <Text as="span">{label}</Text>
+        </Button>
+      </DialogClose>
+    )
+  }
+
+  const testnetPaymasterContent: React.ReactNode = useMemo(() => {
+    return renderDialog({
+      ...testnetPaymasterMetadata,
+    })
+  }, [])
+
+  const uxReviewContent: React.ReactNode = useMemo(() => {
+    return renderDialog({
+      ...uxReviewMetadata,
+      primaryButton: !authenticated
+        ? loginButton('Sign in to apply')
+        : uxReviewMetadata.primaryButton,
+    })
+  }, [authenticated, login])
+
+  const superchainSafeContent = useMemo(() => {
+    return renderDialog({
+      ...superchainSafeMetadata,
+    })
+  }, [])
+
+  const deploymentRebateContent = useMemo(() => {
+    return renderDialog({
+      ...deploymentRebateMetadata,
+      primaryButton: !authenticated
+        ? loginButton('Sign in to apply')
+        : deploymentRebateMetadata.primaryButton,
+    })
+  }, [authenticated, login])
+
+  const mainnetPaymasterContent = useMemo(() => {
+    return renderDialog({
+      ...mainnetPaymasterMetadata,
+      primaryButton: !authenticated
+        ? loginButton('Sign in to join waitlist')
+        : mainnetPaymasterMetadata.primaryButton,
+    })
+  }, [authenticated, login])
+
+  const megaphoneContent = useMemo(() => {
+    return renderDialog({
+      ...megaphoneMetadata,
+      primaryButton: !authenticated
+        ? loginButton('Sign in to apply')
+        : megaphoneMetadata.primaryButton,
+    })
+  }, [authenticated, login])
+
+  const userFeedbackContent = useMemo(() => {
+    return renderDialog({
+      ...userFeedbackMetadata,
+      primaryButton: !authenticated
+        ? loginButton('Sign in to apply')
+        : userFeedbackMetadata.primaryButton,
+    })
+  }, [authenticated, login])
+
+  return {
+    testnetPaymasterContent,
+    uxReviewContent,
+    superchainSafeContent,
+    deploymentRebateContent,
+    mainnetPaymasterContent,
+    megaphoneContent,
+    userFeedbackContent,
+  }
+}
+
+const renderDialog = (dialogMetadata: DialogMetadata) => {
+  return (
+    <div>
+      <Badge variant="secondary">
+        <Text as="p">{dialogMetadata.label}</Text>
+      </Badge>
+      <div className="py-6">
+        <Text as="h3" className="text-lg font-semibold mb-2">
+          {dialogMetadata.title}
+        </Text>
+        <Text as="p" className="text-sm text-muted-foreground">
+          {dialogMetadata.description}
+        </Text>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        {dialogMetadata.primaryButton}
+        {dialogMetadata.secondaryButton}
+      </div>
+    </div>
+  )
+}
+
+export { useDialogContent }

--- a/apps/dapp-console/app/constants/index.tsx
+++ b/apps/dapp-console/app/constants/index.tsx
@@ -19,19 +19,19 @@ const routes: Routes = {
 const externalRoutes: Routes = {
   // Support items
   DEV_FORUM: {
-    path: '',
+    path: 'https://github.com/ethereum-optimism/developers/discussions',
     label: 'Developer Forum',
   },
   FARCASTER: {
-    path: '',
+    path: 'https://warpcast.com/~/channel/op-stack',
     label: 'Farcaster',
   },
   DISCORD: {
-    path: '',
+    path: 'https://discord.optimism.io/',
     label: 'Discord',
   },
   DAPP_EXAPMPLES: {
-    path: '',
+    path: 'https://github.com/ethereum-optimism/ecosystem',
     label: 'Dapp Examples',
   },
   // Documentation items
@@ -66,6 +66,15 @@ const externalRoutes: Routes = {
   ZORA_DOCS: {
     path: 'https://docs.zora.co/',
     label: 'Zora',
+  },
+  // Project links
+  SUPERCHAIN_FAUCET: {
+    path: 'https://app.optimism.io/faucet',
+    label: 'Superchain Faucet',
+  },
+  RETRO_PGF: {
+    path: 'https://optimism.io/retropgf',
+    label: 'Retro PGF',
   },
 }
 


### PR DESCRIPTION
### Description
- Implemented Build section modals 
- Implemented Launch & grow modals

I created a hook to organize the content for these modals in a maintainable + reusable way to keep this surface future-proof. Take a look at `useDialogContent` for the code. Since a little over half of the modals are dynamic based on the user being signed in, I am conditionally rendering the content buttons w/ the `authenticated` state with `usePrivy`.

https://github.com/ethereum-optimism/ecosystem/assets/10838132/095094e6-3073-4ea4-9144-c9666e66c1f8


