### PR TITLE
Implemented mobile nav menu

### DIFF
--- a/apps/dapp-console/app/components/Header/HeaderTabs.tsx
+++ b/apps/dapp-console/app/components/Header/HeaderTabs.tsx
@@ -1,4 +1,4 @@
-import { docsItems, externalRoutes, routes } from '@/app/constants'
+import { docsItems, routes, supportItems } from '@/app/constants'
 import { cn } from '@/app/lib/utils'
 import Link from 'next/link'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
@@ -21,7 +21,7 @@ type HeaderTabsProps = {
 
 const HeaderTabs = ({ currentRoute }: HeaderTabsProps) => {
   return (
-    <div className="flex gap-8 items-end h-full">
+    <div className="gap-8 items-end h-full hidden lg:flex">
       <HeaderTabItem
         href={routes.CONSOLE.path}
         isActive={currentRoute === routes.CONSOLE.path}
@@ -64,13 +64,6 @@ const HeaderTabItem = ({
     </Link>
   )
 }
-
-const supportItems = [
-  externalRoutes.DEV_FORUM,
-  externalRoutes.FARCASTER,
-  externalRoutes.DISCORD,
-  externalRoutes.DAPP_EXAMPLES,
-]
 
 const SupportDropdownMenu = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)

--- a/apps/dapp-console/app/components/Header/MobileMenu.tsx
+++ b/apps/dapp-console/app/components/Header/MobileMenu.tsx
@@ -1,0 +1,212 @@
+import { motion } from 'framer-motion'
+import React, { useEffect } from 'react'
+import Link from 'next/link'
+import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@eth-optimism/ui-components/src/components/ui/accordion'
+
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import Image from 'next/image'
+import { docsItems, routes, supportItems } from '@/app/constants'
+
+interface MobileMenuProps {
+  isOpen: boolean
+  closeMenu: () => void
+}
+
+const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, closeMenu }) => {
+  const variants = {
+    open: {
+      x: 0,
+      transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] }, // Custom easing function
+    },
+    closed: {
+      x: '-100%',
+      transition: { duration: 0.2, ease: 'easeInOut' }, // Standard easing
+    },
+  }
+
+  const backgroundVariants = {
+    open: {
+      opacity: 1,
+      transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] }, // Custom easing function
+    },
+    closed: {
+      opacity: 0,
+      transition: { duration: 0.2, ease: 'easeInOut' }, // Standard easing
+    },
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.classList.add('overflow-hidden')
+    } else {
+      document.body.classList.remove('overflow-hidden')
+    }
+  }, [isOpen])
+
+  return (
+    <div
+      className="fixed top-18 left-0 w-full h-[calc(100vh-80px)] min-h-[calc(100vh-80px)] z-20"
+      style={{ pointerEvents: isOpen ? 'all' : 'none' }}
+    >
+      <motion.div
+        initial="closed"
+        animate={isOpen ? 'open' : 'closed'}
+        variants={variants}
+        className="w-full h-[calc(100vh-80px)] p-6 sm:max-w-[400px] flex flex-col justify-between z-30 bg-background overflow-y-auto"
+      >
+        <div className="flex flex-col gap-4">
+          <Button
+            variant="ghost"
+            className="w-full justify-start"
+            asChild
+            onClick={closeMenu}
+          >
+            <Link href={routes.CONSOLE.path}>
+              <span className="text-lg cursor-pointer">Console</span>
+            </Link>
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full justify-start"
+            asChild
+            onClick={closeMenu}
+          >
+            <Link href={routes.INSIGHTS.path}>
+              <span className="text-lg cursor-pointer">Insights</span>
+            </Link>
+          </Button>
+          <Accordion type="single" collapsible>
+            <AccordionItem value="support" className="border-none">
+              <AccordionTrigger className="h-10 px-4 text-lg hover:no-underline hover:bg-accent hover:text-accent-foreground rounded-md">
+                Support
+              </AccordionTrigger>
+              <AccordionContent className="pt-2">
+                <Text
+                  as="p"
+                  className="font-semibold uppercase text-muted-foreground text-xs px-4 py-1"
+                >
+                  Support
+                </Text>
+                <div className="flex flex-col py-2 gap-1">
+                  {supportItems.map((item) => (
+                    <Button asChild variant="ghost" className="justify-start">
+                      <a href={item.path} target="_blank">
+                        <Text as="span">{item.label}</Text>
+                      </a>
+                    </Button>
+                  ))}
+                </div>
+
+                <Text
+                  as="p"
+                  className="font-semibold uppercase text-muted-foreground text-xs px-4 py-1"
+                >
+                  Docs
+                </Text>
+                <div className="flex flex-col py-2 gap-1">
+                  {docsItems.map((item) => (
+                    <Button
+                      asChild
+                      variant="ghost"
+                      className="justify-start gap-2"
+                    >
+                      <a href={item.path} target="_blank">
+                        <Image
+                          src={item.logo}
+                          alt={`${item.label} logo`}
+                          width={24}
+                          height={24}
+                          className="rounded-full"
+                        />
+                        <Text as="span">{item.label}</Text>
+                      </a>
+                    </Button>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      </motion.div>
+
+      {isOpen && (
+        <motion.div
+          className="absolute top-0 left-0 w-full h-[calc(100vh-80px)] bg-black/80 -z-10"
+          initial="closed"
+          animate={isOpen ? 'open' : 'closed'}
+          variants={backgroundVariants}
+          onClick={closeMenu}
+        />
+      )}
+    </div>
+  )
+}
+
+interface MenuButtonProps {
+  isOpen: boolean
+  onClick: () => void
+}
+
+const MenuButton: React.FC<MenuButtonProps> = ({ isOpen, onClick }) => {
+  const lineCommonStyle = {
+    width: 24,
+    height: 2,
+    originX: 0.5,
+  }
+
+  const topLineVariants = {
+    closed: {
+      rotate: 0,
+      translateY: -4,
+    },
+    open: { rotate: 45, translateY: 2 },
+  }
+
+  const bottomLineVariants = {
+    closed: {
+      rotate: 0,
+      translateY: 2,
+    },
+    open: { rotate: -45, translateY: -2 },
+  }
+
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        border: 'none',
+        cursor: 'pointer',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: 48,
+        height: 48,
+        borderRadius: 12,
+      }}
+    >
+      <motion.div
+        initial={false}
+        animate={isOpen ? 'open' : 'closed'}
+        variants={topLineVariants}
+        style={{ ...lineCommonStyle }}
+        className="bg-foreground mb-0.5"
+      />
+      <motion.div
+        initial={false}
+        animate={isOpen ? 'open' : 'closed'}
+        variants={bottomLineVariants}
+        style={lineCommonStyle}
+        className="bg-foreground"
+      />
+    </button>
+  )
+}
+
+export { MobileMenu, MenuButton }

--- a/apps/dapp-console/app/components/Header/ThemeToggle.tsx
+++ b/apps/dapp-console/app/components/Header/ThemeToggle.tsx
@@ -14,7 +14,12 @@ function ThemeToggle() {
   }
 
   return (
-    <Button variant="ghost" size="icon" onClick={handleButtonClicked}>
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleButtonClicked}
+      className="hidden md:flex"
+    >
       <RiSunLine className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <RiMoonLine className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
     </Button>

--- a/apps/dapp-console/app/components/Header/index.tsx
+++ b/apps/dapp-console/app/components/Header/index.tsx
@@ -7,22 +7,34 @@ import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { HeaderTabs } from '@/app/components/Header/HeaderTabs'
 import { usePathname } from 'next/navigation'
 import { SignInButton } from '@/app/components/Header/SignInButton'
+import { MenuButton, MobileMenu } from '@/app/components/Header/MobileMenu'
+import { useState } from 'react'
 
 const Header = () => {
   const pathname = usePathname()
+  const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <div className="h-20 px-6 border-b border-border flex items-center justify-between">
-      <div className="flex items-center gap-12 h-full">
-        <HeaderLogo />
-        <HeaderTabs currentRoute={pathname} />
+    <>
+      <div className="h-20 px-6 border-b border-border flex items-center justify-between">
+        <div className="flex items-center gap-6 lg:gap-12 h-full">
+          <span className="flex lg:hidden">
+            <MenuButton isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
+          </span>
+          <HeaderLogo />
+          <HeaderTabs currentRoute={pathname} />
+        </div>
+        <div className="flex items-center">
+          <ThemeToggle />
+          <Separator
+            orientation="vertical"
+            className="h-6 mx-4 hidden md:block"
+          />
+          <SignInButton />
+        </div>
       </div>
-      <div className="flex items-center">
-        <ThemeToggle />
-        <Separator orientation="vertical" className="h-6 mx-4" />
-        <SignInButton />
-      </div>
-    </div>
+      <MobileMenu isOpen={isOpen} closeMenu={() => setIsOpen(false)} />
+    </>
   )
 }
 
@@ -35,8 +47,8 @@ const HeaderLogo = () => {
         width={200}
         height={24}
       />
-      <Separator orientation="vertical" className="h-4 mx-4" />
-      <Text as="span" className="tracking-widest font-medium">
+      <Separator orientation="vertical" className="h-4 mx-4 hidden md:block" />
+      <Text as="span" className="tracking-widest font-medium hidden md:block">
         DAPP DEVELOPER
       </Text>
     </div>

--- a/apps/dapp-console/app/constants/index.tsx
+++ b/apps/dapp-console/app/constants/index.tsx
@@ -78,6 +78,13 @@ const externalRoutes: Routes = {
   },
 }
 
+const supportItems = [
+  externalRoutes.DEV_FORUM,
+  externalRoutes.FARCASTER,
+  externalRoutes.DISCORD,
+  externalRoutes.DAPP_EXAMPLES,
+]
+
 const docsItems = [
   {
     ...externalRoutes.ETH_DOCS,
@@ -113,4 +120,4 @@ const docsItems = [
   },
 ]
 
-export { routes, externalRoutes, docsItems }
+export { routes, externalRoutes, docsItems, supportItems }


### PR DESCRIPTION
### Description
Implemented mobile nav menu for dapp-console.

- Implemented a custom menu icon with `framer-motion` since the remix one switching from the menu to x was ugly.
- Designed this as a sliding menu that turns into full width on sm screens.
- Implemented the support dropdown with our `Accordion` component.
- There was no design for the mobile menu so I just took a stab at what I think it should look like based on the desktop view-- if there are any modifications that we should make i'm happy to include them

https://github.com/ethereum-optimism/ecosystem/assets/10838132/d285ea1c-fc64-49cc-9d7b-00c50e53b5cc


