### PR TITLE
[Dapp Console] Adds Initial Settings Page

### DIFF
--- a/apps/dapp-console/app/components/Header/SignInButton.tsx
+++ b/apps/dapp-console/app/components/Header/SignInButton.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
 } from '@eth-optimism/ui-components/src/components/ui/dropdown-menu'
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
+import { Separator } from '@eth-optimism/ui-components/src/components/ui/separator'
 import { usePrivy } from '@privy-io/react-auth'
 import { useState } from 'react'
 import { cn } from '@eth-optimism/ui-components/src/lib/utils'
@@ -30,10 +31,13 @@ const SignInButton = () => {
 type AccountDropdownProps = {
   logout: () => void
 }
+
 const AccountDropdown = ({ logout }: AccountDropdownProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const dropdownItemClasses =
-    'flex items-center gap-2 cursor-pointer h-12 px-4 text-base text-secondary-foreground'
+    'flex items-center gap-2 cursor-pointer h-12 px-4 rounded-none text-base text-secondary-foreground'
+
+  const shouldShowSettings = process.env.NEXT_PUBLIC_ENABLE_SETTINGS === 'true'
 
   return (
     <DropdownMenu
@@ -51,7 +55,30 @@ const AccountDropdown = ({ logout }: AccountDropdownProps) => {
           />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-80">
+      <DropdownMenuContent align="end" className="w-80 p-0">
+        {shouldShowSettings && (
+          <>
+            <DropdownMenuItem asChild>
+              <Link className={dropdownItemClasses} href={routes.ACCOUNT.path}>
+                <Text as="span">{routes.ACCOUNT.label}</Text>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link
+                className={dropdownItemClasses}
+                href={routes.CONTRACTS.path}
+              >
+                <Text as="span">{routes.CONTRACTS.label}</Text>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link className={dropdownItemClasses} href={routes.WALLETS.path}>
+                <Text as="span">{routes.WALLETS.label}</Text>
+              </Link>
+            </DropdownMenuItem>
+            <Separator />
+          </>
+        )}
         <DropdownMenuItem asChild>
           <div className={dropdownItemClasses} onClick={logout}>
             <Text as="span">Sign out</Text>

--- a/apps/dapp-console/app/components/Header/SignInButton.tsx
+++ b/apps/dapp-console/app/components/Header/SignInButton.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,6 +15,7 @@ import { cn } from '@eth-optimism/ui-components/src/lib/utils'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { RiArrowDownSLine, RiUser3Fill } from '@remixicon/react'
 import { trackSignInClick } from '@/app/event-tracking/mixpanel'
+import { routes } from '@/app/constants'
 
 const SignInButton = () => {
   const { login, logout, authenticated } = usePrivy()

--- a/apps/dapp-console/app/components/Header/index.tsx
+++ b/apps/dapp-console/app/components/Header/index.tsx
@@ -9,6 +9,7 @@ import { usePathname } from 'next/navigation'
 import { SignInButton } from '@/app/components/Header/SignInButton'
 import { MenuButton, MobileMenu } from '@/app/components/Header/MobileMenu'
 import { useState } from 'react'
+import Link from 'next/link'
 
 const Header = () => {
   const pathname = usePathname()
@@ -41,16 +42,21 @@ const Header = () => {
 const HeaderLogo = () => {
   return (
     <div className="flex items-center">
-      <Image
-        src="logos/op-superchain-logo.svg"
-        alt="Superchain dapp developer logo"
-        width={200}
-        height={24}
-      />
-      <Separator orientation="vertical" className="h-4 mx-4 hidden md:block" />
-      <Text as="span" className="tracking-widest font-medium hidden md:block">
-        DAPP DEVELOPER
-      </Text>
+      <Link href="/" className="flex flex-row">
+        <Image
+          src="/logos/op-superchain-logo.svg"
+          alt="Superchain dapp developer logo"
+          width={200}
+          height={24}
+        />
+        <Separator
+          orientation="vertical"
+          className="h-4 mx-4 hidden md:block"
+        />
+        <Text as="span" className="tracking-widest font-medium hidden md:block">
+          DAPP DEVELOPER
+        </Text>
+      </Link>
     </div>
   )
 }

--- a/apps/dapp-console/app/constants/index.tsx
+++ b/apps/dapp-console/app/constants/index.tsx
@@ -14,6 +14,18 @@ const routes: Routes = {
     path: '/insights',
     label: 'Insights',
   },
+  ACCOUNT: {
+    path: '/settings/account',
+    label: 'Account',
+  },
+  CONTRACTS: {
+    path: '/settings/contracts',
+    label: 'Contracts',
+  },
+  WALLETS: {
+    path: '/settings/wallets',
+    label: 'Wallets',
+  },
 } as const satisfies Routes
 
 const externalRoutes: Routes = {

--- a/apps/dapp-console/app/settings/account/page.tsx
+++ b/apps/dapp-console/app/settings/account/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Input } from '@eth-optimism/ui-components/src/components/ui/input'
+import { Label } from '@eth-optimism/ui-components/src/components/ui/label'
+
+import { usePrivy } from '@privy-io/react-auth'
+
+export default function Account() {
+  const { user } = usePrivy()
+
+  if (!user) {
+    return
+  }
+
+  return (
+    <div className="flex flex-col">
+      <Label htmlFor="email" className="mb-2">
+        Email
+      </Label>
+      <Input
+        type="email"
+        className="bg-secondary"
+        value={user.email?.address ?? ''}
+        disabled={true}
+      />
+    </div>
+  )
+}

--- a/apps/dapp-console/app/settings/components/SettingsCard.tsx
+++ b/apps/dapp-console/app/settings/components/SettingsCard.tsx
@@ -1,0 +1,61 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@eth-optimism/ui-components/src/components/ui/card'
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+
+import { SettingsTab } from '@/app/settings/types'
+
+export type SettingsCardProps = {
+  className: string
+  children: React.ReactNode
+  tab: SettingsTab
+}
+
+export const SettingsCardTitle = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) => (
+  <Text as="span" className="text-4xl mb-2">
+    {children}
+  </Text>
+)
+
+export const SettingsCardDescription = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) => (
+  <Text
+    as="span"
+    className="block text-base text-secondary-foreground mt-6 mb-6"
+  >
+    {children}
+  </Text>
+)
+
+export const SettingsCard = ({
+  className,
+  children,
+  tab,
+}: SettingsCardProps) => (
+  <Card className={className}>
+    <CardHeader className="md:p-10 lg:p-16">
+      <CardTitle>
+        <div className="flex">{tab.title}</div>
+      </CardTitle>
+      {tab.description && (
+        <CardDescription>
+          <div className="flex">{tab.description}</div>
+        </CardDescription>
+      )}
+    </CardHeader>
+    <CardContent className="pt-0 md:px-10 md:pb-10 lg:px-16 lg:pb-16">
+      <div className="flex flex-col w-full">{children}</div>
+    </CardContent>
+  </Card>
+)

--- a/apps/dapp-console/app/settings/components/SettingsMenu.tsx
+++ b/apps/dapp-console/app/settings/components/SettingsMenu.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import { cn } from '@eth-optimism/ui-components/src/lib/utils'
+import { Separator } from '@eth-optimism/ui-components/src/components/ui/separator'
+
+import { routes } from '@/app/constants'
+import { SettingsTabType } from '@/app/settings/types'
+
+export type SettingsMenuProps = {
+  activeTabType: SettingsTabType
+  className: string
+}
+
+const SettingsMenuItem = ({
+  isActive,
+  title,
+  url,
+}: Readonly<{
+  isActive: boolean
+  title: string
+  url: string
+}>) => (
+  <li className="p-3">
+    <Link className="flex flex-row items-center" href={url}>
+      <div
+        className={cn(
+          'border-1 bg-primary rounded-full w-[6px] h-[6px]',
+          isActive ? 'visibile' : 'invisible',
+        )}
+      ></div>
+      <Text
+        as="span"
+        className={cn('pl-3 text-sm transition', isActive ? 'font-bold' : '')}
+      >
+        {title}
+      </Text>
+    </Link>
+  </li>
+)
+
+export const SettingsMenu = ({
+  activeTabType,
+  className,
+}: SettingsMenuProps) => (
+  <div className={className}>
+    <Text className="text-sm font-semibold p-3">Settings</Text>
+    <Separator />
+    <ul>
+      <SettingsMenuItem
+        isActive={activeTabType === 'account'}
+        title={routes.ACCOUNT.label}
+        url={routes.ACCOUNT.path}
+      />
+      <SettingsMenuItem
+        isActive={activeTabType === 'contracts'}
+        title={routes.CONTRACTS.label}
+        url={routes.CONTRACTS.path}
+      />
+      <SettingsMenuItem
+        isActive={activeTabType === 'wallets'}
+        title={routes.WALLETS.label}
+        url={routes.WALLETS.path}
+      />
+    </ul>
+  </div>
+)

--- a/apps/dapp-console/app/settings/contracts/page.tsx
+++ b/apps/dapp-console/app/settings/contracts/page.tsx
@@ -1,0 +1,3 @@
+export default function Contracts() {
+  return <div>Contracts</div>
+}

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { redirect, usePathname } from 'next/navigation'
+import { useEffect, useMemo } from 'react'
+
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+
+import { SettingsMenu } from '@/app/settings/components/SettingsMenu'
+import {
+  SettingsCard,
+  SettingsCardDescription,
+  SettingsCardTitle,
+} from '@/app/settings/components/SettingsCard'
+import { SettingsTabType, SettingsTab } from '@/app/settings/types'
+
+const tabs: Record<SettingsTabType, SettingsTab> = {
+  account: {
+    title: <SettingsCardTitle>Account</SettingsCardTitle>,
+    type: 'account',
+  },
+  contracts: {
+    title: <SettingsCardTitle>Contracts</SettingsCardTitle>,
+    type: 'contracts',
+    description: (
+      <SettingsCardDescription>
+        Add your dapp contracts here. In the future, we’ll scan them for
+        insights. For now, we’ll check if they’re eligible for the{' '}
+        <Text as="span" className="font-semibold">
+          Deployment Rebate.
+        </Text>
+      </SettingsCardDescription>
+    ),
+  },
+  wallets: {
+    title: <SettingsCardTitle>Wallets</SettingsCardTitle>,
+    type: 'wallets',
+    description: (
+      <SettingsCardDescription>
+        Link any wallets you want associated with your account. Superchain
+        Developer will remember your addresses and use them to verify your
+        onchain identity.
+      </SettingsCardDescription>
+    ),
+  },
+}
+
+function getActiveTab(pathname: string): SettingsTab {
+  const [route, _queryParams] = pathname.split('?')
+  const [_, _settingsPrefix, activeRoute] = route.split('/')
+  return tabs[activeRoute as SettingsTabType] as SettingsTab
+}
+
+export default function SettingsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  const shouldShowSettings = process.env.NEXT_PUBLIC_ENABLE_SETTINGS === 'true'
+  const pathname = usePathname()
+  const tab = useMemo(() => getActiveTab(pathname), [pathname])
+
+  useEffect(() => {
+    if (!shouldShowSettings) {
+      redirect('/')
+    }
+  }, [shouldShowSettings])
+
+  return shouldShowSettings ? (
+    <main className="flex justify-center bg-secondary min-h-screen">
+      <div className="flex flex-row w-full max-w-7xl mt-36 mb-16">
+        <SettingsMenu
+          activeTabType={tab.type}
+          className="hidden w-[246px] pl-10 md:block xl:pl-0"
+        />
+
+        <SettingsCard className="w-full mx-8 z-10" tab={tab}>
+          {children}
+        </SettingsCard>
+      </div>
+    </main>
+  ) : null
+}

--- a/apps/dapp-console/app/settings/types.tsx
+++ b/apps/dapp-console/app/settings/types.tsx
@@ -1,0 +1,7 @@
+export type SettingsTabType = 'account' | 'contracts' | 'wallets'
+
+export type SettingsTab = {
+  type: SettingsTabType
+  title: React.ReactNode
+  description?: React.ReactNode
+}

--- a/apps/dapp-console/app/settings/wallets/page.tsx
+++ b/apps/dapp-console/app/settings/wallets/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { WalletWithMetadata, usePrivy } from '@privy-io/react-auth'
+import { RiAddLine, RiCloseLine } from '@remixicon/react'
+
+import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
+import { Input } from '@eth-optimism/ui-components/src/components/ui/input'
+
+type LinkedWalletProps = {
+  wallet: WalletWithMetadata
+  onUnlink: (wallet: WalletWithMetadata) => void
+}
+
+const LinkedWallet = ({ wallet, onUnlink }: LinkedWalletProps) => (
+  <div className="flex flex-row gap-2">
+    <Input value={wallet.address} disabled />
+    <Button variant="secondary" size="icon" onClick={() => onUnlink(wallet)}>
+      <RiCloseLine />
+    </Button>
+  </div>
+)
+
+export default function Wallets() {
+  const { ready, linkWallet, unlinkWallet, user } = usePrivy()
+
+  if (!ready) {
+    // TODO: Add skeleton
+    return <div>loading</div>
+  }
+
+  const linkedWallets = user?.linkedAccounts.filter(
+    (account) => account.type == 'wallet',
+  ) as WalletWithMetadata[]
+
+  return (
+    <div className="flex flex-col">
+      {linkedWallets.map((wallet) => (
+        <LinkedWallet
+          key={wallet.address}
+          wallet={wallet}
+          onUnlink={(wallet) => unlinkWallet(wallet.address)}
+        />
+      ))}
+      <Button
+        onClick={linkWallet}
+        className="mt-8 gap-2 w-[88px]"
+        variant="secondary"
+      >
+        <RiAddLine /> Add
+      </Button>
+    </div>
+  )
+}

--- a/packages/ui-components/src/components/ui/text.tsx
+++ b/packages/ui-components/src/components/ui/text.tsx
@@ -1,9 +1,6 @@
-import type { ReactNode } from 'react'
-import React from 'react'
-
 type TextProps<T extends React.ElementType> = {
   as?: T
-  children: ReactNode
+  children: React.ReactNode
   className?: string
 }
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds env var to decide if we should display settings page or not `NEXT_PUBLIC_ENABLE_SETTINGS`. Next PR will add growthbook and we can migrate the setting over on that PR
* Adds directory structure for settings page to get next routing working
* Adds redirect to `/` on logo click
* Fixes text ui component importing `ReactNode`

I'm not trying to match the mocks on this PR, just getting the pages all laid out and testing out Privy

**Contracts**
Route: `/settings/contracts`
<img width="1728" alt="Screenshot 2024-03-05 at 10 06 10 AM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/6522f77f-c0db-45de-b3aa-11e002d468d4">

**Account**
Route: `/settings/account`
<img width="1728" alt="Screenshot 2024-03-05 at 10 06 04 AM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/8032224e-b2ac-468e-af28-d968116ae449">

**Wallets**
Route: `/settings/wallets`
<img width="1728" alt="Screenshot 2024-03-05 at 10 05 57 AM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/328a629f-61d0-4d46-bb8d-b6c36e7fe74e">
