### PR TITLE
Update circle executor image to a supported ubuntu version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
         type: string
         default: 'oplabs-tools-artifacts/internal-images'
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2024.01.1
     steps:
       - attach_workspace:
           at: /tmp/docker_images


### PR DESCRIPTION
The linux image we currently use in our circle config will be deprecated in 09/2024: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

Workflow runs successfully with new image: https://app.circleci.com/pipelines/github/ethereum-optimism/ecosystem?branch=harry%2Fupdate_circle_image