### PR TITLE
feat(dapp-console): create endpoint for logging user out

### DIFF
--- a/apps/dapp-console-api/src/Service.ts
+++ b/apps/dapp-console-api/src/Service.ts
@@ -23,6 +23,7 @@ import { ensureAdmin } from './auth'
 import { corsAllowlist, envVars } from './constants'
 import { connectToDatabase, runMigrations } from './db'
 import { metrics } from './monitoring/metrics'
+import { AuthRoute } from './routes/auth'
 import { Trpc } from './Trpc'
 import { retryWithBackoff } from './utils'
 
@@ -121,12 +122,16 @@ export class Service {
      */
     const trpc = new Trpc(privy, logger, appDB)
 
+    const authRoute = new AuthRoute(trpc)
+
     /**
      * The apiServer simply assmbles the routes into a TRPC Server
      */
-    const apiServer = new ApiV0(trpc, {})
+    const apiServer = new ApiV0(trpc, { authRoute })
+    apiServer.setLoggingServer(logger)
 
     const adminServer = new AdminApi(trpc, {})
+    adminServer.setLoggingServer(logger)
 
     const service = new Service(apiServer, middleware, logger, adminServer)
 

--- a/apps/dapp-console-api/src/api/ApiV0.ts
+++ b/apps/dapp-console-api/src/api/ApiV0.ts
@@ -1,3 +1,5 @@
+import type { AuthRoute } from '@/routes/auth'
+
 import { MajorApiVersion } from '../constants'
 import type { Trpc } from '../Trpc'
 import { Api } from './Api'
@@ -27,7 +29,7 @@ export class ApiV0 extends Api {
      * from time to time we will delete old api versions if they are no longer used
      */
     ...this.commonRoutes,
-    // TODO add screening route
+    [this.routes.authRoute.name]: this.routes.authRoute.handler,
   })
 
   /**
@@ -35,7 +37,9 @@ export class ApiV0 extends Api {
    */
   constructor(
     trpc: Trpc,
-    protected readonly routes: {},
+    protected readonly routes: {
+      authRoute: AuthRoute
+    },
   ) {
     super(trpc)
   }

--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -8,4 +8,13 @@ export const metrics = {
     help: 'Number of unhandled API server errors',
     labelNames: ['apiVersion'] as const,
   }),
+  trpcServerErrorCount: new Counter({
+    name: 'trpc_server_total_error_count',
+    help: 'Total number of errors encounterted in trpc server',
+    labelNames: ['apiVersion'] as const,
+  }),
+  logoutUserErrorCount: new Counter({
+    name: 'logout_user_error_count',
+    help: 'Total number of errors encountered while logging user out',
+  }),
 }

--- a/apps/dapp-console-api/src/routes/auth/AuthRoute.spec.ts
+++ b/apps/dapp-console-api/src/routes/auth/AuthRoute.spec.ts
@@ -1,0 +1,40 @@
+import type { RouterCaller } from '@trpc/server'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  createSignedInCaller,
+  mockDB,
+  mockLogger,
+  mockPrivyClient,
+  mockUserSession,
+} from '@/testhelpers'
+import { Trpc } from '@/Trpc'
+
+import { AuthRoute } from './AuthRoute'
+
+describe(AuthRoute.name, () => {
+  let trpc: Trpc
+  let caller: ReturnType<RouterCaller<AuthRoute['handler']['_def']>>
+  const session = mockUserSession({
+    entityId: 'id1',
+    privyAccessTokenExpiration: Date.now(),
+    privyAccessToken: 'accessToken',
+    privyDid: 'privy:did',
+  })
+
+  beforeEach(() => {
+    const privyClient = mockPrivyClient()
+
+    trpc = new Trpc(privyClient, mockLogger, mockDB)
+    const route = new AuthRoute(trpc).handler
+    caller = createSignedInCaller(route, session)
+  })
+
+  it('logoutUser deletes the users session', async () => {
+    expect(session.user).toBeDefined()
+
+    await caller.logoutUser()
+
+    expect(session.user).toBeUndefined()
+  })
+})

--- a/apps/dapp-console-api/src/routes/auth/AuthRoute.ts
+++ b/apps/dapp-console-api/src/routes/auth/AuthRoute.ts
@@ -1,0 +1,31 @@
+import { metrics } from '@/monitoring/metrics'
+import { Trpc } from '@/Trpc'
+
+import { Route } from '../Route'
+
+export class AuthRoute extends Route {
+  public readonly name = 'auth' as const
+
+  public readonly logoutUser = 'logoutUser' as const
+  public readonly logoutUserController = this.trpc.procedure.mutation(
+    async ({ ctx }) => {
+      try {
+        const { session } = ctx
+
+        delete session.user
+
+        await session.save()
+
+        return { success: true }
+      } catch (err) {
+        metrics.logoutUserErrorCount.inc()
+        this.logger?.error(err, 'error saving user session')
+        throw Trpc.handleStatus(500, 'error saving user session')
+      }
+    },
+  )
+
+  public readonly handler = this.trpc.router({
+    [this.logoutUser]: this.logoutUserController,
+  })
+}

--- a/apps/dapp-console-api/src/routes/auth/index.ts
+++ b/apps/dapp-console-api/src/routes/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './AuthRoute'

--- a/apps/dapp-console-api/src/testhelpers/auth.ts
+++ b/apps/dapp-console-api/src/testhelpers/auth.ts
@@ -1,0 +1,65 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+import type { AnyRouter } from '@trpc/server'
+import { createCallerFactory } from '@trpc/server'
+import type { Request, Response } from 'express'
+import type { getIronSession } from 'iron-session'
+import { type Mock, vi } from 'vitest'
+
+import type { SessionData } from '@/constants'
+import { PRIVY_TOKEN_COOKIE_KEY } from '@/constants'
+import type { Session } from '@/constants/session'
+import { getEntity, insertEntity } from '@/models'
+
+vi.mock('../models', async () => ({
+  // @ts-ignore - importActual returns unknown
+  ...(await vi.importActual('../models')),
+  getEntity: vi.fn().mockImplementation(async () => undefined),
+  insertEntity: vi.fn().mockImplementation(async () => undefined),
+}))
+
+export const mockPrivyAccessToken = 'privy_token'
+
+export const createSignedInCaller = <T extends AnyRouter>(
+  router: T,
+  session: Awaited<ReturnType<typeof getIronSession<SessionData>>>,
+  privyAccessToken?: string,
+) => {
+  const callerFactory = createCallerFactory()
+  const createCaller = callerFactory(router)
+  return createCaller({
+    req: {
+      cookies: {
+        [PRIVY_TOKEN_COOKIE_KEY]: privyAccessToken || mockPrivyAccessToken,
+      } as any,
+    } as Request,
+    res: {} as Response,
+    session: session,
+  })
+}
+
+export const createSignedOutCaller = <T extends AnyRouter>(router: T) => {
+  const callerFactory = createCallerFactory()
+  const createCaller = callerFactory(router)
+  return createCaller({
+    req: {
+      cookies: {},
+    } as Request,
+    res: {} as Response,
+    session: {} as Session,
+  })
+}
+
+/** Sets up the mocks required for authentication. */
+export const configureAuthMocks = (privyClient: PrivyClient) => {
+  const verifyAuthTokenMock = privyClient.verifyAuthToken as Mock
+  verifyAuthTokenMock.mockImplementation(async () => ({}))
+  const getEntityMock = getEntity as Mock
+  getEntityMock.mockImplementation(async () => ({}))
+  const insertEntityMock = insertEntity as Mock
+  insertEntityMock.mockImplementation(async () => ({}))
+  return {
+    verifyAuthTokenMock,
+    getEntityMock,
+    insertEntityMock,
+  }
+}

--- a/apps/dapp-console-api/src/testhelpers/index.ts
+++ b/apps/dapp-console-api/src/testhelpers/index.ts
@@ -1,3 +1,5 @@
+export * from './auth'
 export * from './MockDB'
 export * from './MockLogger'
 export * from './MockPrivyClient'
+export * from './session'

--- a/apps/dapp-console-api/src/testhelpers/session.ts
+++ b/apps/dapp-console-api/src/testhelpers/session.ts
@@ -1,0 +1,15 @@
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+import type { SessionData } from '@/constants'
+
+export const mockUserSession = (user?: SessionData['user']) => ({
+  ...(user && {
+    user: {
+      ...user,
+    },
+  }),
+  save: vi.fn() as Mock,
+  destroy: vi.fn() as Mock,
+  updateConfig: vi.fn() as Mock,
+})

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/Service.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/Service.ts
@@ -95,16 +95,18 @@ export class Service {
      */
     const trpc = new Trpc()
 
+    const logger = pino().child({
+      namespace: '<%= name %>-server',
+    })
+
     /**
      * The apiServer simply assmbles the routes into a TRPC Server
      */
     const apiServer = new ApiV0(trpc, {})
-
-    const logger = pino().child({
-      namespace: 'api-server',
-    })
+    apiServer.setLoggingServer(logger)
 
     const adminServer = new AdminApi(trpc, {})
+    adminServer.setLoggingServer(logger)
 
     const service = new Service(apiServer, middleware, logger, adminServer)
 

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/monitoring/metrics.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/monitoring/metrics.ts
@@ -8,4 +8,9 @@ export const metrics = {
     help: 'Number of unhandled API server errors',
     labelNames: ['apiVersion'] as const,
   }),
+  trpcServerErrorCount: new Counter({
+    name: 'trpc_server_total_error_count',
+    help: 'Total number of errors encounterted in trpc server',
+    labelNames: ['apiVersion'] as const,
+  }),
 }


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/892

Logs the user out by deleting the user key on the iron session. This assumes that the frontend will handle logging the user out of privy.