### PR TITLE
[dapp console] Adds mobile settings menu

### DIFF
--- a/apps/dapp-console/app/settings/components/SettingsMenu.tsx
+++ b/apps/dapp-console/app/settings/components/SettingsMenu.tsx
@@ -5,6 +5,17 @@ import { Separator } from '@eth-optimism/ui-components/src/components/ui/separat
 
 import { routes } from '@/app/constants'
 import { SettingsTabType } from '@/app/settings/types'
+import { useTheme } from 'next-themes'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@eth-optimism/ui-components'
+import { useMemo } from 'react'
+import { RiArrowDownSLine } from '@remixicon/react'
 
 export type SettingsMenuProps = {
   activeTabType: SettingsTabType
@@ -24,13 +35,13 @@ const SettingsMenuItem = ({
     <Link className="flex flex-row items-center" href={url}>
       <div
         className={cn(
-          'border-1 bg-primary rounded-full w-[6px] h-[6px]',
+          'bg-foreground rounded-full w-[6px] h-[6px]',
           isActive ? 'visibile' : 'invisible',
         )}
       ></div>
       <Text
         as="span"
-        className={cn('pl-3 text-sm transition', isActive ? 'font-bold' : '')}
+        className={cn('pl-3 text-base transition', isActive ? 'font-bold' : '')}
       >
         {title}
       </Text>
@@ -41,26 +52,83 @@ const SettingsMenuItem = ({
 export const SettingsMenu = ({
   activeTabType,
   className,
-}: SettingsMenuProps) => (
-  <div className={className}>
-    <Text className="text-sm font-semibold p-3">Settings</Text>
-    <Separator />
-    <ul>
-      <SettingsMenuItem
-        isActive={activeTabType === 'account'}
-        title={routes.ACCOUNT.label}
-        url={routes.ACCOUNT.path}
+}: SettingsMenuProps) => {
+  const { resolvedTheme } = useTheme()
+
+  return (
+    <div className={className}>
+      <Text className="text-base font-semibold p-3">Settings</Text>
+      <Separator
+        className={cn(
+          'mb-3',
+          resolvedTheme === 'dark' ? 'bg-foreground/20' : '',
+        )}
       />
-      <SettingsMenuItem
-        isActive={activeTabType === 'contracts'}
-        title={routes.CONTRACTS.label}
-        url={routes.CONTRACTS.path}
-      />
-      <SettingsMenuItem
-        isActive={activeTabType === 'wallets'}
-        title={routes.WALLETS.label}
-        url={routes.WALLETS.path}
-      />
-    </ul>
-  </div>
-)
+      <ul>
+        <SettingsMenuItem
+          isActive={activeTabType === 'account'}
+          title={routes.ACCOUNT.label}
+          url={routes.ACCOUNT.path}
+        />
+        <SettingsMenuItem
+          isActive={activeTabType === 'contracts'}
+          title={routes.CONTRACTS.label}
+          url={routes.CONTRACTS.path}
+        />
+        <SettingsMenuItem
+          isActive={activeTabType === 'wallets'}
+          title={routes.WALLETS.label}
+          url={routes.WALLETS.path}
+        />
+      </ul>
+    </div>
+  )
+}
+
+export const MobileSettingsMenu = ({
+  activeTabType,
+  className,
+}: SettingsMenuProps) => {
+  const activeRoute = useMemo(
+    () => routes[activeTabType.toUpperCase()],
+    [activeTabType],
+  )
+
+  return (
+    <Dialog>
+      <DialogTrigger className={className} asChild>
+        <div className="flex flex-row w-full px-6">
+          <Button variant="outline" className="bg-white w-full justify-between">
+            <Text as="span">{activeRoute.label}</Text>
+            <RiArrowDownSLine />
+          </Button>
+        </div>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            <Text className="text-center">Settings</Text>
+          </DialogTitle>
+        </DialogHeader>
+
+        <ul>
+          <SettingsMenuItem
+            isActive={activeTabType === 'account'}
+            title={routes.ACCOUNT.label}
+            url={routes.ACCOUNT.path}
+          />
+          <SettingsMenuItem
+            isActive={activeTabType === 'contracts'}
+            title={routes.CONTRACTS.label}
+            url={routes.CONTRACTS.path}
+          />
+          <SettingsMenuItem
+            isActive={activeTabType === 'wallets'}
+            title={routes.WALLETS.label}
+            url={routes.WALLETS.path}
+          />
+        </ul>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -5,7 +5,10 @@ import { useEffect, useMemo } from 'react'
 
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 
-import { SettingsMenu } from '@/app/settings/components/SettingsMenu'
+import {
+  MobileSettingsMenu,
+  SettingsMenu,
+} from '@/app/settings/components/SettingsMenu'
 import {
   SettingsCard,
   SettingsCardDescription,
@@ -73,15 +76,21 @@ export default function SettingsLayout({
 
   return shouldShowSettings ? (
     <main className="flex justify-center bg-secondary min-h-screen">
-      <div className="flex flex-row w-full max-w-7xl mt-36 mb-16">
+      <div className="flex flex-row w-full max-w-7xl mt-6 md:mt-36 md:mb-16">
         <SettingsMenu
           activeTabType={tab.type}
           className="hidden w-[246px] pl-10 md:block xl:pl-0"
         />
 
-        <SettingsCard className="w-full mx-8 z-10" tab={tab}>
-          {children}
-        </SettingsCard>
+        <div className="flex flex-col w-full items-center md:mx-8">
+          <MobileSettingsMenu
+            activeTabType={tab.type}
+            className="flex md:hidden mb-6"
+          />
+          <SettingsCard className="w-full z-10 min-h-full md:min-h-0" tab={tab}>
+            {children}
+          </SettingsCard>
+        </div>
       </div>
     </main>
   ) : null


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR adds a mobile settings menu, and cleans up some of the styles in the desktop menu to support dark mode better

**Mobile**
<img width="606" alt="Screenshot 2024-03-22 at 5 09 27 PM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/83021f84-112c-4769-9749-cb67b89a38a6">


**Light Mode Desktop**
<img width="1727" alt="Screenshot 2024-03-22 at 5 09 35 PM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/9f488d18-4d01-41d2-a7eb-36eb8a046511">

**Dark Mode Desktop**
<img width="1728" alt="Screenshot 2024-03-22 at 5 13 15 PM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/cc7c1f48-1a79-40b6-a9d5-d0fc7cd26216">
