### PR TITLE
feat(paymaster-proxy): add pino logger

### DIFF
--- a/apps/paymaster-proxy/package.json
+++ b/apps/paymaster-proxy/package.json
@@ -37,6 +37,7 @@
     "express-prom-bundle": "^7.0.0",
     "express-rate-limit": "^7.1.5",
     "ioredis": "^5.3.2",
+    "pino": "^8.19.0",
     "prom-client": "^15.1.0",
     "rate-limit-redis": "^4.2.0",
     "viem": "^2.7.1",

--- a/apps/paymaster-proxy/src/ProxyService.ts
+++ b/apps/paymaster-proxy/src/ProxyService.ts
@@ -1,5 +1,6 @@
 import type { Express } from 'express'
 import { Redis } from 'ioredis'
+import pino from 'pino'
 import { optimismSepolia, sepolia } from 'viem/chains'
 
 import { envVars } from '@/envVars'
@@ -20,10 +21,12 @@ export class ProxyService {
   static async init() {
     const redisClient = new Redis(envVars.REDIS_URL)
 
+    const logger = pino()
+
     const paymasterConfigs = [
       getAlchemyPaymasterConfig({
         chain: sepolia,
-        rpcUrl: envVars.ALCHEMY_RPC_URL_OP_SEPOLIA,
+        rpcUrl: envVars.ALCHEMY_RPC_URL_SEPOLIA,
         policyId: envVars.ALCHEMY_GAS_MANAGER_POLICY_ID_OP_SEPOLIA,
       }),
       getAlchemyPaymasterConfig({
@@ -37,6 +40,9 @@ export class ProxyService {
       redisClient,
       paymasterConfigs,
       metrics,
+      logger: logger.child({
+        namespace: 'api-server',
+      }),
     })
 
     return new ProxyService(apiServer)

--- a/apps/paymaster-proxy/src/api/getV1ApiRoute.ts
+++ b/apps/paymaster-proxy/src/api/getV1ApiRoute.ts
@@ -1,5 +1,6 @@
 import type { Router } from 'express'
 import express from 'express'
+import type { Logger } from 'pino'
 
 import { jsonRpcRequestParseErrorHandler } from '@/middlewares/jsonRpcRequestParseErrorHandler'
 import type { Metrics } from '@/monitoring/metrics'
@@ -11,16 +12,18 @@ export const V1_API_BASE_PATH = '/v1'
 export const getV1ApiRoute = ({
   paymasterConfigs,
   metrics,
+  logger,
 }: {
   paymasterConfigs: PaymasterConfig[]
   metrics: Metrics
+  logger: Logger
 }): Router => {
   const route = express.Router()
 
   for (const { chain, sponsorUserOperation } of paymasterConfigs) {
     const path = `/${chain.id}/rpc`
 
-    console.info(
+    logger.info(
       `Registering paymaster RPC route at ${V1_API_BASE_PATH}${path}: ${chain.name}`,
     )
 
@@ -29,6 +32,7 @@ export const getV1ApiRoute = ({
       path,
       getJsonRpcRequestHandler({
         sponsorUserOperation,
+        logger: logger.child({ chainId: chain.id }),
         metrics,
         defaultMetricLabels: { apiVersion: 'v1', chainId: chain.id },
       }),

--- a/apps/paymaster-proxy/src/initializeApiServer.ts
+++ b/apps/paymaster-proxy/src/initializeApiServer.ts
@@ -1,6 +1,7 @@
 import type { Express } from 'express'
 import express from 'express'
 import type { Redis } from 'ioredis'
+import { type Logger, pino } from 'pino'
 
 import { getV1ApiRoute, V1_API_BASE_PATH } from '@/api/getV1ApiRoute'
 import { getPromBaseMetrics } from '@/middlewares/getPromBaseMetrics'
@@ -12,10 +13,12 @@ export const initializeApiServer = async ({
   redisClient,
   paymasterConfigs,
   metrics,
+  logger,
 }: {
   redisClient: Redis
   paymasterConfigs: PaymasterConfig[]
   metrics: Metrics
+  logger: Logger
 }): Promise<Express> => {
   const app = express()
 
@@ -34,7 +37,16 @@ export const initializeApiServer = async ({
     res.json({ ok: true })
   })
 
-  app.use(V1_API_BASE_PATH, getV1ApiRoute({ paymasterConfigs, metrics }))
+  app.use(
+    V1_API_BASE_PATH,
+    getV1ApiRoute({
+      paymasterConfigs,
+      metrics,
+      logger: logger.child({
+        apiVersion: 'v1',
+      }),
+    }),
+  )
 
   app.use((req, res) => {
     res.status(404).send()

--- a/apps/paymaster-proxy/src/initializeApiServer.ts
+++ b/apps/paymaster-proxy/src/initializeApiServer.ts
@@ -1,4 +1,10 @@
-import type { Express } from 'express'
+import type {
+  ErrorRequestHandler,
+  Express,
+  NextFunction,
+  Request,
+  Response,
+} from 'express'
 import express from 'express'
 import type { Redis } from 'ioredis'
 import { type Logger, pino } from 'pino'
@@ -51,6 +57,13 @@ export const initializeApiServer = async ({
   app.use((req, res) => {
     res.status(404).send()
   })
+
+  // Default error handler
+  app.use(((err: Error, req: Request, res: Response, next: NextFunction) => {
+    logger.error(err, 'Unhandled error')
+    metrics.unhandledApiServerErrorCount.inc({ apiVersion: 'v1' })
+    res.status(500).send()
+  }) satisfies ErrorRequestHandler)
 
   return app
 }

--- a/apps/paymaster-proxy/src/initializeApiServer.ts
+++ b/apps/paymaster-proxy/src/initializeApiServer.ts
@@ -7,7 +7,7 @@ import type {
 } from 'express'
 import express from 'express'
 import type { Redis } from 'ioredis'
-import { type Logger, pino } from 'pino'
+import { type Logger } from 'pino'
 
 import { getV1ApiRoute, V1_API_BASE_PATH } from '@/api/getV1ApiRoute'
 import { getPromBaseMetrics } from '@/middlewares/getPromBaseMetrics'

--- a/apps/paymaster-proxy/src/monitoring/metrics.ts
+++ b/apps/paymaster-proxy/src/monitoring/metrics.ts
@@ -35,4 +35,9 @@ export const metrics = {
     help: 'Number of successes when calling the paymaster RPC',
     labelNames: [...metricsNamespaceLabels] as const,
   }),
+  unhandledApiServerErrorCount: new Counter({
+    name: 'unhandledApiServerErrorCount',
+    help: 'Number of unhandled API server errors',
+    labelNames: ['apiVersion'] as const,
+  }),
 } as const

--- a/apps/paymaster-proxy/src/paymaster/alchemy/getAlchemyPaymasterConfig.ts
+++ b/apps/paymaster-proxy/src/paymaster/alchemy/getAlchemyPaymasterConfig.ts
@@ -1,6 +1,5 @@
 import { createAlchemyPublicRpcClient } from '@alchemy/aa-alchemy'
-import type { Address, Chain } from 'viem'
-import { HttpRequestError } from 'viem'
+import type { Address, Chain, HttpRequestError } from 'viem'
 import { z } from 'zod'
 
 import {
@@ -17,6 +16,10 @@ const alchemyJsonRpcHttpRequestErrorDetailsSchema = createJsonStringSchema(
     message: z.string(),
   }),
 )
+
+const isHttpRequestError = (e: unknown): e is HttpRequestError => {
+  return (e as any).name === 'HttpRequestError'
+}
 
 export const getAlchemyPaymasterConfig = <T extends Chain>({
   chain,
@@ -91,7 +94,7 @@ export const getAlchemyPaymasterConfig = <T extends Chain>({
         }
       } catch (e: unknown) {
         // Alchemy returns a HttpRequestError when the RPC call fails
-        if (e instanceof HttpRequestError) {
+        if (isHttpRequestError(e)) {
           const detailsParse =
             alchemyJsonRpcHttpRequestErrorDetailsSchema.safeParse(e.details)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       ioredis:
         specifier: ^5.3.2
         version: 5.3.2
+      pino:
+        specifier: ^8.19.0
+        version: 8.19.0
       prom-client:
         specifier: ^15.1.0
         version: 15.1.0
@@ -321,7 +324,7 @@ importers:
     devDependencies:
       '@eth-optimism/superchain-registry':
         specifier: github:ethereum-optimism/superchain-registry
-        version: github.com/ethereum-optimism/superchain-registry/ab073f6aa74fad109f1299d77f015f94059687c9
+        version: github.com/ethereum-optimism/superchain-registry/1cdbad415df731baccfbbc64700a3a0a0dfa9948
       '@tanstack/react-query':
         specifier: ^5.10.0
         version: 5.10.0(react@18.2.0)
@@ -14463,6 +14466,23 @@ packages:
       thread-stream: 2.4.1
     dev: false
 
+  /pino@8.19.0:
+    resolution: {integrity: sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==}
+    hasBin: true
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.3.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.1.0
+      pino-std-serializers: 6.2.2
+      process-warning: 3.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.4.3
+      sonic-boom: 3.8.0
+      thread-stream: 2.4.1
+    dev: false
+
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
@@ -18123,8 +18143,8 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
 
-  github.com/ethereum-optimism/superchain-registry/ab073f6aa74fad109f1299d77f015f94059687c9:
-    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/ab073f6aa74fad109f1299d77f015f94059687c9}
+  github.com/ethereum-optimism/superchain-registry/1cdbad415df731baccfbbc64700a3a0a0dfa9948:
+    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/1cdbad415df731baccfbbc64700a3a0a0dfa9948}
     name: '@eth-optimism/superchain-registry'
     version: 0.0.1-alpha.1
     dev: true


### PR DESCRIPTION
Adds pino logger which is used to log error and info.

nice thing about pino logger is you can create instances with logger.child({ }) with default params allowing you to easily namespace logs. maybe as a future add on i might create something similar for our prom metrics as well (inspired by https://pkg.go.dev/github.com/prometheus/client_golang@v1.8.0/prometheus#MetricVec.CurryWith)

Logging all important failures / address screenings