### PR TITLE
[dapp console] Adds Feature Flag Support

### DIFF
--- a/apps/dapp-console/.eslintrc.cjs
+++ b/apps/dapp-console/.eslintrc.cjs
@@ -25,5 +25,6 @@ module.exports = {
       { varsIgnorePattern: '_', argsIgnorePattern: '_' },
     ],
     'react-refresh/only-export-components': ['off'],
+    'no-extra-semi': 'off'
   },
 }

--- a/apps/dapp-console/app/components/Header/SignInButton.tsx
+++ b/apps/dapp-console/app/components/Header/SignInButton.tsx
@@ -16,6 +16,7 @@ import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { RiArrowDownSLine, RiUser3Fill } from '@remixicon/react'
 import { trackSignInClick } from '@/app/event-tracking/mixpanel'
 import { routes } from '@/app/constants'
+import { useFeature } from '@/app/hooks/useFeatureFlag'
 
 const SignInButton = () => {
   const { login, logout, authenticated } = usePrivy()
@@ -35,11 +36,11 @@ type AccountDropdownProps = {
 }
 
 const AccountDropdown = ({ logout }: AccountDropdownProps) => {
+  const shouldShowSettings = useFeature('enable_console_settings')
+
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const dropdownItemClasses =
     'flex items-center gap-2 cursor-pointer h-12 px-4 rounded-none text-base text-secondary-foreground'
-
-  const shouldShowSettings = process.env.NEXT_PUBLIC_ENABLE_SETTINGS === 'true'
 
   return (
     <DropdownMenu

--- a/apps/dapp-console/app/constants/envVars.ts
+++ b/apps/dapp-console/app/constants/envVars.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+const schema = z.object({
+  GROWTHBOOK_ENDPOINT: z
+    .string()
+    .url()
+    .default('https://cdn.growthbook.io/api/features/')
+    .describe('Growthbook endpoint'),
+  GROWTHBOOK_ENCRYPTION_KEY: z
+    .string()
+    .optional()
+    .describe('Key for decrypting growthbook response'),
+})
+
+export const ENV_VARS = schema.parse({
+  GROWTHBOOK_ENDPOINT: process.env.NEXT_PUBLIC_GROWTHBOOK_ENDPOINT,
+  GROWTHBOOK_ENCRYPTION_KEY: process.env.NEXT_PUBLIC_GROWTHBOOK_ENCRYPTION_KEY,
+})

--- a/apps/dapp-console/app/helpers/featureFlags.ts
+++ b/apps/dapp-console/app/helpers/featureFlags.ts
@@ -1,0 +1,63 @@
+type FetcherOption = {
+  decrypt?: string
+}
+
+export type FeatureFlagMap = Record<string, unknown>
+
+type EncryptedFeatureFlagResponse = {
+  encryptedFeatures: string
+}
+
+type FeatureFlagResponse = {
+  features: FeatureFlagMap
+}
+
+export async function decrypt(encryptionKey: string, encryptedText: string) {
+  const base64ToBuf = (b: string) =>
+    Uint8Array.from(atob(b), (c) => c.charCodeAt(0))
+  const key = await window.crypto.subtle.importKey(
+    'raw',
+    base64ToBuf(encryptionKey),
+    { name: 'AES-CBC', length: 128 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+  const [iv, cipherText] = encryptedText.split('.')
+  const plainTextBuffer = await window.crypto.subtle.decrypt(
+    { name: 'AES-CBC', iv: base64ToBuf(iv) },
+    key,
+    base64ToBuf(cipherText),
+  )
+  return new TextDecoder().decode(plainTextBuffer)
+}
+
+export async function featureFlagsFetcherAndParser(
+  url: string,
+  options: FetcherOption,
+): Promise<FeatureFlagMap | null> {
+  let features: FeatureFlagMap | null = null
+
+  try {
+    const res = await fetch(url)
+    const data = await res.json()
+
+    if (options.decrypt) {
+      const encryptedData = data as EncryptedFeatureFlagResponse
+
+      const decryptedFeatureStr = await decrypt(
+        options.decrypt,
+        encryptedData.encryptedFeatures,
+      )
+
+      features = JSON.parse(decryptedFeatureStr)
+    } else {
+      const unencryptedData = data as FeatureFlagResponse
+      features = unencryptedData.features
+    }
+  } catch (e) {
+    // TODO: capture this once we add sentry
+    console.error(e)
+  }
+
+  return features
+}

--- a/apps/dapp-console/app/hooks/useFeatureFlag.ts
+++ b/apps/dapp-console/app/hooks/useFeatureFlag.ts
@@ -1,0 +1,33 @@
+import type { JSONValue } from '@growthbook/growthbook-react'
+import { useFeature as useGrowthbookFeature } from '@growthbook/growthbook-react'
+import { useEffect } from 'react'
+import { z } from 'zod'
+
+const flag = {
+  bool: z.boolean().catch(false),
+}
+
+const flags = {
+  enable_console_settings: flag.bool,
+}
+
+export type FeatureFlag = keyof typeof flags
+
+export const useFeature = <
+  T extends FeatureFlag,
+  V extends JSONValue = z.infer<(typeof flags)[T]>,
+>(
+  feature: T,
+) => {
+  const { value } = useGrowthbookFeature<V>(feature)
+  const parsedValue = flags[feature].parse(value) as V
+  const isValueValid = [null, parsedValue].includes(value)
+
+  useEffect(() => {
+    if (!isValueValid) {
+      // TODO: capture this and send to sentry
+    }
+  }, [isValueValid])
+
+  return parsedValue
+}

--- a/apps/dapp-console/app/layout.tsx
+++ b/apps/dapp-console/app/layout.tsx
@@ -4,6 +4,7 @@ import '@/app/globals.css'
 import { PrivyProviderWrapper } from '@/app/providers/PrivyProviderWrapper'
 import { Header } from '@/app/components/Header'
 import { ThemeProvider } from '@/app/providers/ThemeProvider'
+import { FeatureFlagProvider } from '@/app/providers/FeatureFlagProvider'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -20,12 +21,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="system">
-          <PrivyProviderWrapper>
-            <Header />
-            {children}
-          </PrivyProviderWrapper>
-        </ThemeProvider>
+        <FeatureFlagProvider>
+          <ThemeProvider attribute="class" defaultTheme="system">
+            <PrivyProviderWrapper>
+              <Header />
+              {children}
+            </PrivyProviderWrapper>
+          </ThemeProvider>
+        </FeatureFlagProvider>
       </body>
     </html>
   )

--- a/apps/dapp-console/app/providers/FeatureFlagProvider.tsx
+++ b/apps/dapp-console/app/providers/FeatureFlagProvider.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+
+import { featureFlagsFetcherAndParser } from '@/app/helpers/featureFlags'
+import { ENV_VARS } from '@/app/constants/envVars'
+import { useEffect, useMemo } from 'react'
+
+export const FeatureFlagProvider = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) => {
+  const growthbook = useMemo(() => new GrowthBook(), [])
+
+  useEffect(() => {
+    if (!ENV_VARS.GROWTHBOOK_ENDPOINT) {
+      // TODO: send error to sentry when we add support
+      return
+    }
+
+    ;(async () => {
+      const features = await featureFlagsFetcherAndParser(
+        ENV_VARS.GROWTHBOOK_ENDPOINT,
+        {
+          decrypt: ENV_VARS.GROWTHBOOK_ENCRYPTION_KEY,
+        },
+      )
+
+      if (features) {
+        console.log(features)
+        // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+        growthbook.setFeatures(features as Record<string, any>)
+      }
+    })()
+  }, [growthbook])
+
+  return (
+    <GrowthBookProvider growthbook={growthbook}>{children}</GrowthBookProvider>
+  )
+}

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -12,6 +12,7 @@ import {
   SettingsCardTitle,
 } from '@/app/settings/components/SettingsCard'
 import { SettingsTabType, SettingsTab } from '@/app/settings/types'
+import { useFeature } from '@/app/hooks/useFeatureFlag'
 
 const tabs: Record<SettingsTabType, SettingsTab> = {
   account: {
@@ -55,7 +56,7 @@ export default function SettingsLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const shouldShowSettings = process.env.NEXT_PUBLIC_ENABLE_SETTINGS === 'true'
+  const shouldShowSettings = useFeature('enable_console_settings')
   const pathname = usePathname()
   const tab = useMemo(() => getActiveTab(pathname), [pathname])
 

--- a/apps/dapp-console/package.json
+++ b/apps/dapp-console/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --no-lint",
     "start": "next start",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn",

--- a/apps/dapp-console/package.json
+++ b/apps/dapp-console/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@eth-optimism/ui-components": "*",
+    "@growthbook/growthbook-react": "^0.24.0",
     "@privy-io/react-auth": "^1.54.3",
     "@remixicon/react": "^4.1.1",
     "class-variance-authority": "^0.7.0",
@@ -22,7 +23,8 @@
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
-    "tailwind-merge": "^2.1.0"
+    "tailwind-merge": "^2.1.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/mixpanel-browser": "^2.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,12 @@ importers:
       '@eth-optimism/ui-components':
         specifier: '*'
         version: link:../../packages/ui-components
+      '@growthbook/growthbook-react':
+        specifier: ^0.24.0
+        version: 0.24.0(react@18.2.0)
       '@privy-io/react-auth':
         specifier: ^1.54.3
-        version: 1.54.3(@babel/core@7.24.0)(@types/react@18.2.47)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(typescript@5.3.2)
+        version: 1.54.3(@babel/core@7.24.0)(@types/react@18.2.47)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(typescript@5.3.2)(zod@3.22.4)
       '@remixicon/react':
         specifier: ^4.1.1
         version: 4.1.1(react@18.2.0)
@@ -168,6 +171,9 @@ importers:
       tailwind-merge:
         specifier: ^2.1.0
         version: 2.1.0
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@types/mixpanel-browser':
         specifier: ^2.49.0
@@ -304,7 +310,7 @@ importers:
         version: 0.2.4(@types/node@20.10.0)(typescript@5.3.2)(viem@1.19.9)
       viem:
         specifier: ^1.19.9
-        version: 1.19.9(typescript@5.3.2)
+        version: 1.19.9(typescript@5.3.2)(zod@3.22.4)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -503,7 +509,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.1
-        version: 8.0.1(postcss@8.4.33)(typescript@5.3.2)
+        version: 8.0.1(ts-node@10.9.1)(typescript@5.3.2)
       typescript:
         specifier: ^5.2.2
         version: 5.3.2
@@ -540,7 +546,7 @@ importers:
     devDependencies:
       '@eth-optimism/superchain-registry':
         specifier: github:ethereum-optimism/superchain-registry
-        version: github.com/ethereum-optimism/superchain-registry/46f8c2f74debd4a40facf5686b2238cf7093023c
+        version: github.com/ethereum-optimism/superchain-registry/b74ab7c9f693ce375917bbc67d1cfb5d680ede42
       '@tanstack/react-query':
         specifier: ^5.10.0
         version: 5.10.0(react@18.2.0)
@@ -4488,7 +4494,7 @@ packages:
       '@wagmi/core': 2.0.2(@types/react@18.2.37)(react@18.2.0)(typescript@5.3.2)(viem@2.0.3)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      viem: 1.19.9(typescript@5.3.2)
+      viem: 1.19.9(typescript@5.3.2)(zod@3.22.4)
       wagmi: 2.0.3(@tanstack/react-query@5.10.0)(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.7)(react@18.2.0)(typescript@5.3.2)(viem@2.0.3)
     transitivePeerDependencies:
       - bufferutil
@@ -4514,7 +4520,7 @@ packages:
       change-case: 4.1.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      viem: 1.19.9(typescript@5.3.2)
+      viem: 1.19.9(typescript@5.3.2)(zod@3.22.4)
       wagmi: 2.0.3(@tanstack/react-query@5.10.0)(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.7)(react@18.2.0)(typescript@5.3.2)(viem@2.0.3)
     transitivePeerDependencies:
       - bufferutil
@@ -4895,6 +4901,23 @@ packages:
 
   /@floating-ui/utils@0.1.6:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+    dev: false
+
+  /@growthbook/growthbook-react@0.24.0(react@18.2.0):
+    resolution: {integrity: sha512-7Nz8FIc5PPlCXbRzv9GyY/86hmDytJ84ZCtLBuOt/Bna/MsuJlh/TXUg6eF4OFeRN039FhgyapBJ4hC4Mqt+Qw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
+    dependencies:
+      '@growthbook/growthbook': 0.34.0
+      react: 18.2.0
+    dev: false
+
+  /@growthbook/growthbook@0.34.0:
+    resolution: {integrity: sha512-3K5JL8QftX7y77EpieYg9anXVYb6+ZafTsrNCWp0HOdmtf4lxHOzCUYwuYDaS3bvmaeIUWJ5hYcOTc6WhNbfJw==}
+    engines: {node: '>=10'}
+    dependencies:
+      dom-mutator: 0.6.0
     dev: false
 
   /@hapi/hoek@9.3.0:
@@ -6407,7 +6430,7 @@ packages:
       retry: 0.13.1
       stacktrace-parser: 0.1.10
       typescript: 5.3.2
-      viem: 1.19.9(typescript@5.3.2)
+      viem: 1.19.9(typescript@5.3.2)(zod@3.22.4)
       vite: 5.0.12(@types/node@20.10.0)
       vite-node: 1.1.3(@types/node@20.10.0)
       vite-tsconfig-paths: 4.3.1(typescript@5.3.2)(vite@5.0.12)
@@ -6428,7 +6451,7 @@ packages:
       - zod
     dev: false
 
-  /@privy-io/react-auth@1.54.3(@babel/core@7.24.0)(@types/react@18.2.47)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(typescript@5.3.2):
+  /@privy-io/react-auth@1.54.3(@babel/core@7.24.0)(@types/react@18.2.47)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(typescript@5.3.2)(zod@3.22.4):
     resolution: {integrity: sha512-Wxp+RRvGaG6U2FSPTyxji95l8DU+7FY38JCLGC6BSzmnD0xwDR2QFxpQdt9pftYyhd/UcCY89MU9DiGWPc+mUQ==}
     peerDependencies:
       react: ^18
@@ -6461,7 +6484,7 @@ packages:
       libphonenumber-js: 1.10.54
       lokijs: 1.5.12
       md5: 2.3.0
-      mipd: 0.0.5(typescript@5.3.2)
+      mipd: 0.0.5(typescript@5.3.2)(zod@3.22.4)
       ofetch: 1.3.3
       pino-pretty: 10.3.1
       qrcode: 1.5.3
@@ -8220,7 +8243,7 @@ packages:
     resolution: {integrity: sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.13.2
-      viem: 1.19.9(typescript@5.3.2)
+      viem: 1.19.9(typescript@5.3.2)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -9624,7 +9647,7 @@ packages:
         optional: true
     dependencies:
       eventemitter3: 5.0.1
-      mipd: 0.0.5(typescript@5.3.2)
+      mipd: 0.0.5(typescript@5.3.2)(zod@3.22.4)
       typescript: 5.3.2
       viem: 2.0.3(typescript@5.3.2)
       zustand: 4.4.1(@types/react@18.2.37)(react@18.2.0)
@@ -9649,7 +9672,7 @@ packages:
         optional: true
     dependencies:
       eventemitter3: 5.0.1
-      mipd: 0.0.5(typescript@5.3.2)
+      mipd: 0.0.5(typescript@5.3.2)(zod@3.22.4)
       typescript: 5.3.2
       viem: 2.7.12(typescript@5.3.2)(zod@3.22.4)
       zustand: 4.4.1(@types/react@18.2.63)(immer@10.0.3)(react@18.2.0)
@@ -10198,7 +10221,7 @@ packages:
       zod: 3.22.4
     dev: false
 
-  /abitype@0.9.8(typescript@5.3.2):
+  /abitype@0.9.8(typescript@5.3.2)(zod@3.22.4):
     resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -10210,6 +10233,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.3.2
+      zod: 3.22.4
 
   /abitype@1.0.0(typescript@5.3.2)(zod@3.22.4):
     resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
@@ -12239,6 +12263,11 @@ packages:
 
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  /dom-mutator@0.6.0:
+    resolution: {integrity: sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==}
+    engines: {node: '>=10'}
+    dev: false
 
   /dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -16101,7 +16130,7 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /mipd@0.0.5(typescript@5.3.2):
+  /mipd@0.0.5(typescript@5.3.2)(zod@3.22.4):
     resolution: {integrity: sha512-gbKA784D2WKb5H/GtqEv+Ofd1S9Zj+Z/PGDIl1u1QAbswkxD28BQ5bSXQxkeBzPBABg1iDSbiwGG1XqlOxRspA==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -16110,7 +16139,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.3.2
-      viem: 1.19.9(typescript@5.3.2)
+      viem: 1.19.9(typescript@5.3.2)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -20259,7 +20288,7 @@ packages:
       - '@types/react-dom'
     dev: false
 
-  /viem@1.19.9(typescript@5.3.2):
+  /viem@1.19.9(typescript@5.3.2)(zod@3.22.4):
     resolution: {integrity: sha512-Sf9U2x4jU0S/FALqYypcspWOGene0NZyD470oUripNhE0Ta6uOE/OgE4toTDVfRxov8qw0JFinr/wPGxYE3+HQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -20272,7 +20301,7 @@ packages:
       '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
-      abitype: 0.9.8(typescript@5.3.2)
+      abitype: 0.9.8(typescript@5.3.2)(zod@3.22.4)
       isows: 1.0.3(ws@8.13.0)
       typescript: 5.3.2
       ws: 8.13.0
@@ -21334,7 +21363,6 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: false
 
   /zustand@4.4.1(@types/react@18.2.37)(react@18.2.0):
     resolution: {integrity: sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==}
@@ -21397,8 +21425,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  github.com/ethereum-optimism/superchain-registry/46f8c2f74debd4a40facf5686b2238cf7093023c:
-    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/46f8c2f74debd4a40facf5686b2238cf7093023c}
+  github.com/ethereum-optimism/superchain-registry/b74ab7c9f693ce375917bbc67d1cfb5d680ede42:
+    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/b74ab7c9f693ce375917bbc67d1cfb5d680ede42}
     name: '@eth-optimism/superchain-registry'
     version: 0.0.1-alpha.1
     dev: true


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds feature flag support to dapp console. These PR just wraps growthbook and ports some of our gateway code into the dapp console.

There are two new env vars
* `NEXT_PUBLIC_GROWTHBOOK_ENDPOINT`
* `NEXT_PUBLIC_GROWTHBOOK_ENCRYPTION_KEY` (only needed for the prod endpoint)

when it comes to configuring what endpoint we hit i'm going to configure it like so in netlify

**Production**: prod endpoint, encrypted (honestly not sure why it even needs to be encrypted but thats how the endpoint is setup)
**Deploy Previews**: staging endpoint, not encrypted
**Branch Deploys**: staging endpoint, not encrypted

if anyone wants to use this locally you can grab the values in netlify 