### PR TITLE
[dapp console] Adds copy address and toast support

### DIFF
--- a/apps/dapp-console/app/layout.tsx
+++ b/apps/dapp-console/app/layout.tsx
@@ -1,9 +1,12 @@
+'use client'
+
 import { Inter } from 'next/font/google'
 import '@/app/globals.css'
 import { PrivyProviderWrapper } from '@/app/providers/PrivyProviderWrapper'
 import { Header } from '@/app/components/Header'
 import { ThemeProvider } from '@/app/providers/ThemeProvider'
 import { FeatureFlagProvider } from '@/app/providers/FeatureFlagProvider'
+import { Toaster } from '@eth-optimism/ui-components'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -23,6 +26,7 @@ export default function RootLayout({
             </PrivyProviderWrapper>
           </ThemeProvider>
         </FeatureFlagProvider>
+        <Toaster />
       </body>
     </html>
   )

--- a/apps/dapp-console/app/settings/components/LinkedWallet.tsx
+++ b/apps/dapp-console/app/settings/components/LinkedWallet.tsx
@@ -8,8 +8,9 @@ import { Input } from '@eth-optimism/ui-components/src/components/ui/input/input
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button/button'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 import { WalletWithMetadata } from '@privy-io/react-auth'
-import { RiAlertFill, RiCloseLine } from '@remixicon/react'
+import { RiAlertFill, RiCloseLine, RiFileCopyLine } from '@remixicon/react'
 import { useCallback, useState } from 'react'
+import { useToast } from '@eth-optimism/ui-components'
 
 export type LinkedWalletProps = {
   wallet: WalletWithMetadata
@@ -17,6 +18,7 @@ export type LinkedWalletProps = {
 }
 
 export const LinkedWallet = ({ wallet, onUnlink }: LinkedWalletProps) => {
+  const { toast } = useToast()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   const handleUnlink = useCallback(() => onUnlink(wallet), [wallet, onUnlink])
@@ -25,12 +27,34 @@ export const LinkedWallet = ({ wallet, onUnlink }: LinkedWalletProps) => {
     [setIsDialogOpen],
   )
 
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(wallet.address)
+    toast({
+      description: 'Address Copied',
+      duration: 1000,
+    })
+  }, [wallet, toast])
+
   return (
     <div className="flex flex-row gap-2">
       <Input value={wallet.address} disabled />
+      <Button
+        variant="secondary"
+        className="px-3"
+        size="icon"
+        aria-label="Unlink Wallet"
+        onClick={handleCopy}
+      >
+        <RiFileCopyLine />
+      </Button>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogTrigger asChild>
-          <Button variant="secondary" size="icon" aria-label="Unlink Wallet">
+          <Button
+            variant="secondary"
+            className="px-3"
+            size="icon"
+            aria-label="Unlink Wallet"
+          >
             <RiCloseLine />
           </Button>
         </DialogTrigger>

--- a/apps/dapp-console/app/settings/components/LinkedWallet.tsx
+++ b/apps/dapp-console/app/settings/components/LinkedWallet.tsx
@@ -40,22 +40,16 @@ export const LinkedWallet = ({ wallet, onUnlink }: LinkedWalletProps) => {
       <Input value={wallet.address} disabled />
       <Button
         variant="secondary"
-        className="px-3"
         size="icon"
         aria-label="Unlink Wallet"
         onClick={handleCopy}
       >
-        <RiFileCopyLine />
+        <RiFileCopyLine size={20} />
       </Button>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogTrigger asChild>
-          <Button
-            variant="secondary"
-            className="px-3"
-            size="icon"
-            aria-label="Unlink Wallet"
-          >
-            <RiCloseLine />
+          <Button variant="secondary" size="icon" aria-label="Unlink Wallet">
+            <RiCloseLine size={20} />
           </Button>
         </DialogTrigger>
         <DialogContent>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds the `Toaster` component to our root layout. This allows us to start showing toasts in the app https://ui.shadcn.com/docs/components/toast
* Updates the wallets page to add the copy icon, and display a toast after copying


https://github.com/ethereum-optimism/ecosystem/assets/1761993/1fcea4e5-6348-4330-8563-9ca496d5f752

