### PR TITLE
event-log-indexer docker & docker-compose setup

### DIFF
--- a/apps/event-log-indexer/.gitignore
+++ b/apps/event-log-indexer/.gitignore
@@ -14,5 +14,4 @@ yarn-error.log*
 .env*.local
 
 # Ponder
-/generated/
 /.ponder/

--- a/apps/event-log-indexer/docker-compose.yml
+++ b/apps/event-log-indexer/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:14-alpine
+    environment:
+      - POSTGRES_USER=db_username
+      - POSTGRES_PASSWORD=db_password
+      - POSTGRES_DB=db_name
+      - PGDATA=/data/postgres
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    ports:
+      - '5432:5432'
+    volumes:
+      - db:/var/lib/postgres_ponder/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -q -U db_username -d db_name']
+  
+  indexer:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      target: event-log-indexer
+    env_file:
+      - .env.local
+    environment:
+      - DATABASE_URL=postgresql://db_username:db_password@postgres:5432/db_name
+    volumes:
+      - ../../certs/extra-ca-certificates.crt:/usr/local/share/ca-certificates/extra-ca-certificates.crt
+    ports:
+      - "42069:42069"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  db:

--- a/apps/event-log-indexer/docker-compose.yml
+++ b/apps/event-log-indexer/docker-compose.yml
@@ -4,17 +4,13 @@ services:
   postgres:
     image: postgres:14-alpine
     environment:
-      - POSTGRES_USER=db_username
-      - POSTGRES_PASSWORD=db_password
-      - POSTGRES_DB=db_name
-      - PGDATA=/data/postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - '5432:5432'
     volumes:
-      - db:/var/lib/postgres_ponder/data
+      - ./setup-local-db.sql:/docker-entrypoint-initdb.d/setup-local-db.sql
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -q -U db_username -d db_name']
+      test: ['CMD-SHELL', 'pg_isready -q -U local-db-user -d event-log-indexer']
   
   indexer:
     build:
@@ -24,7 +20,7 @@ services:
     env_file:
       - .env.local
     environment:
-      - DATABASE_URL=postgresql://db_username:db_password@postgres:5432/db_name
+      - DATABASE_URL=postgresql://local-db-user:@postgres:5432/event-log-indexer
     volumes:
       - ../../certs/extra-ca-certificates.crt:/usr/local/share/ca-certificates/extra-ca-certificates.crt
     ports:

--- a/apps/event-log-indexer/generated/schema.graphql
+++ b/apps/event-log-indexer/generated/schema.graphql
@@ -1,0 +1,69 @@
+type Query {
+  optimist(id: String!, timestamp: Int): Optimist
+  optimists(timestamp: Int, where: OptimistFilter, orderBy: String, orderDirection: String, before: String, after: String, limit: Int): OptimistPage
+}
+
+type Optimist {
+  id: String!
+  chainId: Int!
+  tokenId: BigInt!
+  transactionHash: String!
+  blockNumber: BigInt!
+}
+
+scalar BigInt
+
+type OptimistPage {
+  items: [Optimist!]
+  pageInfo: PageInfo
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+input OptimistFilter {
+  id: String
+  id_not: String
+  id_in: [String]
+  id_not_in: [String]
+  id_gt: String
+  id_lt: String
+  id_gte: String
+  id_lte: String
+  chainId: Int
+  chainId_not: Int
+  chainId_in: [Int]
+  chainId_not_in: [Int]
+  chainId_gt: Int
+  chainId_lt: Int
+  chainId_gte: Int
+  chainId_lte: Int
+  tokenId: BigInt
+  tokenId_not: BigInt
+  tokenId_in: [BigInt]
+  tokenId_not_in: [BigInt]
+  tokenId_gt: BigInt
+  tokenId_lt: BigInt
+  tokenId_gte: BigInt
+  tokenId_lte: BigInt
+  transactionHash: String
+  transactionHash_not: String
+  transactionHash_in: [String]
+  transactionHash_not_in: [String]
+  transactionHash_gt: String
+  transactionHash_lt: String
+  transactionHash_gte: String
+  transactionHash_lte: String
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_in: [BigInt]
+  blockNumber_not_in: [BigInt]
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+}

--- a/apps/event-log-indexer/package.json
+++ b/apps/event-log-indexer/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "ponder dev",
+    "docker:up": "docker compose up",
+    "docker:down": "docker compose down",
     "start": "ponder start",
     "codegen": "ponder codegen",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",

--- a/apps/event-log-indexer/setup-local-db.sql
+++ b/apps/event-log-indexer/setup-local-db.sql
@@ -1,0 +1,33 @@
+CREATE USER "local-db-user";
+
+CREATE ROLE read_only;
+CREATE ROLE read_write;
+
+GRANT read_write TO postgres;
+GRANT read_write TO "local-db-user";
+
+CREATE DATABASE "event-log-indexer";
+
+-- read_only
+GRANT CONNECT ON DATABASE "event-log-indexer" TO read_only;
+
+GRANT USAGE ON SCHEMA public TO read_only;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO read_only;
+
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO read_only;
+
+-- read_write
+GRANT CREATE, CONNECT ON DATABASE "event-log-indexer" TO read_write;
+
+GRANT USAGE, CREATE ON SCHEMA public TO read_write;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO read_write;
+
+ALTER DEFAULT PRIVILEGES GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO read_write;
+
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO read_write;
+
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SEQUENCES TO read_write;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE read_write GRANT SELECT ON TABLES TO read_only;


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Updates `Dockerfile` to generate ponders image
* Adds docker compose setup to spin up a local postgres, and new image locally
* Adds `setup-local-db.sql` to mimic having `read_only` and `read_write` roles in our deployed GCP dbs and hopefully avoiding permission errors when ponder attempts to create a new schema
* Checks in generated graphql schema so we know exactly what schema each image version is running