### PR TITLE
docs(paymaster): add paymaster API docs and example code

### DIFF
--- a/docs/superchain-paymaster/README.md
+++ b/docs/superchain-paymaster/README.md
@@ -6,13 +6,13 @@ The Superchain paymaster is a ERC-4337 [verifying paymaster](https://github.com/
 
 ## Endpoints
 
-| Network      | Chain ID  | Endpoint                                       |
-| ------------ | --------- | ---------------------------------------------- |
-| Sepolia      | 11155111  | https://paymaster.optimism.io/v1/11155111/rpc  |
-| OP Sepolia   | 11155420  | https://paymaster.optimism.io/v1/11155420/rpc  |
-| Base Sepolia | 84532     | https://paymaster.optimism.io/v1/84532/rpc     |
-| Zora Sepolia | 999999999 | https://paymaster.optimism.io/v1/999999999/rpc |
-| Mode Sepolia | 919       | coming soon                                    |
+| Network      | Chain ID  | Endpoint                                      |
+| ------------ | --------- | --------------------------------------------- |
+| Sepolia      | 11155111  | https://paymaster.optimism.io/v1/11155111/rpc |
+| OP Sepolia   | 11155420  | https://paymaster.optimism.io/v1/11155420/rpc |
+| Base Sepolia | 84532     | coming soon                                   |
+| Zora Sepolia | 999999999 | coming soon                                   |
+| Mode Sepolia | 919       | coming soon                                   |
 
 Mainnet endpoints coming soon!
 

--- a/docs/superchain-paymaster/README.md
+++ b/docs/superchain-paymaster/README.md
@@ -52,6 +52,8 @@ This endpoint returns gas estimation, fee estimation, and paymaster signature fo
 
 **Response**
 
+Include the returned fields in your user operation to send to a bundler.
+
 ```typescript
 {
 	jsonrpc: "2.0",
@@ -155,4 +157,15 @@ Only `sender`, `nonce`, `initCode`, `callData`, `signature` are required in the 
 
 - Mainnet support
 - Entrypoint v0.7.0 support
-- ERC-20 paymasters: pay for gas with ERC20 tokens
+
+## Contact us
+
+If you're
+
+- using smart accounts in your dapp
+- bulding smart accounts
+- building account abstraction tooling / infrastructure
+- want to chat about your project
+- have questions
+
+reach out to us [here](https://share.hsforms.com/1fvxLHGW9TQuxdGCmgSlRRgqoshb)!

--- a/docs/superchain-paymaster/README.md
+++ b/docs/superchain-paymaster/README.md
@@ -1,0 +1,158 @@
+# 💳 Superchain paymaster
+
+## Overview
+
+The Superchain paymaster is a ERC-4337 [verifying paymaster](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/VerifyingPaymaster.sol) that sponsors transactions for smart accounts on the Superchain.
+
+## Endpoints
+
+| Network      | Chain ID  | Endpoint                                       |
+| ------------ | --------- | ---------------------------------------------- |
+| Sepolia      | 11155111  | https://paymaster.optimism.io/v1/11155111/rpc  |
+| OP Sepolia   | 11155420  | https://paymaster.optimism.io/v1/11155420/rpc  |
+| Base Sepolia | 84532     | https://paymaster.optimism.io/v1/84532/rpc     |
+| Zora Sepolia | 999999999 | https://paymaster.optimism.io/v1/999999999/rpc |
+| Mode Sepolia | 919       | coming soon                                    |
+
+Mainnet endpoints coming soon!
+
+## Supported methods
+
+### pm_sponsorUserOperation
+
+This endpoint returns gas estimation, fee estimation, and paymaster signature for a [verifying paymaster](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/VerifyingPaymaster.sol). Gas estimation and fee estimation params are included to reduce number of RPC calls necessary when sending a user operation.
+
+**Request**
+
+```typescript
+{
+	jsonrpc: "2.0",
+	id: 1,
+	method: "pm_sponsorUserOperation",
+	params: [
+		{
+			sender, // (required) address in hex string
+			nonce, // (required) hex string
+			initCode, // (required) hex string, if account is already deployed, pass in "0x"
+			callData, // (required) hex string
+			paymasterAndData, // (optional) hex string, will be ignored
+			signature, // (required) hex string, can be a dummy signature that doesn't revert
+			maxFeePerGas, // (optional), will override fee estimations done by the paymaster
+			maxPriorityFeePerGas, // (optional) will override fee estimations done by the paymaster
+			callGasLimit,  // (optional) hex string, will be ignored
+			verificationGasLimit, // (optional) hex string, will be ignored
+			preVerificationGas, // (optional) hex string, will be ignored
+		},
+		"0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789", // entrypoint address (required)
+	],
+
+}
+
+```
+
+**Response**
+
+```typescript
+{
+	jsonrpc: "2.0",
+	id: 1,
+	result: {
+		paymasterAndData: "0x...", // paymaster signature
+		callGasLimit: "0x...",  // gas estimation
+		verificationGasLimit: "0x...", // gas estimation
+		preVerificationGas: "0x...", // gas estimation
+		maxFeePerGas: "0x...", // fee estimation
+		maxPriorityFeePerGas: "0x...", // fee estimation
+	},
+}
+```
+
+**Regarding user operation parameters**
+
+Only `sender`, `nonce`, `initCode`, `callData`, `signature` are required in the user operation object
+
+| parameter            | required/optional | notes                                                             |
+| -------------------- | ----------------- | ----------------------------------------------------------------- |
+| sender               | required          |                                                                   |
+| nonce                | required          |                                                                   |
+| initCode             | required          |                                                                   |
+| callData             | required          |                                                                   |
+| signature            | required          | a dummy signature that won't revert                               |
+| paymasterAndData     | optional          | will be ignored                                                   |
+| callGasLimit         | optional          | will override. use this to set higher fee parameters if necessary |
+| verificationGasLimit | optional          | will override. use this to set higher fee parameters if necessary |
+| preVerificationGas   | optional          | will be ignored                                                   |
+| maxFeePerGas         | optional          | will be ignored                                                   |
+| maxPriorityFeePerGas | optional          | will be ignored                                                   |
+
+- `paymasterAndData`, gas estimation, and fee estimation parameters are **optional**.
+- Fee parameters (`maxFeePerGas` , `maxPriorityFeePerGas`) as part of the user operation **will act as overrides**
+  - the same sent parameters will be returned (no additional fee estimation will occur)
+  - this allows you to set higher fee parameters if necessary.
+- Gas estimation parameters (`callGasLimit`, `verificationGasLimit`, `preVerificationGas`) **are ignored**
+  - new estimation values will be returned (gas estimation will always occur)
+  - we don't support overriding gas estimation parameters
+
+**Notes**
+
+- the returned `paymasterAndData` is signed over the **entire user operation** (including gas estimation and fee parameters), so make sure to use the values received from from the paymaster RPC **as is**.
+
+**Example**
+
+```json
+// Request
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "pm_sponsorUserOperation",
+    "params": [
+        {
+            "sender": "0x315b3be8741Cfb75279Fb75D20777B469A087467",
+            "nonce": "0x0",
+            "initCode": "0x5de4839a76cf55d0c90e2061ef4386d962E15ae3296601cd0000000000000000000000000da6a956b9488ed4dd761e59f52fdc6c8068e6b5000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000084d1f57894000000000000000000000000d9ab5096a832b9ce79914329daee236f8eea039000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000014F4f05B6ED874595c157249659B1cd79cd686c96e00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "callData": "0x51945447000000000000000000000000ab559628b94fd9748658c46e58a85efb52fdaca60000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024755edd17000000000000000000000000315b3be8741cfb75279fb75d20777b469a08746700000000000000000000000000000000000000000000000000000000",
+            "paymasterAndData": "0x",
+            "signature": "0x00000000fffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c",
+            "maxFeePerGas": "0xf436f",
+            "maxPriorityFeePerGas": "0xf4240",
+            "callGasLimit": "0x0",
+            "verificationGasLimit": "0x0",
+            "preVerificationGas": "0x0"
+        },
+        "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+    ]
+}
+
+
+// Response
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "paymasterAndData": "0x4f84a207a80c39e9e8bae717c1f25ba7ad1fb08f000000000000000065eced22000000000000000000000000000000000000000032647b900c688ed00e12205f99559b8f9e09bf2ef7cb2ec029f9f1d59620e0dc3267ec8fa981816f1206c35db6d8d32f078130b75c102af657d74f555a5efbec1c",
+        "callGasLimit": "0xf000",
+        "verificationGasLimit": "0x3c6e0",
+        "preVerificationGas": "0xd4ce07b",
+        "maxFeePerGas": "0xf436f",
+        "maxPriorityFeePerGas": "0xf4240"
+    }
+}
+```
+
+## Usage examples
+
+- [Using the Superchain paymaster with aa-sdk](./example-aa-sdk.md)
+- [Using the Superchain paymaster with permissionless](./example-permissionless.md)
+
+## Supported entrypoint versions
+
+| version | supported?     |
+| ------- | -------------- |
+| v0.6.0  | Supported ✅   |
+| v0.7.0  | Coming soon 🔜 |
+
+## Coming soon
+
+- Mainnet support
+- Entrypoint v0.7.0 support
+- ERC-20 paymasters: pay for gas with ERC20 tokens

--- a/docs/superchain-paymaster/example-aa-sdk.md
+++ b/docs/superchain-paymaster/example-aa-sdk.md
@@ -1,0 +1,124 @@
+# Using the Superchain paymaster with aa-sdk
+
+[aa-sdk](https://github.com/alchemyplatform/aa-sdk) is a popular ERC-4337 Typescript library built on top of [viem](https://viem.sh/), built by [Alchemy](https://www.alchemy.com/). In this example, we use [modular account](https://accountkit.alchemy.com/smart-accounts/modular-account/), a [ERC-6900](https://eips.ethereum.org/EIPS/eip-6900) smart account implementation that supports custom plugins to extend the functionality. Modular account is heavily optimized to minimize calldata usage, making it [one of the most competitive options](https://github.com/alchemyplatform/aa-benchmarks) on L2s in terms of end user cost.
+
+## What we're building
+
+- Using a modular account smart account, [mint an NFT](https://optimism-sepolia.blockscout.com/token/0xAB559628B94Fd9748658c46E58a85EfB52FdaCa6) on Optimism Sepolia using the Superchain paymaster.
+
+## Preparation
+
+You will need
+
+- RPC URL for the chain to use - a regular JSON-RPC provider
+- Bundler RPC URL - this should support bundler RPC methods
+- Paymaster RPC URL - choose the [Superchain paymaster RPC endpoint URL](./README.md) for the chain you are using
+
+## 1. Create a paymaster client
+
+```typescript
+import { UserOperationRequest } from '@alchemy/aa-core'
+import { Address, createClient, http } from 'viem'
+import { optimismSepolia } from 'viem/chains'
+
+// This one is for OP Sepolia, use a different RPC url for a different chain
+const PAYMASTER_RPC_URL = 'https://paymaster.optimism.io/v1/11155420/rpc'
+
+const superchainPaymasterClient = createClient({
+  chain: optimismSepolia,
+  transport: http(PAYMASTER_RPC_URL),
+}).extend((client) => ({
+  sponsorUserOperation: async (
+    request: UserOperationRequest,
+    entryPoint: Address,
+  ) =>
+    client.request({
+      // @ts-expect-error cast the client to include the pm_sponsorUserOperation method to avoid type errors
+      method: 'pm_sponsorUserOperation',
+      params: [request, entryPoint],
+    }),
+}))
+```
+
+## 2. Create a smart account
+
+```typescript
+import { createMultiOwnerModularAccount } from '@alchemy/aa-accounts'
+import { LocalAccountSigner } from '@alchemy/aa-core'
+import { http } from 'viem'
+import { generatePrivateKey } from 'viem/accounts'
+import { optimismSepolia } from 'viem/chains'
+
+const RPC_URL = 'https://sepolia.optimism.io/'
+
+const smartAccountSigner =
+  LocalAccountSigner.privateKeyToAccountSigner(generatePrivateKey())
+
+const modularAccount = await createMultiOwnerModularAccount({
+  signer: smartAccountSigner,
+  chain: optimismSepolia,
+  transport: http(RPC_URL),
+})
+```
+
+## 3. Create a smart account client
+
+We create a smart account client that connects to a bundler to be able to send and fetch user operations. We can override the gas estimation and fee estimation middleware here to save unnecessary RPC calls, since the paymaster RPC will return the estimates anyway.
+
+```typescript
+import {
+  UserOperationRequest,
+  createSmartAccountClient,
+  deepHexlify,
+  resolveProperties,
+} from '@alchemy/aa-core'
+import { http } from 'viem'
+import { optimismSepolia } from 'viem/chains'
+
+const BUNDLER_RPC_URL =
+  'https://opt-sepolia.g.alchemy.com/v2/get-one-from-dashboard'
+
+const smartAccountClient = createSmartAccountClient({
+  transport: http(BUNDLER_RPC_URL),
+  chain: optimismSepolia,
+  account: modularAccount,
+  gasEstimator: async (struct) => struct, // no-op since paymaster RPC will estimate gas
+  feeEstimator: async (struct) => struct, // no-op since paymaster RPC will estimate fees
+  paymasterAndData: {
+    paymasterAndData: async (struct, { account }) => {
+      const sponsorOperationResult =
+        await superchainPaymasterClient.sponsorUserOperation(
+          deepHexlify(await resolveProperties(struct)) as UserOperationRequest,
+          account.getEntryPoint().address,
+        )
+      return {
+        ...struct,
+        ...sponsorOperationResult,
+      }
+    },
+    dummyPaymasterAndData: () => '0x',
+  },
+})
+```
+
+## 4. Send mint NFT user operation
+
+We encode the call to the mint function on the NFT contract, and send the user operation to the bundler. the `sendUserOperation` will wait until the bundle is included, then return the transaction hash.
+
+```typescript
+import { encodeFunctionData, parseAbiItem } from 'viem'
+
+const mintFunctionCalldata = encodeFunctionData({
+  abi: [parseAbiItem('function mint() returns (uint256)')],
+  functionName: 'mint',
+})
+
+const transactionHash = await smartAccountClient.sendUserOperation({
+  uo: {
+    target: '0xAB559628B94Fd9748658c46E58a85EfB52FdaCa6',
+    data: mintFunctionCalldata,
+  },
+})
+```
+
+You can see a working example dapp [here](https://superchain-paymaster-nft-mint-example.pages.dev/), and the source code [here](/apps/paymaster-nft-mint/src/libraries/aa-sdk)

--- a/docs/superchain-paymaster/example-permissionless.md
+++ b/docs/superchain-paymaster/example-permissionless.md
@@ -1,0 +1,101 @@
+# Using the Superchain paymaster with permissionless.js
+
+[permissionless](https://github.com/pimlicolabs/permissionless.js) is a popular Typescript library built on top of [viem](https://viem.sh/), built by [Pimlico](https://docs.pimlico.io/). In this example we use [Kernel](https://github.com/zerodevapp/kernel) as the smart account implementation. Kernel is gas optimized, flexible, and is [one of the most widely used smart account implementation](https://www.bundlebear.com/factories/all).
+
+## What we're building
+
+- Using a Kernel smart account, [mint an NFT](https://optimism-sepolia.blockscout.com/token/0xAB559628B94Fd9748658c46E58a85EfB52FdaCa6) on Optimism Sepolia using the Superchain paymaster.
+
+## Preparation
+
+You will need
+
+- RPC URL for the chain to use - a regular JSON-RPC provider
+- Bundler RPC URL - this should support bundler RPC methods
+- Paymaster RPC URL - choose the [Superchain paymaster RPC endpoint URL](./README.md) for the chain you are using
+
+## 1. Create a paymaster client
+
+The Superchain paymaster has a similar API to [Pimlico](https://docs.pimlico.io/paymaster/verifying-paymaster/reference/endpoints) and [Stackup](https://docs.stackup.sh/docs/paymaster-api-rpc-methods#pm_sponsoruseroperation)'s verifying paymaster service, meaning you can use `createPimlicoPaymasterClient` directly.
+
+```typescript
+import { http } from 'viem'
+import { ENTRYPOINT_ADDRESS_V06 } from 'permissionless'
+import { createPimlicoPaymasterClient } from 'permissionless/clients/pimlico'
+
+// For OP Sepolia, use a different RPC url for a different chain
+const PAYMASTER_RPC_URL = 'https://paymaster.optimism.io/v1/11155420/rpc'
+
+const paymasterClient = createPimlicoPaymasterClient({
+  transport: http(paymasterRpcUrl),
+  entryPoint: ENTRYPOINT_ADDRESS_V06,
+})
+```
+
+## 2. Create a smart account with a signer
+
+We use a randomly generated private key as the signer. You will need a RPC for the chain you are using (this is used to fetch the current state of the smart account - ie. nonces).
+
+```typescript
+import { ENTRYPOINT_ADDRESS_V06 } from 'permissionless'
+import { signerToEcdsaKernelSmartAccount } from 'permissionless/accounts'
+import { createPublicClient, http } from 'viem'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+
+const CHAIN_RPC_URL = 'https://sepolia.optimism.io/'
+
+const publicClient = createPublicClient({
+  transport: http(CHAIN_RPC_URL),
+})
+
+const signer = privateKeyToAccount(generatePrivateKey())
+
+const kernelAccount = await signerToEcdsaKernelSmartAccount(publicClient, {
+  entryPoint: ENTRYPOINT_ADDRESS_V06,
+  signer: signer,
+})
+```
+
+## 3. Create a smart account client
+
+Smart account client connects to the bundler, and sends the user operation using the bundler RPC.
+
+```typescript
+import {
+  ENTRYPOINT_ADDRESS_V06,
+  createSmartAccountClient,
+} from 'permissionless'
+import { http } from 'viem'
+
+import { optimismSepolia } from 'viem/chains'
+
+// Use your own bundler RPC url
+const BUNDLER_RPC_URL =
+  'https://api.pimlico.io/v2/optimism-sepolia/rpc?apikey=get-one-from-dashboard'
+
+const smartAccountClient = createSmartAccountClient({
+  account: kernelAccount,
+  entryPoint: ENTRYPOINT_ADDRESS_V06,
+  chain: optimismSepolia,
+  bundlerTransport: http(BUNDLER_RPC_URL),
+  middleware: {
+    sponsorUserOperation: paymasterClient.sponsorUserOperation,
+  },
+})
+```
+
+## 4. Send a user operation
+
+This user operation mints an [NFT](https://sepolia-optimism.etherscan.io/address/0xAB559628B94Fd9748658c46E58a85EfB52FdaCa6)
+
+```typescript
+import { parseAbiItem } from 'viem'
+
+const transactionHash = await smartAccountClient.writeContract({
+  abi: [parseAbiItem('function mint() returns (uint256)')],
+  address: '0xAB559628B94Fd9748658c46E58a85EfB52FdaCa6',
+  functionName: 'mint',
+})
+```
+
+You can see a working example dapp [here](https://superchain-paymaster-nft-mint-example.pages.dev/), and the source code [here](/apps/paymaster-nft-mint/src/libraries/permissionless).


### PR DESCRIPTION
- adds api docs with endpoints and specs
- adds usage examples for aa-sdk and permissionless