### PR TITLE
feat(dapp-console): set up privy auth middleware

### DIFF
--- a/apps/dapp-console-api/example.env
+++ b/apps/dapp-console-api/example.env
@@ -48,3 +48,12 @@ MIGRATE_MAX_RETRY_DELAY=
 
 # Maximum number of retries for migrations
 MIGRATE_MAX_RETRIES=
+
+# App id for Privy
+PRIVY_APP_ID=
+
+# Secret for privy app
+PRIVY_APP_SECRET=
+
+# bcrypt salt for hashing privy access token
+PRIVY_ACCESS_TOKEN_SALT=

--- a/apps/dapp-console-api/package.json
+++ b/apps/dapp-console-api/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/body-parser": "^1.19.5",
+    "@types/cookie-parser": "^1.4.7",
     "@types/cors": "^2.8.5",
     "@types/express": "^4.17.21",
     "@types/express-serve-static-core": "4.17.41",
@@ -47,9 +48,11 @@
     "vitest": "^1.1.3"
   },
   "dependencies": {
+    "@privy-io/server-auth": "^1.7.2",
     "@trpc/server": "^10.45.1",
     "bcrypt": "^5.1.1",
     "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
     "drizzle-orm": "^0.30.1",

--- a/apps/dapp-console-api/src/Trpc.ts
+++ b/apps/dapp-console-api/src/Trpc.ts
@@ -1,11 +1,14 @@
+import type { PrivyClient } from '@privy-io/server-auth'
 import type { inferAsyncReturnType } from '@trpc/server'
 import { initTRPC, TRPCError } from '@trpc/server'
 import type * as trpcExpress from '@trpc/server/adapters/express'
 import { getIronSession } from 'iron-session'
+import type { Logger } from 'pino'
 import superjson from 'superjson'
 
 import type { SessionData } from './constants'
 import { sessionOptions } from './constants'
+import type { Database } from './db'
 
 const createContext = async ({
   req,
@@ -42,6 +45,9 @@ export class Trpc {
   public readonly middleware = this.trpc.middleware
 
   constructor(
+    public readonly privy: PrivyClient,
+    public readonly logger: Logger,
+    public readonly database: Database,
     private readonly trpc = initTRPC
       // @see https://trpc.io/docs/server/context
       .context<inferAsyncReturnType<typeof createContext>>()

--- a/apps/dapp-console-api/src/api/Middleware.ts
+++ b/apps/dapp-console-api/src/api/Middleware.ts
@@ -21,8 +21,6 @@ export class Middleware {
     },
   })
 
-  // TODO add cookie middleware
-
   /**
    * @param corsAllowlist - regex array of allowlist
    */

--- a/apps/dapp-console-api/src/constants/envVars.ts
+++ b/apps/dapp-console-api/src/constants/envVars.ts
@@ -22,6 +22,7 @@ const envVarSchema = z.object({
     .describe('32 character iron session secret'),
   ADMIN_API_PASSWORD: z.string().optional(),
   ADMIN_API_SALT: z.string().optional(),
+  PRIVY_ACCESS_TOKEN_SALT: z.string(),
   DB_USER: z.string(),
   MIGRATE_DB_USER: z.string(),
   DB_PASSWORD: z.string().optional(),
@@ -33,6 +34,8 @@ const envVarSchema = z.object({
   DB_PORT: z.number().optional(),
   DB_NAME: z.string().optional(),
   DB_MAX_CONNECTIONS: z.number().int().min(1).optional(),
+  PRIVY_APP_ID: z.string(),
+  PRIVY_APP_SECRET: z.string(),
 })
 
 const isTest = process.env.NODE_ENV === 'test'
@@ -72,6 +75,9 @@ export const envVars = envVarSchema.parse(
         MIGRATE_INITIAL_RETRY_DELAY: 1,
         MIGRATE_MAX_RETRY_DELAY: 1,
         MIGRATE_MAX_RETRIES: 1,
+        PRIVY_APP_ID: 'PRIVY_APP_ID',
+        PRIVY_APP_SECRET: 'PRIVY_APP_SECRET',
+        PRIVY_ACCESS_TOKEN_SALT: '$2b$10$Kd085thA56nZmQiRHh2XHu',
       }
     : {
         PORT: process.env.PORT
@@ -103,5 +109,8 @@ export const envVars = envVarSchema.parse(
           process.env.MIGRATE_INITIAL_RETRY_DELAY ?? 30000,
         MIGRATE_MAX_RETRY_DELAY: process.env.MIGRATE_MAX_RETRY_DELAY ?? 120000,
         MIGRATE_MAX_RETRIES: process.env.MIGRATE_MAX_RETRIES ?? 3,
+        PRIVY_APP_ID: process.env.PRIVY_APP_ID,
+        PRIVY_APP_SECRET: process.env.PRIVY_APP_SECRET,
+        PRIVY_ACCESS_TOKEN_SALT: process.env.PRIVY_ACCESS_TOKEN_SALT,
       },
 )

--- a/apps/dapp-console-api/src/constants/index.ts
+++ b/apps/dapp-console-api/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './cors'
 export * from './envVars'
+export * from './privy'
 export * from './session'
 export * from './types'

--- a/apps/dapp-console-api/src/constants/privy.ts
+++ b/apps/dapp-console-api/src/constants/privy.ts
@@ -1,0 +1,1 @@
+export const PRIVY_TOKEN_COOKIE_KEY = 'privy-token'

--- a/apps/dapp-console-api/src/constants/session.ts
+++ b/apps/dapp-console-api/src/constants/session.ts
@@ -18,6 +18,14 @@ export type SessionData = {
     isActive: boolean
     createdAt: string
   }
+  user?: {
+    // bcrypt hash of privy access token
+    privyAccessToken: string
+    // UTC milliseconds at which the token expires
+    privyAccessTokenExpiration: number
+    privyDid: string
+    entityId: string
+  }
 }
 
 export type Session = IronSession<SessionData>

--- a/apps/dapp-console-api/src/middleware/index.ts
+++ b/apps/dapp-console-api/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from './isPrivyAuthed'

--- a/apps/dapp-console-api/src/middleware/isPrivyAuthed.spec.ts
+++ b/apps/dapp-console-api/src/middleware/isPrivyAuthed.spec.ts
@@ -1,0 +1,261 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+import type { RouterCaller } from '@trpc/server'
+import { createCallerFactory } from '@trpc/server'
+import bcrypt from 'bcrypt'
+import type { Request, Response } from 'express'
+import type { getIronSession } from 'iron-session'
+import type { Mock } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionData } from '@/constants'
+import { envVars, PRIVY_TOKEN_COOKIE_KEY } from '@/constants'
+import type { Session } from '@/constants/session'
+import { getEntity, insertEntity } from '@/models'
+import { Route } from '@/routes'
+import { mockDB, mockLogger } from '@/testhelpers'
+import { mockPrivyClient } from '@/testhelpers/MockPrivyClient'
+import { Trpc } from '@/Trpc'
+
+import { isPrivyAuthed } from './isPrivyAuthed'
+
+vi.mock('../models', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('../models')),
+  getEntity: vi.fn().mockImplementation(async () => undefined),
+  insertEntity: vi.fn().mockImplementation(async () => undefined),
+}))
+
+describe('isPrivyAuthed', () => {
+  let privyClient: PrivyClient
+  let trpc: Trpc
+  let handler: TestRoute['handler']
+  let signedOutCaller: ReturnType<RouterCaller<TestRoute['handler']['_def']>>
+  let signedInCaller: ReturnType<RouterCaller<TestRoute['handler']['_def']>>
+  const mockPrivyAccessToken = 'privy_token'
+  let hashedAccessToken: string
+  let verifyAuthTokenMock: Mock
+  let getEntityMock: Mock
+  let insertEntityMock: Mock
+
+  const mockSession = (user?: SessionData['user']) => ({
+    ...(user && {
+      user: {
+        ...user,
+      },
+    }),
+    save: vi.fn(),
+    destroy: vi.fn(),
+    updateConfig: vi.fn(),
+  })
+
+  const createSignedInCallerWithSession = (
+    session: Awaited<ReturnType<typeof getIronSession<SessionData>>>,
+    privyAccessToken?: string,
+  ) => {
+    const callerFactory = createCallerFactory()
+    const createCaller = callerFactory(handler)
+    return createCaller({
+      req: {
+        cookies: {
+          [PRIVY_TOKEN_COOKIE_KEY]: privyAccessToken || mockPrivyAccessToken,
+        } as any,
+      } as Request,
+      res: {} as Response,
+      session: session,
+    })
+  }
+
+  beforeEach(async () => {
+    hashedAccessToken = await bcrypt.hash(
+      mockPrivyAccessToken,
+      envVars.PRIVY_ACCESS_TOKEN_SALT,
+    )
+    privyClient = mockPrivyClient()
+    trpc = new Trpc(privyClient, mockLogger, mockDB)
+    handler = new TestRoute(trpc).handler
+    const callerFactory = createCallerFactory()
+    const createCaller = callerFactory(handler)
+    signedOutCaller = createCaller({
+      req: {
+        cookies: {},
+      } as Request,
+      res: {} as Response,
+      session: {} as Session,
+    })
+    signedInCaller = createSignedInCallerWithSession(mockSession())
+    ;({ verifyAuthTokenMock, getEntityMock, insertEntityMock } =
+      configureMocks())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const configureMocks = () => {
+    const verifyAuthTokenMock = privyClient.verifyAuthToken as Mock
+    verifyAuthTokenMock.mockImplementation(async () => ({
+      expiration: Date.now() / 1000,
+      userId: 'privy:did',
+    }))
+    const getEntityMock = getEntity as Mock
+    getEntityMock.mockImplementation((async) => ({}))
+    const insertEntityMock = insertEntity as Mock
+    insertEntityMock.mockImplementation((async) => {})
+    return {
+      verifyAuthTokenMock,
+      getEntityMock,
+      insertEntityMock,
+    }
+  }
+
+  it('should throw if privy-token cookie is not on request', async () => {
+    await expect(signedOutCaller.test()).rejects.toEqual(Trpc.handleStatus(401))
+  })
+
+  it(
+    'should call to privy to verify token when session does not contain access ' +
+      'token',
+    async () => {
+      await signedInCaller.test()
+
+      expect(verifyAuthTokenMock).toBeCalledWith(mockPrivyAccessToken)
+    },
+  )
+
+  it('should handle error when privy fails to verify the access token', async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error())
+
+    await expect(signedInCaller.test()).rejects.toEqual(Trpc.handleStatus(401))
+  })
+
+  it('should call to privy to verify token when access token changes', async () => {
+    signedInCaller = createSignedInCallerWithSession(
+      mockSession({
+        privyAccessToken: hashedAccessToken,
+        privyAccessTokenExpiration: Date.now() + 1000,
+        entityId: '1',
+        privyDid: 'privy:did',
+      }),
+      `${mockPrivyAccessToken}-new`,
+    )
+
+    await signedInCaller.test()
+
+    expect(verifyAuthTokenMock).toBeCalledWith(`${mockPrivyAccessToken}-new`)
+  })
+
+  it('should call to privy if access token on session is expired', async () => {
+    signedInCaller = createSignedInCallerWithSession(
+      mockSession({
+        privyAccessToken: hashedAccessToken,
+        privyAccessTokenExpiration: Date.now() - 1000,
+        entityId: '1',
+        privyDid: 'privy:did',
+      }),
+    )
+
+    await signedInCaller.test()
+
+    expect(verifyAuthTokenMock).toBeCalledWith(mockPrivyAccessToken)
+  })
+
+  it('should update the session with the user', async () => {
+    const expectedEntityId = 'entityId1'
+    const expectedExpirationTimeSeconds = Date.now() / 1000
+    const expectedPrivyDid = 'privy:did'
+    const session = mockSession()
+    const caller = createSignedInCallerWithSession(session)
+    getEntityMock.mockImplementation(async () => ({ id: expectedEntityId }))
+    verifyAuthTokenMock.mockImplementation(async () => ({
+      expiration: expectedExpirationTimeSeconds,
+      userId: expectedPrivyDid,
+    }))
+
+    await caller.test()
+
+    expect(session.user).toEqual({
+      entityId: expectedEntityId,
+      privyAccessToken: hashedAccessToken,
+      privyAccessTokenExpiration: expectedExpirationTimeSeconds * 1000,
+      privyDid: expectedPrivyDid,
+    })
+    expect(session.save).toBeCalled()
+  })
+
+  it('should create the entity if it does not exist', async () => {
+    const expectedEntityId = 'entityId1'
+    const expectedExpirationTimeSeconds = Date.now() / 1000
+    const expectedPrivyDid = 'privy:did'
+    const session = mockSession()
+    const caller = createSignedInCallerWithSession(session)
+    getEntityMock.mockImplementation(async () => undefined)
+    insertEntityMock.mockImplementation(async () => ({ id: expectedEntityId }))
+    verifyAuthTokenMock.mockImplementation(async () => ({
+      expiration: expectedExpirationTimeSeconds,
+      userId: expectedPrivyDid,
+    }))
+
+    await caller.test()
+
+    expect(insertEntityMock).toBeCalledWith(mockDB, {
+      privyDid: expectedPrivyDid,
+    })
+    expect(session.user).toEqual({
+      entityId: expectedEntityId,
+      privyAccessToken: hashedAccessToken,
+      privyAccessTokenExpiration: expectedExpirationTimeSeconds * 1000,
+      privyDid: expectedPrivyDid,
+    })
+    expect(session.save).toBeCalled()
+  })
+
+  it('should not create the entity if it already exists', async () => {
+    const expectedEntityId = 'entityId1'
+    const expectedExpirationTimeSeconds = Date.now() / 1000
+    const expectedPrivyDid = 'privy:did'
+    const session = mockSession()
+    const caller = createSignedInCallerWithSession(session)
+    getEntityMock.mockImplementation(async () => ({ id: expectedEntityId }))
+    verifyAuthTokenMock.mockImplementation(async () => ({
+      expiration: expectedExpirationTimeSeconds,
+      userId: expectedPrivyDid,
+    }))
+
+    await caller.test()
+
+    expect(insertEntityMock).not.toBeCalled()
+    expect(getEntityMock).toBeCalledWith(mockDB, expectedPrivyDid)
+  })
+
+  it('should not call privy and should not fetch entity if session is valid', async () => {
+    const session = mockSession({
+      privyAccessToken: hashedAccessToken,
+      privyAccessTokenExpiration: Date.now() + 1000,
+      entityId: 'id1',
+      privyDid: 'privy:did',
+    })
+    const caller = createSignedInCallerWithSession(session)
+
+    await caller.test()
+
+    expect(verifyAuthTokenMock).not.toBeCalled()
+    expect(getEntityMock).not.toBeCalled()
+    expect(insertEntityMock).not.toBeCalled()
+    expect(session.save).not.toBeCalled()
+  })
+})
+
+class TestRoute extends Route {
+  public readonly name = 'testroute' as const
+
+  public readonly test = 'test' as const
+  public readonly testController = this.trpc.procedure
+    .use(isPrivyAuthed(this.trpc))
+    .query(async () => {
+      return 'test'
+    })
+
+  public readonly handler = this.trpc.router({
+    [this.test]: this.testController,
+  })
+}

--- a/apps/dapp-console-api/src/middleware/isPrivyAuthed.ts
+++ b/apps/dapp-console-api/src/middleware/isPrivyAuthed.ts
@@ -1,0 +1,56 @@
+import bcrypt from 'bcrypt'
+
+import { envVars, PRIVY_TOKEN_COOKIE_KEY } from '@/constants'
+import { getEntity, insertEntity } from '@/models'
+import { Trpc } from '@/Trpc'
+
+/** Middleware used for checking if the request has a valid privy token associated with it. */
+export const isPrivyAuthed = (trpc: Trpc) => {
+  return trpc.middleware(async ({ ctx, next }) => {
+    const { req, session } = ctx
+    const cookieAccessToken = req.cookies[PRIVY_TOKEN_COOKIE_KEY]
+
+    if (!cookieAccessToken) {
+      throw Trpc.handleStatus(401, `user not signed in to privy`)
+    }
+
+    const hashedCookieAccessToken = await hashAccessToken(cookieAccessToken)
+
+    if (
+      !session.user ||
+      session.user.privyAccessToken !== hashedCookieAccessToken ||
+      session.user.privyAccessTokenExpiration < Date.now()
+    ) {
+      try {
+        const verifiedPrivy =
+          await trpc.privy.verifyAuthToken(cookieAccessToken)
+        // TODO: sync privy linked accounts
+
+        let entity = await getEntity(trpc.database, verifiedPrivy.userId)
+        if (!entity) {
+          entity = await insertEntity(trpc.database, {
+            privyDid: verifiedPrivy.userId,
+          })
+        }
+
+        session.user = {
+          privyAccessToken: hashedCookieAccessToken,
+          // verifiedPrivy.expiration is in seconds
+          privyAccessTokenExpiration: verifiedPrivy.expiration * 1000,
+          privyDid: verifiedPrivy.userId,
+          entityId: entity.id,
+        }
+        await session.save()
+      } catch (err) {
+        trpc.logger.error('error logging user in', err)
+        throw Trpc.handleStatus(401, `unable to validate access token`)
+      }
+    }
+
+    return next()
+  })
+}
+
+const hashAccessToken = (accessToken: string) => {
+  return bcrypt.hash(accessToken, envVars.PRIVY_ACCESS_TOKEN_SALT)
+}

--- a/apps/dapp-console-api/src/models/entities.ts
+++ b/apps/dapp-console-api/src/models/entities.ts
@@ -1,4 +1,8 @@
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
+
+import type { Database } from '@/db'
 
 export enum EntityState {
   ACTIVE = 'active',
@@ -20,3 +24,29 @@ export const entities = pgTable('entities', {
     .notNull(),
   disabledAt: timestamp('disabled_at', { withTimezone: true }),
 })
+
+export type Entity = InferSelectModel<typeof entities>
+export type InsertEntity = InferInsertModel<typeof entities>
+
+export const getEntity = async (
+  db: Database,
+  privyDid: Entity['privyDid'],
+): Promise<Entity | null> => {
+  const results = await db
+    .select()
+    .from(entities)
+    .where(
+      and(
+        eq(entities.privyDid, privyDid),
+        eq(entities.state, EntityState.ACTIVE),
+      ),
+    )
+
+  return results[0] || null
+}
+
+export const insertEntity = async (db: Database, newEntity: InsertEntity) => {
+  const result = await db.insert(entities).values(newEntity).returning()
+
+  return result[0]
+}

--- a/apps/dapp-console-api/src/testhelpers/MockDB.ts
+++ b/apps/dapp-console-api/src/testhelpers/MockDB.ts
@@ -1,0 +1,14 @@
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
+
+import { envVars } from '..'
+import type { Database } from '../db'
+
+export const mockDB: Database = drizzle(
+  new Pool({
+    user: envVars.DB_USER,
+    password: envVars.DB_PASSWORD,
+    host: envVars.DB_HOST,
+    database: envVars.DB_NAME,
+  }),
+)

--- a/apps/dapp-console-api/src/testhelpers/MockLogger.ts
+++ b/apps/dapp-console-api/src/testhelpers/MockLogger.ts
@@ -1,0 +1,8 @@
+import type { Logger } from 'pino'
+import type pino from 'pino'
+
+export const mockLogger: Logger = {
+  error: ((msg?: string, ...args: any[]) => {
+    console.error(msg) // eslint-disable-line no-console
+  }) as pino.LogFn,
+} as any

--- a/apps/dapp-console-api/src/testhelpers/MockPrivyClient.ts
+++ b/apps/dapp-console-api/src/testhelpers/MockPrivyClient.ts
@@ -1,0 +1,7 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+import { vi } from 'vitest'
+
+export const mockPrivyClient: () => PrivyClient = () =>
+  ({
+    verifyAuthToken: vi.fn().mockImplementation(async () => undefined),
+  }) as any

--- a/apps/dapp-console-api/src/testhelpers/index.ts
+++ b/apps/dapp-console-api/src/testhelpers/index.ts
@@ -1,0 +1,3 @@
+export * from './MockDB'
+export * from './MockLogger'
+export * from './MockPrivyClient'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
 
   apps/dapp-console-api:
     dependencies:
+      '@privy-io/server-auth':
+        specifier: ^1.7.2
+        version: 1.7.2
       '@trpc/server':
         specifier: ^10.45.1
         version: 10.45.1
@@ -229,6 +232,9 @@ importers:
       body-parser:
         specifier: ^1.20.2
         version: 1.20.2
+      cookie-parser:
+        specifier: ^1.4.6
+        version: 1.4.6
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -278,6 +284,9 @@ importers:
       '@types/body-parser':
         specifier: ^1.19.5
         version: 1.19.5
+      '@types/cookie-parser':
+        specifier: ^1.4.7
+        version: 1.4.7
       '@types/cors':
         specifier: ^2.8.5
         version: 2.8.17
@@ -1050,6 +1059,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
+    dev: true
 
   /@ampproject/remapping@2.3.0:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1173,6 +1183,7 @@ packages:
   /@babel/compat-data@7.23.3:
     resolution: {integrity: sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/compat-data@7.23.5:
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
@@ -1203,6 +1214,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.23.7:
     resolution: {integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==}
@@ -1248,6 +1260,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.24.1:
     resolution: {integrity: sha512-F82udohVyIgGAY2VVj/g34TpFUG606rumIHjTfVbssPg2zTR7PuuEpZcX8JA6sgBfIYmJrFtWgPvHQuJamVqZQ==}
@@ -1293,6 +1306,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.23.6:
     resolution: {integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==}
@@ -1302,6 +1316,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.24.1:
     resolution: {integrity: sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==}
@@ -1333,6 +1348,7 @@ packages:
       browserslist: 4.23.0
       lru-cache: 5.1.1
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-compilation-targets@7.23.6:
     resolution: {integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==}
@@ -1360,6 +1376,7 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.24.0):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
@@ -1377,6 +1394,7 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.24.1):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
@@ -1394,41 +1412,6 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
-
-  /@babel/helper-create-class-features-plugin@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.3)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-
-  /@babel/helper-create-class-features-plugin@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-    dev: false
 
   /@babel/helper-create-class-features-plugin@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==}
@@ -1457,6 +1440,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.24.0):
     resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
@@ -1465,6 +1449,18 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.24.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      regexpu-core: 5.3.2
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.24.1):
+    resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.1
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
@@ -1499,12 +1495,12 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.23.3):
+  /@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-o7SDgTJuvx5vLKD6SFvkydkSMBvahDKGiNJzG22IZYXhiqoe9efY7zocICBgzHV4IRg5wdgl2nEL/tulKIEIbA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
       debug: 4.3.4(supports-color@5.5.0)
@@ -1512,21 +1508,6 @@ packages:
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-o7SDgTJuvx5vLKD6SFvkydkSMBvahDKGiNJzG22IZYXhiqoe9efY7zocICBgzHV4IRg5wdgl2nEL/tulKIEIbA==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.0
-      debug: 4.3.4(supports-color@5.5.0)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
@@ -1575,6 +1556,7 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -1602,6 +1584,7 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.24.1):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
@@ -1640,6 +1623,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
+    dev: true
 
   /@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.24.0):
     resolution: {integrity: sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==}
@@ -1648,6 +1632,18 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.24.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-wrap-function': 7.22.20
+    dev: true
+
+  /@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.24.1):
+    resolution: {integrity: sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.1
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
@@ -1662,6 +1658,7 @@ packages:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
+    dev: true
 
   /@babel/helper-replace-supers@7.22.20(@babel/core@7.24.0):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
@@ -1673,6 +1670,7 @@ packages:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
+    dev: true
 
   /@babel/helper-replace-supers@7.22.20(@babel/core@7.24.1):
     resolution: {integrity: sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==}
@@ -1684,29 +1682,6 @@ packages:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-
-  /@babel/helper-replace-supers@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-
-  /@babel/helper-replace-supers@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-    dev: false
 
   /@babel/helper-replace-supers@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==}
@@ -1748,6 +1723,7 @@ packages:
   /@babel/helper-validator-option@7.22.15:
     resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-option@7.23.5:
     resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
@@ -1770,6 +1746,7 @@ packages:
       '@babel/types': 7.23.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.23.8:
     resolution: {integrity: sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==}
@@ -1791,6 +1768,7 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.24.1:
     resolution: {integrity: sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==}
@@ -1825,6 +1803,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.23.4
+    dev: true
 
   /@babel/parser@7.23.6:
     resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
@@ -1867,13 +1846,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.23.3):
@@ -1900,16 +1879,16 @@ packages:
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.23.3)
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.24.1)
 
   /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-XaJak1qcityzrX0/IU5nKHb34VaibwP3saKqG6a/tppelgllOH13LUann4ZCIBcVOeE6H18K4Vx9QKkVww3z/w==}
@@ -1933,42 +1912,28 @@ packages:
       '@babel/helper-plugin-utils': 7.24.0
     dev: true
 
-  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-m9m/fXsXLiHfwdgydIFnpk+7jlVbnvlK5B2EKiPdLUb6WX654ZaaEWJUjk8TftRbZpK0XibovlLWX4KIZhV6jw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.0
 
-  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.23.3):
+  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.24.1):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.3)
-
-  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.24.0):
-    resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.0)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.0)
-    dev: false
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.1)
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.3):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -1980,18 +1945,7 @@ packages:
       '@babel/core': 7.23.3
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.3)
       '@babel/helper-plugin-utils': 7.22.5
-
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.0):
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.1):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -2018,26 +1972,15 @@ packages:
       '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.23.3)
     dev: true
 
-  /@babel/plugin-proposal-export-default-from@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-proposal-export-default-from@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-+0hrgGGV3xyYIjOrD/bUZk/iUwOIGuoANfRfVg1cPhYBxF+TIXSEcc42DqzBICmWsnAQ+SfKedY0bj8QD+LuMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.23.3)
-
-  /@babel/plugin-proposal-export-default-from@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-+0hrgGGV3xyYIjOrD/bUZk/iUwOIGuoANfRfVg1cPhYBxF+TIXSEcc42DqzBICmWsnAQ+SfKedY0bj8QD+LuMg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.24.0)
-    dev: false
+      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.24.1)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -2049,18 +1992,7 @@ packages:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.3)
-
-  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.0):
-    resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.0)
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.1):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -2083,20 +2015,20 @@ packages:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.3)
+    dev: true
 
-  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.24.0):
+  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.24.1):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.0
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.0)
-    dev: false
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.1)
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.3):
+  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.24.1):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
@@ -2104,49 +2036,22 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.24.1
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.23.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.1)
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.24.0):
-    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.24.1
-      '@babel/core': 7.24.0
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.0)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.0)
-    dev: false
-
-  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.23.3):
+  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.24.1):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.3)
-
-  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.24.0):
-    resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.0)
-    dev: false
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.3):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
@@ -2159,19 +2064,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.3)
-
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.0):
-    resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.0)
-    dev: false
+    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.1):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
@@ -2204,6 +2097,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.3
+    dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.0):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
@@ -2213,6 +2107,14 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
     dev: true
+
+  /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.1):
+    resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
 
   /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.23.3):
     resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
@@ -2235,6 +2137,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -2251,6 +2154,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.1):
+    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.7):
@@ -2278,6 +2190,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.7):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -2297,6 +2210,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.1):
+    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.3):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
@@ -2305,6 +2226,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.0):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -2315,6 +2237,15 @@ packages:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
+
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.1):
+    resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==}
@@ -2333,6 +2264,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -2341,25 +2273,24 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
-  /@babel/plugin-syntax-export-default-from@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.1):
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-syntax-export-default-from@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-cNXSxv9eTkGUtd0PsNMK8Yx5xeScxfpWOUAxE+ZPAXXEcAMOC3fk7LRdXq5fvpra2pLx2p1YtkAhpUbB2SwaRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-syntax-export-default-from@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-cNXSxv9eTkGUtd0PsNMK8Yx5xeScxfpWOUAxE+ZPAXXEcAMOC3fk7LRdXq5fvpra2pLx2p1YtkAhpUbB2SwaRA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -2368,6 +2299,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -2377,6 +2309,14 @@ packages:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
+
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.1):
+    resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-flow@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-YZiAIpkJAwQXBJLIQbRFayR5c+gJ35Vcz3bg954k7cd73zqjvhacJuL9RbrzPz8qPmZdgqP6EUKwy0PCNhaaPA==}
@@ -2397,25 +2337,6 @@ packages:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
-
-  /@babel/plugin-syntax-flow@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-syntax-flow@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==}
@@ -2446,13 +2367,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.23.3):
@@ -2475,13 +2396,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.3):
@@ -2491,6 +2412,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -2510,6 +2432,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.1):
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
@@ -2517,6 +2447,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -2536,6 +2467,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.1):
+    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
     engines: {node: '>=6.9.0'}
@@ -2544,6 +2483,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
@@ -2553,6 +2493,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.24.1):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
@@ -2562,7 +2503,6 @@ packages:
     dependencies:
       '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-2eCtxZXf+kbkMIsXS4poTvT4Yu5rXiRa+9xGVT56raghjmBTKMpFNc9R4IDiB4emao9eO22Ox7CxuJG7BgExqA==}
@@ -2580,6 +2520,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -2599,6 +2540,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.1):
+    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
@@ -2606,6 +2555,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -2623,6 +2573,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.1):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -2639,6 +2590,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.7):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -2656,6 +2608,15 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.1):
+    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -2664,6 +2625,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -2681,6 +2643,15 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.1):
+    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -2689,6 +2660,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -2706,6 +2678,15 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.1):
+    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -2714,6 +2695,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.7):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -2731,6 +2713,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.1):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -2748,6 +2731,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.0):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -2756,6 +2740,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.1):
+    resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.3):
@@ -2766,6 +2760,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.7):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -2787,6 +2782,15 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.1):
+    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==}
     engines: {node: '>=6.9.0'}
@@ -2807,25 +2811,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
-
   /@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-Yhnmvy5HZEnHUty6i++gcfH1/l68AHnItFHnaCv6hn9dNh0hQvvQJsxpi4BMBFN5DLeHBuucT/0DgzXif/OyRw==}
     engines: {node: '>=6.9.0'}
@@ -2844,6 +2829,7 @@ packages:
       '@babel/core': 7.23.3
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.3)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.0):
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
@@ -2855,6 +2841,16 @@ packages:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.0)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
+
+  /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.1):
+    resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.1)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==}
@@ -2876,24 +2872,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-async-generator-functions@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==}
@@ -2921,17 +2907,17 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-async-generator-functions@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-async-generator-functions@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-OTkLJM0OtmzcpOgF7MREERUCdCnCBtBsq3vVFbuq/RKMK0/jdYqdMexWi3zNs7Nzd95ase65MbTGrpFJflOb6A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.3)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.1)
 
   /@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==}
@@ -2957,28 +2943,16 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-module-imports': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.3)
-
-  /@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-module-imports': 7.24.1
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.0)
-    dev: false
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.1)
 
   /@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==}
@@ -3000,13 +2974,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.3):
@@ -3029,24 +3003,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-block-scoping@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-h71T2QQvDgM2SmT29UYU6ozjMlAt7s7CSs5Hvy8f8cf/GM/Z4a2zMfN+fjVGaieeCrXR3EdQl6C4gQG+OgmbKw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-block-scoping@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-h71T2QQvDgM2SmT29UYU6ozjMlAt7s7CSs5Hvy8f8cf/GM/Z4a2zMfN+fjVGaieeCrXR3EdQl6C4gQG+OgmbKw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==}
@@ -3070,14 +3034,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.23.3):
@@ -3104,16 +3068,16 @@ packages:
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-class-static-block@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-class-static-block@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-FUHlKCn6J3ERiu8Dv+4eoz7w8+kFLSyeVG4vDAikwADGjUCoHw/JHokyGtr8OR4UjpwPVivyF+h8Q5iv/JmrtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.3)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.1)
 
   /@babel/plugin-transform-classes@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-FGEQmugvAEu2QtgtU0uTASXevfLMFfBeVCIIdcQhn/uBQsMTjBajdnAtanQlOcuihWh10PZ7+HWvc7NtBwP74w==}
@@ -3150,38 +3114,21 @@ packages:
       globals: 11.12.0
     dev: true
 
-  /@babel/plugin-transform-classes@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-classes@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.3)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.1)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-
-  /@babel/plugin-transform-classes@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.0)
-      '@babel/helper-split-export-declaration': 7.22.6
-      globals: 11.12.0
-    dev: false
 
   /@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==}
@@ -3205,26 +3152,15 @@ packages:
       '@babel/template': 7.22.15
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/template': 7.24.0
-
-  /@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/template': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==}
@@ -3246,24 +3182,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==}
@@ -3287,14 +3213,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.23.3):
@@ -3317,13 +3243,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.23.3):
@@ -3348,15 +3274,15 @@ packages:
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-av2gdSTyXcJVdI+8aFZsCAtR29xJt0S5tas+Ef8NvBNmD1a+N/3ecMLeMBgfcK+xzsjdLDT6oHt+DFPyeqUbDA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==}
@@ -3380,13 +3306,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.24.0
 
@@ -3412,15 +3338,15 @@ packages:
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-Ft38m/KFOyzKw2UaJFkWG9QnHPG/Q/2SkOrRk4pNBPg5IPZ+dOxcmkK5IyuBcxiNPyyYowPGUReyBvrvZs7IlQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-26/pQTf9nQSNVJCrLB1IkHUKyPxR+lMrH2QDPG89+Znu9rAMbtrybdbWeE9bb7gzjmE5iXHEY+e0HUwM6Co93Q==}
@@ -3443,27 +3369,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.24.0)
     dev: true
-
-  /@babel/plugin-transform-flow-strip-types@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.23.3)
-
-  /@babel/plugin-transform-flow-strip-types@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.0)
-    dev: false
 
   /@babel/plugin-transform-flow-strip-types@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==}
@@ -3496,13 +3401,13 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-for-of@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-for-of@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
@@ -3530,28 +3435,16 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-function-name@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-function-name@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-function-name@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==}
@@ -3575,15 +3468,15 @@ packages:
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-transform-literals@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==}
@@ -3605,24 +3498,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-literals@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-literals@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-literals@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==}
@@ -3646,15 +3529,15 @@ packages:
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.3)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.1)
 
   /@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==}
@@ -3676,13 +3559,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.23.3):
@@ -3707,14 +3590,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.3):
@@ -3740,29 +3623,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
     dev: true
-
-  /@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-simple-access': 7.22.5
-
-  /@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-simple-access': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==}
@@ -3801,15 +3661,15 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-identifier': 7.22.20
 
@@ -3835,14 +3695,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.3):
@@ -3854,6 +3714,7 @@ packages:
       '@babel/core': 7.23.3
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.3)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.24.0):
     resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
@@ -3863,6 +3724,17 @@ packages:
     dependencies:
       '@babel/core': 7.24.0
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.0)
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.24.1):
+    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-new-target@7.23.3(@babel/core@7.23.3):
@@ -3885,13 +3757,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-new-target@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-new-target@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.23.3):
@@ -3916,15 +3788,15 @@ packages:
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-iQ+caew8wRrhCikO5DrUYx0mrmdhkaELgFa+7baMcVuhxIkN7oxt06CZ51D65ugIb1UWRQ8oQe+HXAVM6qHFjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==}
@@ -3948,15 +3820,15 @@ packages:
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-7GAsGlK4cNL2OExJH1DzmDeKnRv/LXq0eLUSvudrehVA5Rgg4bIrqEUW29FbKMBRT0ztSqisv7kjP+XIC4ZMNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.3)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.1)
 
   /@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==}
@@ -3986,17 +3858,17 @@ packages:
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-XjD5f0YqOtebto4HGISLNfiNMTTs6tbkFf2TOqJlYKYmbo+mN9Dnpl4SRoofiziuOWMIyq3sZEUqLo3hLITFEA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.23.3)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.1)
 
   /@babel/plugin-transform-object-super@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==}
@@ -4020,15 +3892,15 @@ packages:
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-object-super@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-object-super@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.3)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.1)
 
   /@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==}
@@ -4052,15 +3924,15 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==}
@@ -4086,16 +3958,16 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-optional-chaining@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-optional-chaining@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-n03wmDt+987qXwAgcBlnUUivrZBPZ8z1plL0YvgQalLm+ZE5BMhGm94jhxXtA1wzv1Cu2aaOv1BM9vbVttrzSg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.3)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.1)
 
   /@babel/plugin-transform-parameters@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==}
@@ -4117,24 +3989,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-parameters@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-parameters@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-parameters@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==}
@@ -4158,26 +4020,15 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==}
@@ -4205,30 +4056,17 @@ packages:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.0)
     dev: true
 
-  /@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-pTHxDVa0BpUbvAgX3Gat+7cSciXqUcY9j2VZKTbSB6+VQGpNgNO9ailxTGHSXlqOnX1Hcx1Enme2+yv7VqP9bg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.3)
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.3)
-
-  /@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-pTHxDVa0BpUbvAgX3Gat+7cSciXqUcY9j2VZKTbSB6+VQGpNgNO9ailxTGHSXlqOnX1Hcx1Enme2+yv7VqP9bg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.0)
-    dev: false
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.1)
 
   /@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==}
@@ -4250,13 +4088,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.23.3):
@@ -4269,24 +4107,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-react-display-name@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-mvoQg2f9p2qlpDQRBC7M3c3XTr0k7cp/0+kFKKO/7Gtu0LSw16eKB+Fabe2bDT/UpsyasTBBkAnbdsLrkD5XMw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.3):
     resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
@@ -4318,24 +4146,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx-self@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-react-jsx-self@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-kDJgnPujTmAZ/9q2CN4m2/lRsUUPDvsG3+tSHWUJIzMGTt5U/b/fwWd3RO3n+5mjLrsBrVa5eKFRVSQbi3dF1w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-react-jsx-self@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-kDJgnPujTmAZ/9q2CN4m2/lRsUUPDvsG3+tSHWUJIzMGTt5U/b/fwWd3RO3n+5mjLrsBrVa5eKFRVSQbi3dF1w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==}
@@ -4357,24 +4175,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-react-jsx-source@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-react-jsx-source@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-1v202n7aUq4uXAieRTKcwPzNyphlCuqHHDcdSNc+vdhoTEZcFMh+L5yZuCmGaIO7bs1nJUNfHB89TZyoL48xNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-react-jsx-source@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-1v202n7aUq4uXAieRTKcwPzNyphlCuqHHDcdSNc+vdhoTEZcFMh+L5yZuCmGaIO7bs1nJUNfHB89TZyoL48xNA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.3):
     resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
@@ -4388,20 +4196,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.3)
       '@babel/types': 7.23.4
-
-  /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.0):
-    resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.24.1
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.0)
-      '@babel/types': 7.23.4
-    dev: false
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.1):
     resolution: {integrity: sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==}
@@ -4415,7 +4210,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.1)
       '@babel/types': 7.23.4
-    dev: true
 
   /@babel/plugin-transform-react-pure-annotations@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-qMFdSS+TUhB7Q/3HVPnEdYJDQIk57jkntAwSuz9xfSE4n+3I+vHYCli3HoHawN1Z3RfCz/y1zXA/JXjG6cVImQ==}
@@ -4450,13 +4244,13 @@ packages:
       regenerator-transform: 0.15.2
     dev: true
 
-  /@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
       regenerator-transform: 0.15.2
 
@@ -4480,13 +4274,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-runtime@7.23.4(@babel/core@7.23.3):
@@ -4506,38 +4300,21 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-runtime@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-runtime@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-yHLX14/T+tO0gjgJroDb8JYjOcQuzVC+Brt4CjHAxq/Ghw4xBVG+N02d1rMEcyUnKUQBL4Yy2gA9R72GK961jQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-module-imports': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.23.3)
-      babel-plugin-polyfill-corejs3: 0.10.1(@babel/core@7.23.3)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.23.3)
+      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.24.1)
+      babel-plugin-polyfill-corejs3: 0.10.1(@babel/core@7.24.1)
+      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.24.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/plugin-transform-runtime@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-yHLX14/T+tO0gjgJroDb8JYjOcQuzVC+Brt4CjHAxq/Ghw4xBVG+N02d1rMEcyUnKUQBL4Yy2gA9R72GK961jQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-module-imports': 7.24.1
-      '@babel/helper-plugin-utils': 7.24.0
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.24.0)
-      babel-plugin-polyfill-corejs3: 0.10.1(@babel/core@7.24.0)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.24.0)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==}
@@ -4559,24 +4336,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-spread@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==}
@@ -4600,26 +4367,15 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-spread@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-spread@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-
-  /@babel/plugin-transform-spread@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-    dev: false
 
   /@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==}
@@ -4641,24 +4397,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==}
@@ -4680,13 +4426,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.23.3):
@@ -4709,13 +4455,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-typeof-symbol@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-CBfU4l/A+KruSUoW+vTQthwcAdwuqbpRNB8HQKlZABwHRhsdHZ9fezp4Sn18PeAlYxTNiLMlx4xUBV3AWfg1BA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-typescript@7.23.4(@babel/core@7.23.3):
@@ -4743,31 +4489,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.0)
     dev: true
-
-  /@babel/plugin-transform-typescript@7.24.1(@babel/core@7.23.3):
-    resolution: {integrity: sha512-liYSESjX2fZ7JyBFkYG78nfvHlMKE6IpNdTVnxmlYUR+j5ZLsitFbaAE+eJSK2zPPkNWNw4mXL51rQ8WrvdK0w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.3)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.23.3)
-
-  /@babel/plugin-transform-typescript@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-liYSESjX2fZ7JyBFkYG78nfvHlMKE6IpNdTVnxmlYUR+j5ZLsitFbaAE+eJSK2zPPkNWNw4mXL51rQ8WrvdK0w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.0)
-    dev: false
 
   /@babel/plugin-transform-typescript@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-liYSESjX2fZ7JyBFkYG78nfvHlMKE6IpNdTVnxmlYUR+j5ZLsitFbaAE+eJSK2zPPkNWNw4mXL51rQ8WrvdK0w==}
@@ -4801,13 +4522,13 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.23.3):
@@ -4832,14 +4553,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-Ss4VvlfYV5huWApFsF8/Sq0oXnGO+jB+rijFEFugTd3cwSObUSnUi88djgR5528Csl0uKlrI331kRqe56Ov2Ng==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.23.3):
@@ -4864,26 +4585,15 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
-
-  /@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.0)
-      '@babel/helper-plugin-utils': 7.24.0
-    dev: false
 
   /@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==}
@@ -4907,14 +4617,14 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.23.3):
+  /@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-fqj4WuzzS+ukpgerpAoOnMfQXwUHFxXUZUE84oL2Kao2N8uSlvcpnAidKASgsNgzZHBsHWvcm8s9FPWUhAb8fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/preset-env@7.23.3(@babel/core@7.23.3):
@@ -5099,91 +4809,91 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/preset-env@7.24.1(@babel/core@7.23.3):
+  /@babel/preset-env@7.24.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-CwCMz1Z28UHLI2iE+cbnWT2epPMV9bzzoBGM6A3mOS22VQd/1TPoWItV7S7iL9TkPmPEf5L/QzurmztyyDN9FA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.24.1
-      '@babel/core': 7.23.3
+      '@babel/core': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.3)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.3)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.3)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.3)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.3)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.3)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.3)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-async-generator-functions': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-class-static-block': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.3)
-      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-typeof-symbol': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.23.3)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.3)
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.23.3)
-      babel-plugin-polyfill-corejs3: 0.10.1(@babel/core@7.23.3)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.23.3)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.1)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.1)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.1)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.1)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.1)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.1)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.1)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.1)
+      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-async-generator-functions': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-class-static-block': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.1)
+      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-typeof-symbol': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.24.1)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.1)
+      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.24.1)
+      babel-plugin-polyfill-corejs3: 0.10.1(@babel/core@7.24.1)
+      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.24.1)
       core-js-compat: 3.36.1
       semver: 6.3.1
     transitivePeerDependencies:
@@ -5221,6 +4931,7 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.4
       esutils: 2.0.3
+    dev: true
 
   /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.0):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
@@ -5232,6 +4943,16 @@ packages:
       '@babel/types': 7.23.4
       esutils: 2.0.3
     dev: true
+
+  /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.1):
+    resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
+    dependencies:
+      '@babel/core': 7.24.1
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/types': 7.23.4
+      esutils: 2.0.3
 
   /@babel/preset-react@7.23.3(@babel/core@7.23.3):
     resolution: {integrity: sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==}
@@ -5376,6 +5097,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.24.0:
     resolution: {integrity: sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==}
@@ -5393,6 +5115,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.24.1(supports-color@5.5.0):
     resolution: {integrity: sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==}
@@ -7184,6 +6907,7 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@jridgewell/trace-mapping@0.3.25:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -7435,7 +7159,7 @@ packages:
       qrcode-terminal-nooctal: 0.12.1
       react: 18.2.0
       react-i18next: 13.5.0(i18next@22.5.1)(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0)
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.24.1)(react@18.2.0)
+      react-native: 0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0)
       react-native-webview: 11.26.1(react-native@0.73.6)(react@18.2.0)
       readable-stream: 2.3.8
       rollup-plugin-visualizer: 5.11.0
@@ -7482,7 +7206,7 @@ packages:
       qrcode-terminal-nooctal: 0.12.1
       react: 18.2.0
       react-i18next: 13.5.0(i18next@22.5.1)(react-dom@18.2.0)(react-native@0.73.6)(react@18.2.0)
-      react-native: 0.73.6(@babel/core@7.24.0)(@babel/preset-env@7.24.1)(react@18.2.0)
+      react-native: 0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0)
       react-native-webview: 11.26.1(react-native@0.73.6)(react@18.2.0)
       readable-stream: 2.3.8
       rollup-plugin-visualizer: 5.11.0
@@ -8481,6 +8205,17 @@ packages:
       - typescript
       - utf-8-validate
       - zod
+    dev: false
+
+  /@privy-io/server-auth@1.7.2:
+    resolution: {integrity: sha512-0/BNu5IX9DEg29XHN1Ml98W2dAu07KY/Y5KZCnN46XyvOYUex1slxKJhsPfnsFhVwfiGdp/aYcyn6Q150mcypA==}
+    dependencies:
+      dotenv: 16.4.1
+      jose: 4.15.5
+      node-fetch-native: 1.6.2
+      redaxios: 0.5.1
+      ts-case-convert: 2.0.7
+      type-fest: 3.13.1
     dev: false
 
   /@radix-ui/number@1.0.1:
@@ -9907,7 +9642,7 @@ packages:
       react-native: ^0.0.0-0 || >=0.60 <1.0
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.24.1)(react@18.2.0)
+      react-native: 0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0)
 
   /@react-native-community/cli-clean@12.3.6:
     resolution: {integrity: sha512-gUU29ep8xM0BbnZjwz9MyID74KKwutq9x5iv4BCr2im6nly4UMf1B1D+V225wR7VcDGzbgWjaezsJShLLhC5ig==}
@@ -10077,110 +9812,57 @@ packages:
       - '@babel/preset-env'
       - supports-color
 
-  /@react-native/babel-preset@0.73.21(@babel/core@7.23.3)(@babel/preset-env@7.24.1):
+  /@react-native/babel-preset@0.73.21(@babel/core@7.24.1)(@babel/preset-env@7.24.1):
     resolution: {integrity: sha512-WlFttNnySKQMeujN09fRmrdWqh46QyJluM5jdtDNrkl/2Hx6N4XeDUGhABvConeK95OidVO7sFFf7sNebVXogA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.23.3)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-export-default-from': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.3)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.3)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-flow-strip-types': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-runtime': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-typescript': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.1)
+      '@babel/plugin-proposal-export-default-from': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.1)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.1)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.1)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.1)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.1)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.1)
+      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-flow-strip-types': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.1)
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.1)
+      '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-runtime': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-typescript': 7.24.1(@babel/core@7.24.1)
+      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.24.1)
       '@babel/template': 7.24.0
       '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.24.1)
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.23.3)
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.1)
       react-refresh: 0.14.0
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
-
-  /@react-native/babel-preset@0.73.21(@babel/core@7.24.0)(@babel/preset-env@7.24.1):
-    resolution: {integrity: sha512-WlFttNnySKQMeujN09fRmrdWqh46QyJluM5jdtDNrkl/2Hx6N4XeDUGhABvConeK95OidVO7sFFf7sNebVXogA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@babel/core': '*'
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.0)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.0)
-      '@babel/plugin-proposal-export-default-from': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.0)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.0)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.0)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.0)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.0)
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.0)
-      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-flow-strip-types': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.0)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.0)
-      '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-runtime': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-typescript': 7.24.1(@babel/core@7.24.0)
-      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.24.0)
-      '@babel/template': 7.24.0
-      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.24.1)
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.0)
-      react-refresh: 0.14.0
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-    dev: false
 
   /@react-native/codegen@0.73.3(@babel/preset-env@7.24.1):
     resolution: {integrity: sha512-sxslCAAb8kM06vGy9Jyh4TtvjhcP36k/rvj2QE2Jdhdm61KvfafCATSIsOfc0QvnduWFcpXUPvAVyYwuv7PYDg==}
@@ -10189,7 +9871,7 @@ packages:
       '@babel/preset-env': ^7.1.6
     dependencies:
       '@babel/parser': 7.24.1
-      '@babel/preset-env': 7.24.1(@babel/core@7.23.3)
+      '@babel/preset-env': 7.24.1(@babel/core@7.24.1)
       flow-parser: 0.206.0
       glob: 7.2.3
       invariant: 2.2.4
@@ -10199,14 +9881,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@react-native/community-cli-plugin@0.73.17(@babel/core@7.23.3)(@babel/preset-env@7.24.1):
+  /@react-native/community-cli-plugin@0.73.17(@babel/core@7.24.1)(@babel/preset-env@7.24.1):
     resolution: {integrity: sha512-F3PXZkcHg+1ARIr6FRQCQiB7ZAA+MQXGmq051metRscoLvgYJwj7dgC8pvgy0kexzUkHu5BNKrZeySzUft3xuQ==}
     engines: {node: '>=18'}
     dependencies:
       '@react-native-community/cli-server-api': 12.3.6
       '@react-native-community/cli-tools': 12.3.6
       '@react-native/dev-middleware': 0.73.8
-      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.23.3)(@babel/preset-env@7.24.1)
+      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.24.1)(@babel/preset-env@7.24.1)
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.7
@@ -10221,30 +9903,6 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
-
-  /@react-native/community-cli-plugin@0.73.17(@babel/core@7.24.0)(@babel/preset-env@7.24.1):
-    resolution: {integrity: sha512-F3PXZkcHg+1ARIr6FRQCQiB7ZAA+MQXGmq051metRscoLvgYJwj7dgC8pvgy0kexzUkHu5BNKrZeySzUft3xuQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@react-native-community/cli-server-api': 12.3.6
-      '@react-native-community/cli-tools': 12.3.6
-      '@react-native/dev-middleware': 0.73.8
-      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.24.0)(@babel/preset-env@7.24.1)
-      chalk: 4.1.2
-      execa: 5.1.1
-      metro: 0.80.7
-      metro-config: 0.80.7
-      metro-core: 0.80.7
-      node-fetch: 2.7.0(encoding@0.1.13)
-      readline: 1.3.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: false
 
   /@react-native/debugger-frontend@0.73.3:
     resolution: {integrity: sha512-RgEKnWuoo54dh7gQhV7kvzKhXZEhpF9LlMdZolyhGxHsBqZ2gXdibfDlfcARFFifPIiaZ3lXuOVVa4ei+uPgTw==}
@@ -10279,34 +9937,19 @@ packages:
     resolution: {integrity: sha512-ewMwGcumrilnF87H4jjrnvGZEaPFCAC4ebraEK+CurDDmwST/bIicI4hrOAv+0Z0F7DEK4O4H7r8q9vH7IbN4g==}
     engines: {node: '>=18'}
 
-  /@react-native/metro-babel-transformer@0.73.15(@babel/core@7.23.3)(@babel/preset-env@7.24.1):
+  /@react-native/metro-babel-transformer@0.73.15(@babel/core@7.24.1)(@babel/preset-env@7.24.1):
     resolution: {integrity: sha512-LlkSGaXCz+xdxc9819plmpsl4P4gZndoFtpjN3GMBIu6f7TBV0GVbyJAU4GE8fuAWPVSVL5ArOcdkWKSbI1klw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.23.3
-      '@react-native/babel-preset': 0.73.21(@babel/core@7.23.3)(@babel/preset-env@7.24.1)
+      '@babel/core': 7.24.1
+      '@react-native/babel-preset': 0.73.21(@babel/core@7.24.1)(@babel/preset-env@7.24.1)
       hermes-parser: 0.15.0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
-
-  /@react-native/metro-babel-transformer@0.73.15(@babel/core@7.24.0)(@babel/preset-env@7.24.1):
-    resolution: {integrity: sha512-LlkSGaXCz+xdxc9819plmpsl4P4gZndoFtpjN3GMBIu6f7TBV0GVbyJAU4GE8fuAWPVSVL5ArOcdkWKSbI1klw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@babel/core': '*'
-    dependencies:
-      '@babel/core': 7.24.0
-      '@react-native/babel-preset': 0.73.21(@babel/core@7.24.0)(@babel/preset-env@7.24.1)
-      hermes-parser: 0.15.0
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-    dev: false
 
   /@react-native/normalize-colors@0.73.2:
     resolution: {integrity: sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==}
@@ -10319,7 +9962,7 @@ packages:
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.24.1)(react@18.2.0)
+      react-native: 0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0)
 
   /@remix-run/router@1.13.1:
     resolution: {integrity: sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==}
@@ -12108,6 +11751,12 @@ packages:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
       '@types/node': 20.11.25
+
+  /@types/cookie-parser@1.4.7:
+    resolution: {integrity: sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==}
+    dependencies:
+      '@types/express': 4.17.21
+    dev: true
 
   /@types/cookie@0.6.0:
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -14911,30 +14560,17 @@ packages:
       cosmiconfig: 7.1.0
       resolve: 1.22.8
 
-  /babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.23.3):
+  /babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.24.1):
     resolution: {integrity: sha512-rpIuu//y5OX6jVU+a5BCn1R5RSZYWAl2Nar76iwaOdycqb6JPxediskWFMMl7stfwNJR4b7eiQvh5fB5TEQJTQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
       '@babel/compat-data': 7.24.1
-      '@babel/core': 7.23.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  /babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.24.0):
-    resolution: {integrity: sha512-rpIuu//y5OX6jVU+a5BCn1R5RSZYWAl2Nar76iwaOdycqb6JPxediskWFMMl7stfwNJR4b7eiQvh5fB5TEQJTQ==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/compat-data': 7.24.1
-      '@babel/core': 7.24.0
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.0)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.23.3):
     resolution: {integrity: sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==}
@@ -14962,28 +14598,16 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3@0.10.1(@babel/core@7.23.3):
+  /babel-plugin-polyfill-corejs3@0.10.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-XiFei6VGwM4ii6nKC1VCenGD8Z4bjiNYcrdkM8oqM3pbuemmyb8biMgrDX1ZHSbIuMLXatM6JJ/StPYIuTl6MQ==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.1)
       core-js-compat: 3.36.1
     transitivePeerDependencies:
       - supports-color
-
-  /babel-plugin-polyfill-corejs3@0.10.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-XiFei6VGwM4ii6nKC1VCenGD8Z4bjiNYcrdkM8oqM3pbuemmyb8biMgrDX1ZHSbIuMLXatM6JJ/StPYIuTl6MQ==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.0)
-      core-js-compat: 3.36.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /babel-plugin-polyfill-corejs3@0.8.6(@babel/core@7.23.3):
     resolution: {integrity: sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==}
@@ -15031,26 +14655,15 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.23.3):
+  /babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.24.1):
     resolution: {integrity: sha512-JfTApdE++cgcTWjsiCQlLyFBMbTUft9ja17saCc93lgV33h4tuCVj7tlvu//qpLwaG+3yEz7/KhahGrUMkVq9g==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
     dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.3)
+      '@babel/core': 7.24.1
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.1)
     transitivePeerDependencies:
       - supports-color
-
-  /babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.24.0):
-    resolution: {integrity: sha512-JfTApdE++cgcTWjsiCQlLyFBMbTUft9ja17saCc93lgV33h4tuCVj7tlvu//qpLwaG+3yEz7/KhahGrUMkVq9g==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.24.0
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.0)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /babel-plugin-styled-components@2.1.4(@babel/core@7.24.1)(styled-components@5.3.11):
     resolution: {integrity: sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==}
@@ -15067,20 +14680,12 @@ packages:
       - '@babel/core'
     dev: false
 
-  /babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.23.3):
+  /babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.24.1):
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
     dependencies:
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.23.3)
+      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.1)
     transitivePeerDependencies:
       - '@babel/core'
-
-  /babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.24.0):
-    resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-    dev: false
 
   /babel-plugin-transform-react-remove-prop-types@0.4.24:
     resolution: {integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==}
@@ -16044,8 +15649,21 @@ packages:
   /cookie-es@1.0.0:
     resolution: {integrity: sha512-mWYvfOLrfEc996hlKcdABeIiPHUPC6DM2QYZdGGOvhOTbA3tjm2eBwqlJpoFdjC89NI4Qt6h0Pu06Mp+1Pj5OQ==}
 
+  /cookie-parser@1.4.6:
+    resolution: {integrity: sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      cookie: 0.4.1
+      cookie-signature: 1.0.6
+    dev: false
+
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  /cookie@0.4.1:
+    resolution: {integrity: sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
@@ -20121,7 +19739,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.1)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.1)
       '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.1)
-      '@babel/preset-env': 7.24.1(@babel/core@7.23.3)
+      '@babel/preset-env': 7.24.1(@babel/core@7.24.1)
       '@babel/preset-flow': 7.24.1(@babel/core@7.24.1)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.1)
       '@babel/register': 7.23.7(@babel/core@7.24.1)
@@ -22886,7 +22504,7 @@ packages:
       i18next: 22.5.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.24.1)(react@18.2.0)
+      react-native: 0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0)
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -22921,9 +22539,9 @@ packages:
       escape-string-regexp: 2.0.0
       invariant: 2.2.4
       react: 18.2.0
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.24.1)(react@18.2.0)
+      react-native: 0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0)
 
-  /react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.24.1)(react@18.2.0):
+  /react-native@0.73.6(@babel/core@7.24.1)(@babel/preset-env@7.24.1)(react@18.2.0):
     resolution: {integrity: sha512-oqmZe8D2/VolIzSPZw+oUd6j/bEmeRHwsLn1xLA5wllEYsZ5zNuMsDus235ONOnCRwexqof/J3aztyQswSmiaA==}
     engines: {node: '>=18'}
     hasBin: true
@@ -22936,7 +22554,7 @@ packages:
       '@react-native-community/cli-platform-ios': 12.3.6
       '@react-native/assets-registry': 0.73.1
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.24.1)
-      '@react-native/community-cli-plugin': 0.73.17(@babel/core@7.23.3)(@babel/preset-env@7.24.1)
+      '@react-native/community-cli-plugin': 0.73.17(@babel/core@7.24.1)(@babel/preset-env@7.24.1)
       '@react-native/gradle-plugin': 0.73.4
       '@react-native/js-polyfills': 0.73.1
       '@react-native/normalize-colors': 0.73.2
@@ -22976,61 +22594,6 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
-
-  /react-native@0.73.6(@babel/core@7.24.0)(@babel/preset-env@7.24.1)(react@18.2.0):
-    resolution: {integrity: sha512-oqmZe8D2/VolIzSPZw+oUd6j/bEmeRHwsLn1xLA5wllEYsZ5zNuMsDus235ONOnCRwexqof/J3aztyQswSmiaA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      react: 18.2.0
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 12.3.6
-      '@react-native-community/cli-platform-android': 12.3.6
-      '@react-native-community/cli-platform-ios': 12.3.6
-      '@react-native/assets-registry': 0.73.1
-      '@react-native/codegen': 0.73.3(@babel/preset-env@7.24.1)
-      '@react-native/community-cli-plugin': 0.73.17(@babel/core@7.24.0)(@babel/preset-env@7.24.1)
-      '@react-native/gradle-plugin': 0.73.4
-      '@react-native/js-polyfills': 0.73.1
-      '@react-native/normalize-colors': 0.73.2
-      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.6)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      base64-js: 1.5.1
-      chalk: 4.1.2
-      deprecated-react-native-prop-types: 5.0.0
-      event-target-shim: 5.0.1
-      flow-enums-runtime: 0.0.6
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      jsc-android: 250231.0.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.80.7
-      metro-source-map: 0.80.7
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-      pretty-format: 26.6.2
-      promise: 8.3.0
-      react: 18.2.0
-      react-devtools-core: 4.28.5
-      react-refresh: 0.14.0
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      scheduler: 0.24.0-canary-efb381bbf-20230505
-      stacktrace-parser: 0.1.10
-      whatwg-fetch: 3.6.20
-      ws: 6.2.2
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: false
 
   /react-reconciler@0.29.0(react@18.2.0):
     resolution: {integrity: sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==}
@@ -23354,6 +22917,10 @@ packages:
       tiny-invariant: 1.3.3
       tslib: 2.6.2
     dev: true
+
+  /redaxios@0.5.1:
+    resolution: {integrity: sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg==}
+    dev: false
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -24893,6 +24460,10 @@ packages:
     dependencies:
       typescript: 5.4.2
     dev: true
+
+  /ts-case-convert@2.0.7:
+    resolution: {integrity: sha512-Kqj8wrkuduWsKUOUNRczrkdHCDt4ZNNd6HKjVw42EnMIGHQUABS4pqfy0acETVLwUTppc1fzo/yi11+uMTaqzw==}
+    dev: false
 
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecopod/issues/887
Closes https://github.com/ethereum-optimism/ecopod/issues/882

This middleware should guard any trpc routes that require privy authentication. This middleware does the following:
- verifies that the request coming from the frontend has a valid access token provided by privy 
- if the access token is valid, then the access token, expiration time, and entity id are written to the iron session
- revalidates the privy access token in the following scenarios:
  - the access token expires
  - a new access token is sent to the backend
  - the `user` key does not exist on the iron session