### PR TITLE
Adding tracking events for dapp console

### DIFF
--- a/apps/dapp-console/app/components/Header/HeaderTabs.tsx
+++ b/apps/dapp-console/app/components/Header/HeaderTabs.tsx
@@ -13,7 +13,7 @@ import {
 } from '@eth-optimism/ui-components/src/components/ui/dropdown-menu'
 
 import { RiArrowDownSLine } from '@remixicon/react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { trackSupportDocsClick, trackTopBarClick } from '@/app/event-tracking/mixpanel'
 
 type HeaderTabsProps = {
@@ -60,14 +60,11 @@ const HeaderTabItem = ({
   isActive,
   children,
 }: HeaderTabItemProps) => {
-  const handleClick = (id: string) => {
-    trackTopBarClick(id)
-  }
   return (
     <Link
       href={href}
       className={cn(baseClasses, isActive ? activeClasses : hoverClasses)}
-      onClick={() => handleClick(id)}
+      onClick={() => trackTopBarClick(id)}
     >
       {children}
     </Link>
@@ -81,12 +78,12 @@ const SupportDropdownMenu = () => {
   const dropdownItemClasses =
     'flex items-center gap-2 cursor-pointer h-12 px-4 text-base text-secondary-foreground'
 
-  const handleDropdownOpenChange = (isOpen: boolean) => {
+  const handleDropdownOpenChange = useCallback((isOpen: boolean) => {
     setIsDropdownOpen(isOpen);
     if (isOpen) {
       trackTopBarClick('Support');
     }
-  };
+  }, [])
 
   return (
     <DropdownMenu

--- a/apps/dapp-console/app/components/Header/HeaderTabs.tsx
+++ b/apps/dapp-console/app/components/Header/HeaderTabs.tsx
@@ -14,6 +14,7 @@ import {
 
 import { RiArrowDownSLine } from '@remixicon/react'
 import { useState } from 'react'
+import { trackSupportDocsClick, trackTopBarClick } from '@/app/event-tracking/mixpanel'
 
 type HeaderTabsProps = {
   currentRoute: string
@@ -23,12 +24,14 @@ const HeaderTabs = ({ currentRoute }: HeaderTabsProps) => {
   return (
     <div className="gap-8 items-end h-full hidden lg:flex">
       <HeaderTabItem
+        id='Console'
         href={routes.CONSOLE.path}
         isActive={currentRoute === routes.CONSOLE.path}
       >
         <Text as="span">{routes.CONSOLE.label}</Text>
       </HeaderTabItem>
       <HeaderTabItem
+        id= 'Insights'
         href={routes.INSIGHTS.path}
         isActive={currentRoute === routes.INSIGHTS.path}
       >
@@ -45,20 +48,26 @@ const hoverClasses = 'hover:border-muted-foreground hover:text-foreground'
 const activeClasses = 'border-foreground text-foreground'
 
 type HeaderTabItemProps = {
+  id: string,
   href?: string
   isActive?: boolean
   children: React.ReactNode
 }
 
 const HeaderTabItem = ({
+  id,
   href = '',
   isActive,
   children,
 }: HeaderTabItemProps) => {
+  const handleClick = (id: string) => {
+    trackTopBarClick(id)
+  }
   return (
     <Link
       href={href}
       className={cn(baseClasses, isActive ? activeClasses : hoverClasses)}
+      onClick={() => handleClick(id)}
     >
       {children}
     </Link>
@@ -72,10 +81,17 @@ const SupportDropdownMenu = () => {
   const dropdownItemClasses =
     'flex items-center gap-2 cursor-pointer h-12 px-4 text-base text-secondary-foreground'
 
+  const handleDropdownOpenChange = (isOpen: boolean) => {
+    setIsDropdownOpen(isOpen);
+    if (isOpen) {
+      trackTopBarClick('Support');
+    }
+  };
+
   return (
     <DropdownMenu
       onOpenChange={(isOpen) => {
-        setIsDropdownOpen(isOpen)
+        handleDropdownOpenChange(isOpen)
       }}
     >
       <DropdownMenuTrigger
@@ -109,7 +125,7 @@ const SupportDropdownMenu = () => {
         </DropdownMenuLabel>
         {docsItems.map((item) => (
           <DropdownMenuItem key={item.path} asChild>
-            <a href={item.path} target="_blank" className={dropdownItemClasses}>
+            <a href={item.path} target="_blank" className={dropdownItemClasses} onClick={() => trackSupportDocsClick(item.label)} >
               <Image
                 src={item.logo}
                 alt={`${item.label} logo`}

--- a/apps/dapp-console/app/components/Header/HeaderTabs.tsx
+++ b/apps/dapp-console/app/components/Header/HeaderTabs.tsx
@@ -14,7 +14,10 @@ import {
 
 import { RiArrowDownSLine } from '@remixicon/react'
 import { useCallback, useState } from 'react'
-import { trackSupportDocsClick, trackTopBarClick } from '@/app/event-tracking/mixpanel'
+import {
+  trackSupportDocsClick,
+  trackTopBarClick,
+} from '@/app/event-tracking/mixpanel'
 
 type HeaderTabsProps = {
   currentRoute: string
@@ -24,14 +27,14 @@ const HeaderTabs = ({ currentRoute }: HeaderTabsProps) => {
   return (
     <div className="gap-8 items-end h-full hidden lg:flex">
       <HeaderTabItem
-        id='Console'
+        id="Console"
         href={routes.CONSOLE.path}
         isActive={currentRoute === routes.CONSOLE.path}
       >
         <Text as="span">{routes.CONSOLE.label}</Text>
       </HeaderTabItem>
       <HeaderTabItem
-        id= 'Insights'
+        id="Insights"
         href={routes.INSIGHTS.path}
         isActive={currentRoute === routes.INSIGHTS.path}
       >
@@ -48,7 +51,7 @@ const hoverClasses = 'hover:border-muted-foreground hover:text-foreground'
 const activeClasses = 'border-foreground text-foreground'
 
 type HeaderTabItemProps = {
-  id: string,
+  id: string
   href?: string
   isActive?: boolean
   children: React.ReactNode
@@ -79,9 +82,9 @@ const SupportDropdownMenu = () => {
     'flex items-center gap-2 cursor-pointer h-12 px-4 text-base text-secondary-foreground'
 
   const handleDropdownOpenChange = useCallback((isOpen: boolean) => {
-    setIsDropdownOpen(isOpen);
+    setIsDropdownOpen(isOpen)
     if (isOpen) {
-      trackTopBarClick('Support');
+      trackTopBarClick('Support')
     }
   }, [])
 
@@ -122,7 +125,12 @@ const SupportDropdownMenu = () => {
         </DropdownMenuLabel>
         {docsItems.map((item) => (
           <DropdownMenuItem key={item.path} asChild>
-            <a href={item.path} target="_blank" className={dropdownItemClasses} onClick={() => trackSupportDocsClick(item.label)} >
+            <a
+              href={item.path}
+              target="_blank"
+              className={dropdownItemClasses}
+              onClick={() => trackSupportDocsClick(item.label)}
+            >
               <Image
                 src={item.logo}
                 alt={`${item.label} logo`}

--- a/apps/dapp-console/app/components/Header/SignInButton.tsx
+++ b/apps/dapp-console/app/components/Header/SignInButton.tsx
@@ -12,11 +12,16 @@ import { useState } from 'react'
 import { cn } from '@eth-optimism/ui-components/src/lib/utils'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { RiArrowDownSLine, RiUser3Fill } from '@remixicon/react'
+import { trackSignInClick } from '@/app/event-tracking/mixpanel'
 
 const SignInButton = () => {
   const { login, logout, authenticated } = usePrivy()
+  const handleLogin = () => {
+    trackSignInClick()
+    login()
+  }
   return !authenticated ? (
-    <Button onClick={login}>Sign in</Button>
+    <Button onClick={handleLogin}>Sign in</Button>
   ) : (
     <AccountDropdown logout={logout} />
   )

--- a/apps/dapp-console/app/console/components/BuildSection.tsx
+++ b/apps/dapp-console/app/console/components/BuildSection.tsx
@@ -12,6 +12,7 @@ import {
 import { useState } from 'react'
 import { useDialogContent } from '@/app/console/useDialogContent'
 import { openWindow } from '@/app/helpers'
+import { trackCardClick } from '@/app/event-tracking/mixpanel'
 
 const BuildSection = () => {
   const [dialogContent, setDialogContent] = useState<React.ReactNode>()
@@ -29,6 +30,7 @@ const BuildSection = () => {
             title="Superchain Faucet"
             description="Get test ETH tokens to build your dapp on the Superchain."
             onClick={() => {
+              trackCardClick('Superchain Faucet')
               openWindow(externalRoutes.SUPERCHAIN_FAUCET.path)
             }}
           />
@@ -37,6 +39,7 @@ const BuildSection = () => {
               title="Testnet Paymaster"
               description="Get your testnet transactions sponsored to remove friction from your dapp experience."
               onClick={() => {
+                trackCardClick('Testnet Paymaster')
                 setDialogContent(testnetPaymasterContent)
               }}
             />
@@ -46,6 +49,7 @@ const BuildSection = () => {
               title="UX Review"
               description="Get actionable feedback from Superchain pros to get your dapp ready for launch."
               onClick={() => {
+                trackCardClick('UX Review')
                 setDialogContent(uxReviewContent)
               }}
               badge={<Badge>Featured</Badge>}
@@ -56,6 +60,7 @@ const BuildSection = () => {
               title="Superchain Safe"
               description="Get multisig support on any OP Chain in the Superchain."
               onClick={() => {
+                trackCardClick('Superchain Safe')
                 setDialogContent(superchainSafeContent)
               }}
             />

--- a/apps/dapp-console/app/console/components/LaunchSection.tsx
+++ b/apps/dapp-console/app/console/components/LaunchSection.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react'
 import { useDialogContent } from '@/app/console/useDialogContent'
 import { externalRoutes } from '@/app/constants'
 import { openWindow } from '@/app/helpers'
+import { trackCardClick } from '@/app/event-tracking/mixpanel'
 
 const LaunchSection = () => {
   const [dialogContent, setDialogContent] = useState<React.ReactNode>()
@@ -33,6 +34,7 @@ const LaunchSection = () => {
               title="Deployment Rebate"
               description="Launch on the Superchain and get your deployment costs covered up to $200."
               onClick={() => {
+                trackCardClick('Deployment Rebate')
                 setDialogContent(deploymentRebateContent)
               }}
               badge={<Badge>Featured</Badge>}
@@ -43,6 +45,7 @@ const LaunchSection = () => {
               title="Paymaster"
               description="Get up to $500 in free gas for your users when you use the Superchain Paymaster."
               onClick={() => {
+                trackCardClick('Paymaster')
                 setDialogContent(mainnetPaymasterContent)
               }}
               badge={<Badge variant="secondary">Join waitlist</Badge>}
@@ -53,6 +56,7 @@ const LaunchSection = () => {
               title="Megaphone"
               description="Amplify your launch through Superchain marketing channels."
               onClick={() => {
+                trackCardClick('Megaphone')
                 setDialogContent(megaphoneContent)
               }}
             />
@@ -62,6 +66,7 @@ const LaunchSection = () => {
               title="User Feedback"
               description="Get actionable feedback from Superchain contributors to improve your app."
               onClick={() => {
+                trackCardClick('User Feedback')
                 setDialogContent(userFeedbackContent)
               }}
             />
@@ -70,6 +75,7 @@ const LaunchSection = () => {
             title="RetroPGF"
             description="Get funded for adding value to the Superchain ecosystem."
             onClick={() => {
+              trackCardClick('RetroPGF')
               openWindow(externalRoutes.RETRO_PGF.path)
             }}
           />

--- a/apps/dapp-console/app/console/components/PromotionsSection.tsx
+++ b/apps/dapp-console/app/console/components/PromotionsSection.tsx
@@ -11,6 +11,7 @@ import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import Image from 'next/image'
 import { useDialogContent } from '@/app/console/useDialogContent'
 import { useState } from 'react'
+import { trackCardClick } from '@/app/event-tracking/mixpanel'
 
 const PromotionsSection = () => {
   const { quicknodeContent, moralisContent, gelatoContent, thirdWebContent } =
@@ -34,6 +35,7 @@ const PromotionsSection = () => {
               title="Gelato"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
               onClick={() => {
+                trackCardClick('Gelato')
                 setDialogContent(gelatoContent)
               }}
               variant="secondary"
@@ -52,6 +54,7 @@ const PromotionsSection = () => {
               title="Moralis"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
               onClick={() => {
+                trackCardClick('Moralis')
                 setDialogContent(moralisContent)
               }}
               variant="secondary"
@@ -70,6 +73,7 @@ const PromotionsSection = () => {
               title="QuickNode"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
               onClick={() => {
+                trackCardClick('QuickNode')
                 setDialogContent(quicknodeContent)
               }}
               variant="secondary"
@@ -88,6 +92,7 @@ const PromotionsSection = () => {
               title="ThirdWeb"
               description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
               onClick={() => {
+                trackCardClick('ThirdWeb')
                 setDialogContent(thirdWebContent)
               }}
               variant="secondary"

--- a/apps/dapp-console/app/console/components/SupportSection.tsx
+++ b/apps/dapp-console/app/console/components/SupportSection.tsx
@@ -2,6 +2,7 @@
 
 import { Tile } from '@/app/components/Tile/Tile'
 import { docsItems, externalRoutes } from '@/app/constants'
+import { trackCardClick } from '@/app/event-tracking/mixpanel'
 import { openWindow } from '@/app/helpers'
 import { FarcasterIcon } from '@/app/icons/FarcasterIcon'
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
@@ -26,6 +27,7 @@ const SupportSection = () => {
           title="Github Developer Forum"
           description="Get all of your development questions answered by Superchain experts."
           onClick={() => {
+            trackCardClick('Github Developer Forum')
             openWindow(externalRoutes.DEV_FORUM.path)
           }}
           variant="secondary"
@@ -37,6 +39,7 @@ const SupportSection = () => {
             title="Farcaster"
             description="Join the /op-stack channel."
             onClick={() => {
+              trackCardClick('Farcaster')
               openWindow(externalRoutes.FARCASTER.path)
             }}
             variant="secondary"
@@ -45,6 +48,7 @@ const SupportSection = () => {
           <Tile
             title="Dapp examples"
             onClick={() => {
+              trackCardClick('Dapp examples')
               openWindow(externalRoutes.DAPP_EXAMPLES.path)
             }}
             variant="secondary"
@@ -53,6 +57,7 @@ const SupportSection = () => {
           <Tile
             title="Discord"
             onClick={() => {
+              trackCardClick('Discord')
               openWindow(externalRoutes.DISCORD.path)
             }}
             variant="secondary"
@@ -62,7 +67,9 @@ const SupportSection = () => {
             <DialogTrigger asChild>
               <Tile
                 title="Docs"
-                onClick={() => {}}
+                onClick={() => {
+                  trackCardClick('Docs')
+                }}
                 variant="secondary"
                 icon={<RiGitForkFill size={24} />}
               />

--- a/apps/dapp-console/app/console/constants.tsx
+++ b/apps/dapp-console/app/console/constants.tsx
@@ -1,6 +1,17 @@
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { DialogMetadata } from '@/app/console/useDialogContent'
+import { trackOfferEngaged } from '@/app/event-tracking/mixpanel'
+
+function generatePrimaryButton(label: string, buttonText: string, url: string): React.ReactNode {
+  return (
+    <Button asChild>
+      <a href={url} onClick={() => trackOfferEngaged(label)}>
+        <Text as="span">{buttonText}</Text>
+      </a>
+    </Button>
+  );
+}
 
 // Build Section
 export const testnetPaymasterMetadata: DialogMetadata = {
@@ -9,13 +20,7 @@ export const testnetPaymasterMetadata: DialogMetadata = {
     'Get your testnet transactions sponsored to remove friction from your dapp experience',
   description:
     'Continue to Github for information on how to setup and use the Testnet Paymaster.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">View on Github</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Testnet Paymaster', 'View on Github', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -31,13 +36,7 @@ export const uxReviewMetadata: DialogMetadata = {
     'Get actionable feedback from Superchain pros to get your dapp ready for launch',
   description:
     'Technical builders from Superchain teams are standing by to review your dapp. Whether you’re building DeFi, DeSo, Infra, or anything else, we’ll connect you with people who get it.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('UX Review', 'Apply', ''),
 }
 
 export const superchainSafeMetadata: DialogMetadata = {
@@ -45,13 +44,7 @@ export const superchainSafeMetadata: DialogMetadata = {
   title: 'Get multisig support on any OP Chain in the Superchain with Safe',
   description:
     'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Get safe for Base or Optimism</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Superchain Safe', 'Get safe for Base or Optimism', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -68,13 +61,7 @@ export const deploymentRebateMetadata: DialogMetadata = {
     'Launch on the Superchain and get your deployment costs covered up to $200',
   description:
     'Get your app up and running without having to worry about deployment fees.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Deployment Rebate', 'Apply', ''),
 }
 
 export const mainnetPaymasterMetadata: DialogMetadata = {
@@ -83,13 +70,7 @@ export const mainnetPaymasterMetadata: DialogMetadata = {
     'Get up to $500 in free gas for your users when you use the Superchain Paymaster',
   description:
     'Optimism will sponsor your mainnet transactions to help you attract users and grow your product.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Join waitlist</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Paymaster', 'Join waitlist', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -104,13 +85,7 @@ export const megaphoneMetadata: DialogMetadata = {
   title: 'Amplify your launch through Superchain marketing channels',
   description:
     'When you’re ready, Superchain teams will communicate your launch to audiences across X, Farcaster, and other marketing channels.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Megaphone', 'Apply', ''),
 }
 
 export const userFeedbackMetadata: DialogMetadata = {
@@ -119,13 +94,7 @@ export const userFeedbackMetadata: DialogMetadata = {
     'Get actionable feedback from Superchain contributors to improve your app',
   description:
     'Passionate contributors from Superchain communities, like Base and Optimism, are standing by to provide feedback on any topic.',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('User Feedback', 'Apply', ''),
 }
 
 // Promo Section
@@ -135,13 +104,7 @@ export const gelatoMetadata: DialogMetadata = {
   description:
     'Gelato is a protocol that automates smart contract executions on Ethereum. Use Gelato to automate your dapp and save on gas fees.',
   bannerImage: '/banners/gelato-banner.png',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Gelato', 'Apply', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -157,13 +120,7 @@ export const moralisMetadata: DialogMetadata = {
   description:
     'Moralis is a protocol that automates smart contract executions on Ethereum. Use Moralis to automate your dapp and save on gas fees.',
   bannerImage: '/banners/moralis-banner.png',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Moralis', 'Apply', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -179,13 +136,7 @@ export const quicknodeMetadata: DialogMetadata = {
   description:
     'Quicknode is a protocol that automates smart contract executions on Ethereum. Use Quicknode to automate your dapp and save on gas fees.',
   bannerImage: '/banners/quicknode-banner.png',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Quicknode', 'Apply', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -201,13 +152,7 @@ export const thirdWebMetadata: DialogMetadata = {
   description:
     'Third Web is a protocol that automates smart contract executions on Ethereum. Use Third Web to automate your dapp and save on gas fees.',
   bannerImage: '/banners/thirdweb-banner.png',
-  primaryButton: (
-    <Button asChild>
-      <a href="">
-        <Text as="span">Apply</Text>
-      </a>
-    </Button>
-  ),
+  primaryButton: generatePrimaryButton('Third Web', 'Apply', ''),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">

--- a/apps/dapp-console/app/console/constants.tsx
+++ b/apps/dapp-console/app/console/constants.tsx
@@ -3,14 +3,18 @@ import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { DialogMetadata } from '@/app/console/useDialogContent'
 import { trackOfferEngaged } from '@/app/event-tracking/mixpanel'
 
-function generatePrimaryButton(label: string, buttonText: string, url: string): React.ReactNode {
+function generatePrimaryButton(
+  label: string,
+  buttonText: string,
+  url: string,
+): React.ReactNode {
   return (
     <Button asChild>
       <a href={url} onClick={() => trackOfferEngaged(label)}>
         <Text as="span">{buttonText}</Text>
       </a>
     </Button>
-  );
+  )
 }
 
 // Build Section
@@ -20,7 +24,11 @@ export const testnetPaymasterMetadata: DialogMetadata = {
     'Get your testnet transactions sponsored to remove friction from your dapp experience',
   description:
     'Continue to Github for information on how to setup and use the Testnet Paymaster.',
-  primaryButton: generatePrimaryButton('Testnet Paymaster', 'View on Github', ''),
+  primaryButton: generatePrimaryButton(
+    'Testnet Paymaster',
+    'View on Github',
+    '',
+  ),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">
@@ -44,7 +52,11 @@ export const superchainSafeMetadata: DialogMetadata = {
   title: 'Get multisig support on any OP Chain in the Superchain with Safe',
   description:
     'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore.',
-  primaryButton: generatePrimaryButton('Superchain Safe', 'Get safe for Base or Optimism', ''),
+  primaryButton: generatePrimaryButton(
+    'Superchain Safe',
+    'Get safe for Base or Optimism',
+    '',
+  ),
   secondaryButton: (
     <Button asChild variant="secondary">
       <a href="">

--- a/apps/dapp-console/app/event-tracking/mixpanel.tsx
+++ b/apps/dapp-console/app/event-tracking/mixpanel.tsx
@@ -1,11 +1,57 @@
 import mixpanelBrowser from 'mixpanel-browser'
 
 const initMixpanel = () => {
-  if (!process.env.VITE_MIXPANEL_TOKEN) {
+  if (!process.env.NEXT_PUBLIC_MIXPANEL_TOKEN) {
     return null
   }
-  mixpanelBrowser.init(process.env.VITE_MIXPANEL_TOKEN)
+  mixpanelBrowser.init(process.env.NEXT_PUBLIC_MIXPANEL_TOKEN, {track_pageview: true})
   return mixpanelBrowser
 }
 
 export const mixpanel = initMixpanel()
+
+enum TRACKING_EVENT_NAME {
+  PageVisit = 'Page Visit',
+  SignInClick = 'Sign In Click',
+  SuccessfulSignIn = 'Successful Sign In',
+  CardClick = 'Card Click',
+  TopBarClick = 'Top Bar Click',
+  SupportDocsClick = 'Support Docs Click',
+  OfferEngaged = 'Offer Engaged',
+}
+
+enum CUSTOM_TRACKING_PROPERTY {
+  NewUser = 'New User',
+  CardName = 'Card Name',
+  PageName = 'Page Name',
+  ChainName = 'Chain Name',
+  OfferingName = 'Offering Name',
+}
+
+export const trackPageVisit = () => {
+  mixpanel?.track(TRACKING_EVENT_NAME.PageVisit)
+}
+
+export const trackSignInClick = () => {
+  mixpanel?.track(TRACKING_EVENT_NAME.SignInClick)
+}
+
+export const trackSuccessfulSignIn = (isNewUser: boolean) => {
+  mixpanel?.track(TRACKING_EVENT_NAME.SuccessfulSignIn, {[CUSTOM_TRACKING_PROPERTY.NewUser]: isNewUser})
+};
+
+export const trackCardClick = (cardName: string) => {
+  mixpanel?.track(TRACKING_EVENT_NAME.CardClick, {[CUSTOM_TRACKING_PROPERTY.CardName]: cardName});
+};
+
+export const trackTopBarClick = (pageName: string) => {
+  mixpanel?.track(TRACKING_EVENT_NAME.TopBarClick, {[CUSTOM_TRACKING_PROPERTY.PageName]: pageName});
+};
+
+export const trackSupportDocsClick = (chainName: string) => {
+  mixpanel?.track(TRACKING_EVENT_NAME.SupportDocsClick, {[CUSTOM_TRACKING_PROPERTY.ChainName]: chainName});
+};
+
+export const trackOfferEngaged = (offeringName: string) => {
+  mixpanel?.track(TRACKING_EVENT_NAME.OfferEngaged, {[CUSTOM_TRACKING_PROPERTY.OfferingName]: offeringName});
+};

--- a/apps/dapp-console/app/event-tracking/mixpanel.tsx
+++ b/apps/dapp-console/app/event-tracking/mixpanel.tsx
@@ -4,7 +4,9 @@ const initMixpanel = () => {
   if (!process.env.NEXT_PUBLIC_MIXPANEL_TOKEN) {
     return null
   }
-  mixpanelBrowser.init(process.env.NEXT_PUBLIC_MIXPANEL_TOKEN, {track_pageview: true})
+  mixpanelBrowser.init(process.env.NEXT_PUBLIC_MIXPANEL_TOKEN, {
+    track_pageview: true,
+  })
   return mixpanelBrowser
 }
 
@@ -37,21 +39,31 @@ export const trackSignInClick = () => {
 }
 
 export const trackSuccessfulSignIn = (isNewUser: boolean) => {
-  mixpanel?.track(TRACKING_EVENT_NAME.SuccessfulSignIn, {[CUSTOM_TRACKING_PROPERTY.NewUser]: isNewUser})
-};
+  mixpanel?.track(TRACKING_EVENT_NAME.SuccessfulSignIn, {
+    [CUSTOM_TRACKING_PROPERTY.NewUser]: isNewUser,
+  })
+}
 
 export const trackCardClick = (cardName: string) => {
-  mixpanel?.track(TRACKING_EVENT_NAME.CardClick, {[CUSTOM_TRACKING_PROPERTY.CardName]: cardName});
-};
+  mixpanel?.track(TRACKING_EVENT_NAME.CardClick, {
+    [CUSTOM_TRACKING_PROPERTY.CardName]: cardName,
+  })
+}
 
 export const trackTopBarClick = (pageName: string) => {
-  mixpanel?.track(TRACKING_EVENT_NAME.TopBarClick, {[CUSTOM_TRACKING_PROPERTY.PageName]: pageName});
-};
+  mixpanel?.track(TRACKING_EVENT_NAME.TopBarClick, {
+    [CUSTOM_TRACKING_PROPERTY.PageName]: pageName,
+  })
+}
 
 export const trackSupportDocsClick = (chainName: string) => {
-  mixpanel?.track(TRACKING_EVENT_NAME.SupportDocsClick, {[CUSTOM_TRACKING_PROPERTY.ChainName]: chainName});
-};
+  mixpanel?.track(TRACKING_EVENT_NAME.SupportDocsClick, {
+    [CUSTOM_TRACKING_PROPERTY.ChainName]: chainName,
+  })
+}
 
 export const trackOfferEngaged = (offeringName: string) => {
-  mixpanel?.track(TRACKING_EVENT_NAME.OfferEngaged, {[CUSTOM_TRACKING_PROPERTY.OfferingName]: offeringName});
-};
+  mixpanel?.track(TRACKING_EVENT_NAME.OfferEngaged, {
+    [CUSTOM_TRACKING_PROPERTY.OfferingName]: offeringName,
+  })
+}

--- a/apps/dapp-console/app/providers/PrivyProviderWrapper.tsx
+++ b/apps/dapp-console/app/providers/PrivyProviderWrapper.tsx
@@ -12,7 +12,7 @@ function PrivyProviderWrapper({ children }: { children: React.ReactNode }) {
 
   const handleSuccess = (user: User, isNewUser: boolean) => {
     trackSuccessfulSignIn(isNewUser)
-  };
+  }
 
   return (
     <PrivyProvider

--- a/apps/dapp-console/app/providers/PrivyProviderWrapper.tsx
+++ b/apps/dapp-console/app/providers/PrivyProviderWrapper.tsx
@@ -1,13 +1,18 @@
 'use client'
 
-import { PrivyProvider } from '@privy-io/react-auth'
+import { PrivyProvider, User } from '@privy-io/react-auth'
 import { useTheme } from 'next-themes'
+import { trackSuccessfulSignIn } from '@/app/event-tracking/mixpanel'
 
 // This is a public app_id provided in the privy docs: https://docs.privy.io/guide/quickstart
 const PRIVY_PUBLIC_APP_ID = 'clpispdty00ycl80fpueukbhl'
 
 function PrivyProviderWrapper({ children }: { children: React.ReactNode }) {
   const { theme } = useTheme()
+
+  const handleSuccess = (user: User, isNewUser: boolean) => {
+    trackSuccessfulSignIn(isNewUser)
+  };
 
   return (
     <PrivyProvider
@@ -25,6 +30,7 @@ function PrivyProviderWrapper({ children }: { children: React.ReactNode }) {
           privacyPolicyUrl: '',
         },
       }}
+      onSuccess={handleSuccess}
     >
       {children}
     </PrivyProvider>


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/ecosystem/issues/104

This PR adds the individual events and tracking calls for each of the Dapp Console user actions we want to track. More detailed information on the tracking can be found here: https://docs.google.com/document/d/1iJeKa9o3cRnIO0yxxwnDgFaP8nr_hocsBKr6tDlWKD0/edit#heading=h.lnsjyxig3l7x

This is the list of events added:
```
enum TRACKING_EVENT_NAME {
  PageVisit = 'Page Visit',
  SignInClick = 'Sign In Click',
  SuccessfulSignIn = 'Successful Sign In',
  CardClick = 'Card Click',
  TopBarClick = 'Top Bar Click',
  SupportDocsClick = 'Support Docs Click',
  OfferEngaged = 'Offer Engaged',
}
```