### PR TITLE
Deployment Rebate Dialog

### DIFF
--- a/apps/dapp-console/app/components/StandardDialogContent.tsx
+++ b/apps/dapp-console/app/components/StandardDialogContent.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image'
+
+import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
+import { Badge } from '@eth-optimism/ui-components/src/components/ui/badge'
+
+export type DialogMetadata = {
+  label: string
+  title: string
+  description: React.ReactNode
+  primaryButton: React.ReactNode
+  secondaryButton?: React.ReactNode
+  bannerImage?: string
+}
+
+export type StandardDialogContentProps = {
+  dialogMetadata: DialogMetadata
+}
+
+export const StandardDialogContent = ({
+  dialogMetadata,
+}: StandardDialogContentProps) => (
+  <div>
+    <Badge variant="secondary">
+      <Text as="p">{dialogMetadata.label}</Text>
+    </Badge>
+    {dialogMetadata.bannerImage && (
+      <Image
+        src={dialogMetadata.bannerImage}
+        alt={`${dialogMetadata.label} banner`}
+        className="w-full rounded-xs mt-6 object-cover"
+        width={450}
+        height={140}
+      />
+    )}
+    <div className="py-6">
+      <Text as="h3" className="text-lg font-semibold mb-2">
+        {dialogMetadata.title}
+      </Text>
+      <div className="text-md text-muted-foreground">
+        {dialogMetadata.description}
+      </div>
+    </div>
+    <div className="flex flex-col gap-2.5">
+      {dialogMetadata.primaryButton}
+      {dialogMetadata.secondaryButton}
+    </div>
+  </div>
+)

--- a/apps/dapp-console/app/components/StandardDialogContent.tsx
+++ b/apps/dapp-console/app/components/StandardDialogContent.tsx
@@ -7,7 +7,7 @@ export type DialogMetadata = {
   label: string
   title: string
   description: React.ReactNode
-  primaryButton: React.ReactNode
+  primaryButton?: React.ReactNode
   secondaryButton?: React.ReactNode
   bannerImage?: string
 }
@@ -40,7 +40,7 @@ export const StandardDialogContent = ({
         {dialogMetadata.description}
       </div>
     </div>
-    <div className="flex flex-col gap-2.5">
+    <div className="flex flex-col gap-2.5 w-full">
       {dialogMetadata.primaryButton}
       {dialogMetadata.secondaryButton}
     </div>

--- a/apps/dapp-console/app/console/constants.tsx
+++ b/apps/dapp-console/app/console/constants.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
-import { DialogMetadata } from '@/app/console/useDialogContent'
 import { trackOfferEngaged } from '@/app/event-tracking/mixpanel'
-import { externalRoutes, forms } from '@/app/constants'
+import { externalRoutes, forms, routes } from '@/app/constants'
+import Link from 'next/link'
+import { DialogMetadata } from '@/app/components/StandardDialogContent'
 
 function generatePrimaryButton(
   label: string,
@@ -112,6 +113,56 @@ export const deploymentRebateMetadata: DialogMetadata = {
   primaryButton: (
     <Button disabled size="lg">
       <Text as="span">Coming soon</Text>
+    </Button>
+  ),
+}
+
+export const deploymentRebateM2Metadata: DialogMetadata = {
+  label: 'Deployment Rebate',
+  title:
+    'Launch on the Superchain and get your deployment costs covered up to 0.05 ETH',
+  description: (
+    <>
+      <Text as="p">
+        Get your app up and running without having to worry about deployment
+        fees.
+      </Text>
+      <Text as="p" className="mt-6">
+        Details:
+      </Text>
+      <ul className="list-disc pl-6 mb-2">
+        <li>
+          <Text as="p">
+            You must have signed up to Dapp Console before launching contracts
+          </Text>
+        </li>
+        <li>
+          <Text as="p">Contracts must be added to Dapp Console</Text>
+        </li>
+        <li>
+          <Text as="p">
+            Your onchain identity must be verified through Coinbase Verification
+          </Text>
+        </li>
+      </ul>
+    </>
+  ),
+  primaryButton: (
+    <Button size="lg" asChild>
+      <Link href={routes.CONTRACTS.path}>
+        <Text as="span">Add Contracts</Text>
+      </Link>
+    </Button>
+  ),
+  secondaryButton: (
+    <Button size="lg" variant="outline" asChild>
+      <Link
+        href={externalRoutes.TERMS.path}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Text as="span">See Terms</Text>
+      </Link>
     </Button>
   ),
 }

--- a/apps/dapp-console/app/console/useDialogContent.tsx
+++ b/apps/dapp-console/app/console/useDialogContent.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@eth-optimism/ui-components/src/components/ui/badge'
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text'
 import { usePrivy } from '@privy-io/react-auth'
@@ -7,6 +6,7 @@ import {
   testnetPaymasterMetadata,
   uxReviewMetadata,
   deploymentRebateMetadata,
+  deploymentRebateM2Metadata,
   mainnetPaymasterMetadata,
   megaphoneMetadata,
   userFeedbackMetadata,
@@ -17,20 +17,16 @@ import {
   alchemySubgraphMetadata,
   quickStartMetadata,
 } from '@/app/console/constants'
-import Image from 'next/image'
 import { DialogClose } from '@eth-optimism/ui-components/src/components/ui/dialog'
-
-export type DialogMetadata = {
-  label: string
-  title: string
-  description: React.ReactNode
-  primaryButton?: React.ReactNode
-  secondaryButton?: React.ReactNode
-  bannerImage?: string
-}
+import { useFeature } from '@/app/hooks/useFeatureFlag'
+import {
+  DialogMetadata,
+  StandardDialogContent,
+} from '@/app/components/StandardDialogContent'
 
 const useDialogContent = () => {
   const { authenticated, login } = usePrivy()
+  const isSettingsEnabled = useFeature('enable_console_settings')
 
   const loginButton = (label: string) => {
     return (
@@ -65,9 +61,11 @@ const useDialogContent = () => {
 
   const deploymentRebateContent = useMemo(() => {
     return renderDialog({
-      ...deploymentRebateMetadata,
+      ...(isSettingsEnabled
+        ? deploymentRebateM2Metadata
+        : deploymentRebateMetadata),
     })
-  }, [authenticated, login])
+  }, [authenticated, login, isSettingsEnabled])
 
   const mainnetPaymasterContent = useMemo(() => {
     return renderDialog({
@@ -168,36 +166,8 @@ const useDialogContent = () => {
   }
 }
 
-export const renderDialog = (dialogMetadata: DialogMetadata) => {
-  return (
-    <div>
-      <Badge variant="secondary">
-        <Text as="p">{dialogMetadata.label}</Text>
-      </Badge>
-      {dialogMetadata.bannerImage && (
-        <Image
-          src={dialogMetadata.bannerImage}
-          alt={`${dialogMetadata.label} banner`}
-          className="w-full rounded-xs mt-6 object-cover"
-          width={450}
-          height={140}
-        />
-      )}
-      <div className="py-6">
-        <Text as="h3" className="text-lg font-semibold mb-2">
-          {dialogMetadata.title}
-        </Text>
-        <div className="text-md text-muted-foreground">
-          {dialogMetadata.description}
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2.5 w-full">
-        {dialogMetadata.primaryButton}
-        {dialogMetadata.secondaryButton}
-      </div>
-    </div>
-  )
-}
+const renderDialog = (dialogMetadata: DialogMetadata) => (
+  <StandardDialogContent dialogMetadata={dialogMetadata} />
+)
 
 export { useDialogContent }

--- a/apps/dapp-console/app/console/useDialogContent.tsx
+++ b/apps/dapp-console/app/console/useDialogContent.tsx
@@ -166,7 +166,7 @@ const useDialogContent = () => {
   }
 }
 
-const renderDialog = (dialogMetadata: DialogMetadata) => (
+export const renderDialog = (dialogMetadata: DialogMetadata) => (
   <StandardDialogContent dialogMetadata={dialogMetadata} />
 )
 

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -14,6 +14,13 @@ import {
 import { SettingsTabType, SettingsTab } from '@/app/settings/types'
 import { useFeature } from '@/app/hooks/useFeatureFlag'
 import { WalletVerificationMethods } from '@/app/settings/components/WalletVerificationMethods'
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from '@eth-optimism/ui-components'
+import { deploymentRebateM2Metadata } from '@/app/console/constants'
+import { StandardDialogContent } from '@/app/components/StandardDialogContent'
 
 const tabs: Record<SettingsTabType, SettingsTab> = {
   account: {
@@ -27,9 +34,18 @@ const tabs: Record<SettingsTabType, SettingsTab> = {
       <SettingsCardDescription>
         Add your app contracts here. In the future, we’ll scan them for
         insights. For now, we’ll check if they’re eligible for the{' '}
-        <Text as="span" className="font-semibold">
-          Deployment Rebate.
-        </Text>
+        <Dialog>
+          <DialogTrigger>
+            <Text as="span" className="font-semibold">
+              Deployment Rebate.
+            </Text>
+          </DialogTrigger>
+          <DialogContent>
+            <StandardDialogContent
+              dialogMetadata={deploymentRebateM2Metadata}
+            />
+          </DialogContent>
+        </Dialog>
       </SettingsCardDescription>
     ),
   },


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Moves all shared dialog styles to `StandardDialogContent` so we can reuse the styles across pages
* Adds `deploymentRebateM2Metadata` that will be displayed when settings are enabled. Once M2 is shipped we'll rename it to `deploymentRebateMetadata`.
* Updates contract page header to include the new dialog

<img width="451" alt="Screenshot 2024-03-19 at 10 55 23 AM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/18cdc90a-9618-4c06-8401-2d51806ad6c4">
