### PR TITLE
feat(paymaster-proxy): screen sanctioned addresses

### DIFF
--- a/apps/paymaster-proxy/docker-compose.yml
+++ b/apps/paymaster-proxy/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       context: ../../
       dockerfile: Dockerfile
       target: paymaster-proxy
+    env_file: .env
     environment:
-      - PORT=7310
       - REDIS_URL=redis://redis:6379
     healthcheck:
       test: wget localhost:7310/healthz -q -O - > /dev/null 2>&1

--- a/apps/paymaster-proxy/example.env
+++ b/apps/paymaster-proxy/example.env
@@ -6,6 +6,9 @@ PORT=
 # URL of Redis instance
 REDIS_URL=
 
+# URL of the screening service
+SCREENING_SERVICE_URL=
+
 # Alchemy RPC URL for Sepolia
 ALCHEMY_RPC_URL_SEPOLIA=
 

--- a/apps/paymaster-proxy/package.json
+++ b/apps/paymaster-proxy/package.json
@@ -22,6 +22,7 @@
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",
+    "msw": "^2.2.1",
     "prettier": "^3.1.0",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",

--- a/apps/paymaster-proxy/src/envVars.ts
+++ b/apps/paymaster-proxy/src/envVars.ts
@@ -1,5 +1,8 @@
 import 'dotenv/config'
 
 import { envVarsSchema } from '@/envVarsSchema'
+import { testEnvVars } from '@/testUtils/testEnvVars'
 
-export const envVars = envVarsSchema.parse(process.env)
+const isTest = process.env.NODE_ENV === 'test'
+
+export const envVars = envVarsSchema.parse(isTest ? testEnvVars : process.env)

--- a/apps/paymaster-proxy/src/envVarsSchema.ts
+++ b/apps/paymaster-proxy/src/envVarsSchema.ts
@@ -15,3 +15,5 @@ export const envVarsSchema = z.object({
     .string()
     .describe('Alchemy Gas Manager policyId for OP Sepolia'),
 })
+
+export type EnvVars = z.infer<typeof envVarsSchema>

--- a/apps/paymaster-proxy/src/envVarsSchema.ts
+++ b/apps/paymaster-proxy/src/envVarsSchema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export const envVarsSchema = z.object({
   PORT: z.coerce.number().describe('Port to listen on'),
   REDIS_URL: z.string().describe('URL of Redis instance'),
+  SCREENING_SERVICE_URL: z.string().describe('URL of the screening service'),
   ALCHEMY_RPC_URL_SEPOLIA: z.string().describe('Alchemy RPC URL for Sepolia'),
   ALCHEMY_GAS_MANAGER_POLICY_ID_SEPOLIA: z
     .string()

--- a/apps/paymaster-proxy/src/errors/JsonRpcError.ts
+++ b/apps/paymaster-proxy/src/errors/JsonRpcError.ts
@@ -65,6 +65,13 @@ export class JsonRpcError extends Error {
     return new JsonRpcError(internalErrorCode, { id, message })
   }
 
+  static internalErrorSanctionedAddress = ({
+    id = null,
+    message = 'Ineligible address: sanctioned address',
+  }: JsonRpcErrorParams = {}): JsonRpcError => {
+    return new JsonRpcError(internalErrorCode, { id, message })
+  }
+
   response() {
     return {
       jsonrpc: '2.0' as const,

--- a/apps/paymaster-proxy/src/helpers/screenAddress.spec.ts
+++ b/apps/paymaster-proxy/src/helpers/screenAddress.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { envVars } from '@/envVars'
+import { screenAddress } from '@/helpers/screenAddress'
+import { getRandomAddress } from '@/testUtils/getRandomAddress'
+import { mockPostSuccessJson } from '@/testUtils/mswServer'
+
+describe('screenAddress', () => {
+  it('correctly parses API response', async () => {
+    const address = getRandomAddress()
+    mockPostSuccessJson(envVars.SCREENING_SERVICE_URL, {
+      jsonrpc: '2.0',
+      id: 1,
+      result: [
+        {
+          Addr: address,
+          IsSanctioned: false,
+          Error: '',
+        },
+      ],
+    })
+
+    const result = await screenAddress(address)
+
+    expect(result).toBe(false)
+  })
+
+  it('throws error if response is empty', async () => {
+    const address = getRandomAddress()
+    mockPostSuccessJson(envVars.SCREENING_SERVICE_URL, {
+      jsonrpc: '2.0',
+      id: 1,
+      result: [],
+    })
+
+    await expect(screenAddress(address)).rejects.toThrow(
+      'Failed to call screening service',
+    )
+  })
+
+  it('throws error if response contains error', async () => {
+    const address = getRandomAddress()
+    mockPostSuccessJson(envVars.SCREENING_SERVICE_URL, {
+      jsonrpc: '2.0',
+      id: 1,
+      error: {
+        code: -32600,
+        message: 'Invalid request',
+      },
+    })
+    await expect(screenAddress(address)).rejects.toThrow(
+      'Failed to call screening service',
+    )
+  })
+})

--- a/apps/paymaster-proxy/src/helpers/screenAddress.ts
+++ b/apps/paymaster-proxy/src/helpers/screenAddress.ts
@@ -18,7 +18,7 @@ const screeningServiceResponse = createJsonRpcResponseSchema(
 )
 
 export const screenAddress = async (address: Address) => {
-  const res = await fetch(`${envVars.SCREENING_SERVICE_URL}`, {
+  const res = await fetch(envVars.SCREENING_SERVICE_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -34,7 +34,11 @@ export const screenAddress = async (address: Address) => {
   const json = await res.json()
   const response = screeningServiceResponse.parse(json)
 
-  if ('error' in response || response.result.length === 0) {
+  if (
+    'error' in response ||
+    response.result.length === 0 ||
+    !!response.result[0].Error
+  ) {
     throw new Error('Failed to call screening service')
   }
 

--- a/apps/paymaster-proxy/src/helpers/screenAddress.ts
+++ b/apps/paymaster-proxy/src/helpers/screenAddress.ts
@@ -1,0 +1,42 @@
+import type { Address } from 'viem'
+import { z } from 'zod'
+
+import { envVars } from '@/envVars'
+import { addressSchema } from '@/schemas/addressSchema'
+import { createJsonRpcResponseSchema } from '@/schemas/createJsonRpcResponseSchema'
+
+const screeningServiceResultSchema = z.array(
+  z.object({
+    Addr: addressSchema,
+    IsSanctioned: z.boolean(),
+    Error: z.string(),
+  }),
+)
+
+const screeningServiceResponse = createJsonRpcResponseSchema(
+  screeningServiceResultSchema,
+)
+
+export const screenAddress = async (address: Address) => {
+  const res = await fetch(`${envVars.SCREENING_SERVICE_URL}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'svc_screening',
+      params: [[address]],
+      id: 1,
+    }),
+  })
+
+  const json = await res.json()
+  const response = screeningServiceResponse.parse(json)
+
+  if ('error' in response || response.result.length === 0) {
+    throw new Error('Failed to call screening service')
+  }
+
+  return response.result[0].IsSanctioned
+}

--- a/apps/paymaster-proxy/src/rpc/getJsonRpcRequestHandler.ts
+++ b/apps/paymaster-proxy/src/rpc/getJsonRpcRequestHandler.ts
@@ -48,7 +48,7 @@ export const getJsonRpcRequestHandler =
           if (isAddressSanctioned) {
             return JsonRpcError.internalErrorSanctionedAddress({
               id: paymasterRequest.id,
-            })
+            }).response()
           }
 
           // Send transaction to paymaster RPC and return result

--- a/apps/paymaster-proxy/src/schemas/addressSchema.ts
+++ b/apps/paymaster-proxy/src/schemas/addressSchema.ts
@@ -1,0 +1,3 @@
+import { Address } from 'abitype/zod'
+
+export const addressSchema = Address

--- a/apps/paymaster-proxy/src/schemas/createJsonRpcResponseSchema.ts
+++ b/apps/paymaster-proxy/src/schemas/createJsonRpcResponseSchema.ts
@@ -1,0 +1,25 @@
+import z from 'zod'
+
+export const createJsonRpcResponseSchema = <T extends z.ZodTypeAny>(
+  resultSchema: T,
+) => {
+  return z.union([
+    z
+      .object({
+        jsonrpc: z.literal('2.0'),
+        id: z.number(),
+        result: resultSchema,
+      })
+      .strict(),
+    z
+      .object({
+        jsonrpc: z.literal('2.0'),
+        id: z.number(),
+        error: z.object({
+          code: z.number(),
+          message: z.string(),
+        }),
+      })
+      .strict(),
+  ])
+}

--- a/apps/paymaster-proxy/src/testUtils/getRandomAddress.ts
+++ b/apps/paymaster-proxy/src/testUtils/getRandomAddress.ts
@@ -1,0 +1,5 @@
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+
+export const getRandomAddress = () => {
+  return privateKeyToAccount(generatePrivateKey()).address
+}

--- a/apps/paymaster-proxy/src/testUtils/mswServer.ts
+++ b/apps/paymaster-proxy/src/testUtils/mswServer.ts
@@ -1,0 +1,22 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+export const mswServer = setupServer()
+
+export const mockPostSuccessJson = (route: string, response: any) => {
+  mswServer.use(
+    http.post(route, () => {
+      return HttpResponse.json(response)
+    }),
+  )
+}
+
+export const mockPostError = (route: string, status: number) => {
+  mswServer.use(
+    http.post(route, () => {
+      return new HttpResponse(null, {
+        status,
+      })
+    }),
+  )
+}

--- a/apps/paymaster-proxy/src/testUtils/setup.ts
+++ b/apps/paymaster-proxy/src/testUtils/setup.ts
@@ -1,0 +1,9 @@
+import { afterAll, afterEach, beforeAll } from 'vitest'
+
+import { mswServer } from '@/testUtils/mswServer'
+
+beforeAll(() => mswServer.listen())
+
+afterAll(() => mswServer.close())
+
+afterEach(() => mswServer.resetHandlers())

--- a/apps/paymaster-proxy/src/testUtils/testEnvVars.ts
+++ b/apps/paymaster-proxy/src/testUtils/testEnvVars.ts
@@ -1,0 +1,12 @@
+import type { EnvVars } from '@/envVarsSchema'
+
+export const testEnvVars = {
+  PORT: 3000,
+  REDIS_URL: 'redis://redis:6379',
+  SCREENING_SERVICE_URL: 'http://localhost:3001',
+  ALCHEMY_RPC_URL_SEPOLIA: 'https://eth-mainnet.alchemyapi.io/v2/your-api-key',
+  ALCHEMY_GAS_MANAGER_POLICY_ID_SEPOLIA: 'your-policy-id',
+  ALCHEMY_RPC_URL_OP_SEPOLIA:
+    'https://eth-mainnet.alchemyapi.io/v2/your-api-key',
+  ALCHEMY_GAS_MANAGER_POLICY_ID_OP_SEPOLIA: 'your-policy-id',
+} as const satisfies EnvVars

--- a/apps/paymaster-proxy/vitest.config.ts
+++ b/apps/paymaster-proxy/vitest.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  test: {
+    hookTimeout: 20_000,
+    testTimeout: 20_000,
+    setupFiles: ['./src/testUtils/setup.ts'],
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@nx/js':
         specifier: 17.1.3
-        version: 17.1.3(@types/node@20.10.0)(nx@17.1.3)(typescript@5.3.2)
+        version: 17.1.3(@types/node@20.11.19)(nx@17.1.3)(typescript@5.3.2)
       eslint-config-react-app:
         specifier: ^7.0.1
         version: 7.0.1(@babel/plugin-syntax-flow@7.23.3)(@babel/plugin-transform-react-jsx@7.23.4)(eslint@8.56.0)(typescript@5.3.2)
@@ -125,7 +125,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.10.0)
+        version: 5.0.12(@types/node@20.11.19)
 
   apps/dapp-console:
     dependencies:
@@ -264,6 +264,9 @@ importers:
       eslint:
         specifier: ^8.53.0
         version: 8.56.0
+      msw:
+        specifier: ^2.2.1
+        version: 2.2.1(typescript@5.3.2)
       prettier:
         specifier: ^3.1.0
         version: 3.1.0
@@ -312,7 +315,7 @@ importers:
     devDependencies:
       '@eth-optimism/superchain-registry':
         specifier: github:ethereum-optimism/superchain-registry
-        version: github.com/ethereum-optimism/superchain-registry/a87e7b7a2f774051885eb9032f9d0150a4cf4746
+        version: github.com/ethereum-optimism/superchain-registry/ab073f6aa74fad109f1299d77f015f94059687c9
       '@tanstack/react-query':
         specifier: ^5.10.0
         version: 5.10.0(react@18.2.0)
@@ -2800,6 +2803,18 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
+    dev: true
+
   /@coinbase/wallet-sdk@3.9.1:
     resolution: {integrity: sha512-cGUE8wm1/cMI8irRMVOqbFWYcnNugqCtuy2lnnHfgloBg+GRLs9RsrkOUDMdv/StfUeeKhCDyYudsXXvcL1xIA==}
     dependencies:
@@ -3681,6 +3696,39 @@ packages:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
 
+  /@inquirer/confirm@3.0.0:
+    resolution: {integrity: sha512-LHeuYP1D8NmQra1eR4UqvZMXwxEdDXyElJmmZfU44xdNLL6+GcQBS0uE16vyfZVjH8c22p9e+DStROfE/hyHrg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 7.0.0
+      '@inquirer/type': 1.2.0
+    dev: true
+
+  /@inquirer/core@7.0.0:
+    resolution: {integrity: sha512-g13W5yEt9r1sEVVriffJqQ8GWy94OnfxLCreNSOTw0HPVcszmc/If1KIf7YBmlwtX4klmvwpZHnQpl3N7VX2xA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/type': 1.2.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.11.19
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      figures: 3.2.0
+      mute-stream: 1.0.0
+      run-async: 3.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: true
+
+  /@inquirer/type@1.2.0:
+    resolution: {integrity: sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==}
+    engines: {node: '>=18'}
+    dev: true
+
   /@ioredis/commands@1.2.0:
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
@@ -3707,7 +3755,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       jest-mock: 29.7.0
 
   /@jest/fake-timers@29.7.0:
@@ -3716,7 +3764,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3733,7 +3781,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -3743,7 +3791,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -3754,7 +3802,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -4081,6 +4129,23 @@ packages:
       '@motionone/dom': 10.16.4
       tslib: 2.6.2
 
+  /@mswjs/cookies@1.1.0:
+    resolution: {integrity: sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@mswjs/interceptors@0.25.16:
+    resolution: {integrity: sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
+    dev: true
+
   /@next/env@14.1.0:
     resolution: {integrity: sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw==}
     dev: false
@@ -4233,10 +4298,10 @@ packages:
       - nx
     dev: true
 
-  /@nrwl/js@17.1.3(@types/node@20.10.0)(nx@17.1.3)(typescript@5.3.2):
+  /@nrwl/js@17.1.3(@types/node@20.11.19)(nx@17.1.3)(typescript@5.3.2):
     resolution: {integrity: sha512-aUE6lK8+D37xNlRz7ZpFbUOwIU6Vb1aNVjXxaouFQ2kcirv2NdJVmUIpbK7zDE/pzC3YmdZADqG2UjpvSUAErw==}
     dependencies:
-      '@nx/js': 17.1.3(@types/node@20.10.0)(nx@17.1.3)(typescript@5.3.2)
+      '@nx/js': 17.1.3(@types/node@20.11.19)(nx@17.1.3)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4287,7 +4352,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@nx/js@17.1.3(@types/node@20.10.0)(nx@17.1.3)(typescript@5.3.2):
+  /@nx/js@17.1.3(@types/node@20.11.19)(nx@17.1.3)(typescript@5.3.2):
     resolution: {integrity: sha512-FCvIjTtuVYctRJw4S+Sp0ZCPeiwNxOR++CsLciWAogO81k3k6ajMIfjn0Xmwuq/FKWK8thtjkk9MfKjTDuxFkg==}
     peerDependencies:
       verdaccio: ^5.0.4
@@ -4302,7 +4367,7 @@ packages:
       '@babel/preset-env': 7.23.3(@babel/core@7.23.3)
       '@babel/preset-typescript': 7.23.3(@babel/core@7.23.3)
       '@babel/runtime': 7.23.4
-      '@nrwl/js': 17.1.3(@types/node@20.10.0)(nx@17.1.3)(typescript@5.3.2)
+      '@nrwl/js': 17.1.3(@types/node@20.11.19)(nx@17.1.3)(typescript@5.3.2)
       '@nx/devkit': 17.1.3(nx@17.1.3)
       '@nx/workspace': 17.1.3
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
@@ -4322,7 +4387,7 @@ packages:
       ora: 5.3.0
       semver: 7.5.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@types/node@20.10.0)(typescript@5.3.2)
+      ts-node: 10.9.1(@types/node@20.11.19)(typescript@5.3.2)
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -4441,6 +4506,21 @@ packages:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+    dev: true
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
   /@opentelemetry/api@1.7.0:
@@ -6861,6 +6941,10 @@ packages:
       '@types/node': 20.10.0
     dev: true
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
     dependencies:
@@ -6950,12 +7034,23 @@ packages:
   /@types/ms@0.7.34:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+    dependencies:
+      '@types/node': 20.11.19
+    dev: true
+
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: false
 
   /@types/node@20.10.0:
     resolution: {integrity: sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==}
+    dependencies:
+      undici-types: 5.26.5
+
+  /@types/node@20.11.19:
+    resolution: {integrity: sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==}
     dependencies:
       undici-types: 5.26.5
 
@@ -7022,8 +7117,16 @@ packages:
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  /@types/statuses@2.0.4:
+    resolution: {integrity: sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==}
+    dev: true
+
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  /@types/wrap-ansi@3.0.0:
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+    dev: true
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -7468,7 +7571,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.3)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.0.12(@types/node@20.10.0)
+      vite: 5.0.12(@types/node@20.11.19)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8208,6 +8311,13 @@ packages:
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+    dev: true
+
+  /ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      type-fest: 0.21.3
     dev: true
 
   /ansi-escapes@6.2.0:
@@ -9184,6 +9294,11 @@ packages:
       string-width: 5.1.2
     dev: false
 
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+    dev: true
+
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
@@ -9439,7 +9554,6 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -10429,8 +10543,8 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.7)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.7)
+      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.3)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.3)
       eslint: 8.56.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -11533,7 +11647,6 @@ packages:
   /graphql@16.8.1:
     resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: false
 
   /h3@1.9.0:
     resolution: {integrity: sha512-+F3ZqrNV/CFXXfZ2lXBINHi+rM4Xw3CDC5z2CDK3NMPocjonKipGLLDSkrqY9DOrioZNPTIdDMWfQKm//3X2DA==}
@@ -11595,6 +11708,10 @@ packages:
       capital-case: 1.0.4
       tslib: 2.6.2
     dev: false
+
+  /headers-polyfill@4.0.2:
+    resolution: {integrity: sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==}
+    dev: true
 
   /help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -12053,6 +12170,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
+
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
@@ -12236,7 +12357,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -12263,7 +12384,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       jest-util: 29.7.0
 
   /jest-regex-util@27.5.1:
@@ -12275,7 +12396,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12286,7 +12407,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12307,7 +12428,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.10.0
+      '@types/node': 20.11.19
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13334,8 +13455,44 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msw@2.2.1(typescript@5.3.2):
+    resolution: {integrity: sha512-DCsZAQwan+2onEcpD86fiEnCKW4IvYzqcwDq/2TIoeNrmBqNp/mJW4wHQyxcoYrRPwgujin7wDFflqiSO1iT/w==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x <= 5.3.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 3.0.0
+      '@mswjs/cookies': 1.1.0
+      '@mswjs/interceptors': 0.25.16
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.4
+      chalk: 4.1.2
+      graphql: 16.8.1
+      headers-polyfill: 4.0.2
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.10.2
+      typescript: 5.3.2
+      yargs: 17.7.2
+    dev: true
+
   /multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
+  /mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -13934,6 +14091,10 @@ packages:
     resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
     dev: false
 
+  /outvariant@1.4.2:
+    resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
+    dev: true
+
   /p-cancelable@3.0.0:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
     engines: {node: '>=12.20'}
@@ -14116,6 +14277,10 @@ packages:
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: false
+
+  /path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
+    dev: true
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -15402,6 +15567,11 @@ packages:
       '@babel/runtime': 7.23.5
     dev: false
 
+  /run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -15896,6 +16066,10 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
     dev: false
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+    dev: true
 
   /strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -16454,6 +16628,37 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  /ts-node@10.9.1(@types/node@20.11.19)(typescript@5.3.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.11.19
+      acorn: 8.11.2
+      acorn-walk: 8.3.1
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.3.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tsconfck@3.0.2(typescript@5.3.2):
     resolution: {integrity: sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==}
     engines: {node: ^18 || >=20}
@@ -16614,6 +16819,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+    dev: true
+
   /type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
@@ -16627,6 +16837,11 @@ packages:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
     dev: false
+
+  /type-fest@4.10.2:
+    resolution: {integrity: sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==}
+    engines: {node: '>=16'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -17220,6 +17435,42 @@ packages:
       rollup: 4.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  /vite@5.0.12(@types/node@20.11.19):
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.11.19
+      esbuild: 0.19.7
+      postcss: 8.4.33
+      rollup: 4.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
 
   /vitest@1.1.3(@types/node@20.10.0)(jsdom@23.2.0):
     resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
@@ -17857,8 +18108,8 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
 
-  github.com/ethereum-optimism/superchain-registry/a87e7b7a2f774051885eb9032f9d0150a4cf4746:
-    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/a87e7b7a2f774051885eb9032f9d0150a4cf4746}
+  github.com/ethereum-optimism/superchain-registry/ab073f6aa74fad109f1299d77f015f94059687c9:
+    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/ab073f6aa74fad109f1299d77f015f94059687c9}
     name: '@eth-optimism/superchain-registry'
     version: 0.0.1-alpha.1
     dev: true


### PR DESCRIPTION
### Overview
- adds support for screening sanctioned addresses using internal screening service
- adds msw to help with mocking fetch responses for testing
- updates docker compose to use the local .env file

### Testing
- tested inside local docker container to check that certs work correctly - using a sanctioned address in https://www.treasury.gov/ofac/downloads/sdn_comments.csv