### PR TITLE
ci:(monorepo): add CircleCI config for building and publishing dapp-console api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,3 +176,29 @@ workflows:
             - oplabs-gcr-internal
           requires:
             - paymaster-proxy-docker-build
+
+  build-and-publish-dapp-console-api:
+    jobs:
+      - docker-build:
+          filters:
+            branches:
+              only:
+                - main
+          name: dapp-console-api-docker-build
+          docker_file: ./Dockerfile
+          docker_name: dapp-console-api
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          docker_context: .
+          docker_target: dapp-console-api
+      - docker-publish:
+          filters:
+            branches:
+              only:
+                - main
+          name: dapp-console-api-docker-publish
+          docker_name: dapp-console-api
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          context:
+            - oplabs-gcr-internal
+          requires:
+            - dapp-console-api-docker-build


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecopod/issues/870

- created a `docker-build` job that is similar to our existing one but also takes a docker_target for multi-stage builds
- created a `docker-publish` job that pushes to our gcr repo after authenticating - same as existing config on monorepo
- both of these jobs only run on merges to main