### PR TITLE
build(event-log-indexer): remove build command

### DIFF
--- a/apps/event-log-indexer/package.json
+++ b/apps/event-log-indexer/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "echo 'No build step'",
     "dev": "ponder dev",
     "start": "ponder start",
     "codegen": "ponder codegen",

--- a/apps/event-log-indexer/package.json
+++ b/apps/event-log-indexer/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm codegen",
+    "build": "echo 'No build step'",
     "dev": "ponder dev",
     "start": "ponder start",
     "codegen": "ponder codegen",


### PR DESCRIPTION
build step isn't needed for ponder since it runs codegen at runtime.

it was breaking builds with

```
Error: Cannot find module '@ast-grep/napi-linux-arm64-musl'
```
