### PR TITLE
Add admin check for accessing playground and admin endpoints to trpc-api generator

### DIFF
--- a/packages/api-plugin/src/generators/trpc-api-generator/files/example.env
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/example.env
@@ -12,3 +12,9 @@ CORS_ALLOWLIST_REG_EXP=
 
 # 32 character secret for encrypting iron session
 IRON_SESSION_SECRET=
+
+# bcrypt hash of the salted password for the admin account
+ADMIN_API_PASSWORD=
+
+# Salt used for hashing the admin password
+ADMIN_API_SALT=

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/package.json
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/package.json
@@ -19,6 +19,7 @@
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
     "@types/body-parser": "^1.19.5",
     "@types/cors": "^2.8.5",
     "@types/express": "^4.17.21",
@@ -36,6 +37,7 @@
   },
   "dependencies": {
     "@trpc/server": "^10.45.1",
+    "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/api/AdminApi.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/api/AdminApi.ts
@@ -1,0 +1,131 @@
+import * as trpcExpress from '@trpc/server/adapters/express'
+import bcrypt from 'bcrypt'
+import type { NextFunction, Request, Response, Router } from 'express'
+import { getIronSession } from 'iron-session'
+import * as trpcPlayground from 'trpc-playground/handlers/express'
+
+import { ensureAdmin } from '@/auth'
+
+import type { SessionData } from '../constants'
+import { envVars, sessionOptions } from '../constants'
+import { Route } from '../routes'
+import type { Trpc } from '../Trpc'
+
+const loginFormCss = [
+  'display:flex',
+  'align-items:center',
+  'justify-content:space-between',
+  'flex-direction:column',
+  'height: 60px',
+]
+
+const loginForm = `
+    <form action="/api/admin/login?{queryParams}" method="post" style="${loginFormCss.join(
+      ';',
+    )}">
+        <div>
+            <label for="password">Admin Password:</label>
+            <input type="password" id="password" name="password">
+        </div>
+        <div>
+            <button type="submit">Login</button>
+        </div>
+    </form>
+`
+
+export type AdminHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => void
+
+export class AdminApi extends Route {
+  public readonly name = 'AdminAPI'
+
+  public readonly handler = this.trpc.router({})
+
+  constructor(
+    trpc: Trpc,
+    protected readonly routes: {},
+  ) {
+    super(trpc)
+  }
+
+  public async registerRoutes(router: Router) {
+    // login routes
+    router.get('/admin/login', this.getLogin())
+    router.post('/admin/login', this.postLogin())
+
+    // trpc endpoints
+    const trpcHandler = trpcExpress.createExpressMiddleware({
+      router: this.handler,
+      createContext: this.trpc.createContext,
+    })
+    router.use('/admin/trpc', ensureAdmin(), trpcHandler)
+
+    // trpc playground
+    const playgroundHandler = await trpcPlayground.expressHandler({
+      trpcApiEndpoint: `/api/admin/trpc`,
+      playgroundEndpoint: `/api/admin/playground`,
+      router: this.handler,
+      request: {
+        superjson: true,
+      },
+    })
+    router.use('/admin/playground', ensureAdmin(), playgroundHandler)
+  }
+
+  private getLogin(): AdminHandler {
+    return (req: Request, res: Response) => {
+      res.send(
+        loginForm.replace('{queryParams}', this.getRequestQueryParams(req)),
+      )
+    }
+  }
+
+  private postLogin(): AdminHandler {
+    return async (req: Request, res: Response) => {
+      const { password } = req.body
+      const session = await getIronSession<SessionData>(
+        req,
+        res,
+        sessionOptions,
+      )
+
+      if (!password) {
+        res.status(401).send('Login Failed!')
+      }
+
+      const hashedPassword = await this.hashPassword(password)
+      if (hashedPassword === envVars.ADMIN_API_PASSWORD) {
+        session.admin = {
+          isActive: true,
+          createdAt: new Date().toUTCString(),
+        }
+        await session.save()
+
+        const searchParams = new URLSearchParams(
+          this.getRequestQueryParams(req),
+        )
+        const redirectURL = searchParams.get('redirect_url')
+
+        if (redirectURL) {
+          res.redirect(redirectURL)
+          return
+        }
+
+        res.status(200).send('Login Successful!')
+      } else {
+        res.status(401).send('Login Failed!')
+      }
+    }
+  }
+
+  private getRequestQueryParams(req: Request): string {
+    return req.originalUrl.split('?').pop() ?? ''
+  }
+
+  private async hashPassword(password: string) {
+    return bcrypt.hash(password, envVars.ADMIN_API_SALT!)
+  }
+}

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/auth/admin.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/auth/admin.ts
@@ -1,0 +1,19 @@
+import type { NextFunction, Request, Response } from 'express'
+import { getIronSession } from 'iron-session'
+
+import type { SessionData } from '../constants'
+import { envVars, sessionOptions } from '../constants'
+
+export const ensureAdmin = () => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const session = await getIronSession<SessionData>(req, res, sessionOptions)
+
+    if (envVars.DEPLOYMENT_ENV === 'development') {
+      next()
+    } else if (session.admin?.isActive) {
+      next()
+    } else {
+      res.redirect(`/api/admin/login?redirect_url=${req.originalUrl}`)
+    }
+  }
+}

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/auth/index.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './admin'

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/envVars.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/envVars.ts
@@ -18,6 +18,8 @@ const envVarSchema = z.object({
     .min(32)
     .max(32)
     .describe('32 character iron session secret'),
+  ADMIN_API_PASSWORD: z.string().optional(),
+  ADMIN_API_SALT: z.string().optional(),
 })
 
 const isTest = process.env.NODE_ENV === 'test'
@@ -62,5 +64,7 @@ export const envVars = envVarSchema.parse(
           'CORS_ALLOWLIST_REG_EXP',
         ).map((regExp) => new RegExp(regExp)),
         IRON_SESSION_SECRET: process.env.IRON_SESSION_SECRET,
+        ADMIN_API_PASSWORD: process.env.ADMIN_API_PASSWORD,
+        ADMIN_API_SALT: process.env.ADMIN_API_SALT,
       },
 )

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/session.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/session.ts
@@ -13,6 +13,11 @@ export const sessionOptions: SessionOptions = {
   },
 }
 
-export type SessionData = {}
+export type SessionData = {
+  admin?: {
+    isActive: boolean
+    createdAt: string
+  }
+}
 
 export type Session = IronSession<SessionData>


### PR DESCRIPTION
This ensures that only admins can access the trpc playground