### PR TITLE
feat(api-key-service): add api-keys table

### DIFF
--- a/apps/api-key-service/docker-compose.yml
+++ b/apps/api-key-service/docker-compose.yml
@@ -1,6 +1,21 @@
 version: '3.8'
 
 services:
+  postgres:
+    image: postgres:latest
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'pg_isready -q -U api-key-service@oplabs-local-web.iam -d api-key-service',
+        ]
+    volumes:
+      - ./setup-local-db.sql:/docker-entrypoint-initdb.d/setup-local-db.sql
+    ports:
+      - '5432:5432'
+
   api-key-service:
     build:
       context: ../../

--- a/apps/api-key-service/drizzle.config.ts
+++ b/apps/api-key-service/drizzle.config.ts
@@ -1,0 +1,17 @@
+import * as dotenv from 'dotenv'
+import type { Config } from 'drizzle-kit'
+
+dotenv.config()
+
+export default {
+  schema: './src/models/*',
+  out: './migrations',
+  driver: 'pg',
+  dbCredentials: {
+    host: process.env.DB_HOST ?? '0.0.0.0',
+    port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 5432,
+    user: process.env.MIGRATE_DB_USER,
+    password: process.env.MIGRATE_DB_PASSWORD,
+    database: process.env.DB_NAME ?? 'api-key-service',
+  },
+} satisfies Config

--- a/apps/api-key-service/migrations/0000_broad_justin_hammer.sql
+++ b/apps/api-key-service/migrations/0000_broad_justin_hammer.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "api-keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"entity_id" uuid NOT NULL,
+	"key" varchar NOT NULL,
+	"state" varchar NOT NULL,
+	"state_updated_at" timestamp with time zone,
+	"deleted_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "api-keys_deleted_at_index" ON "api-keys" ("deleted_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "api-keys_entity_id_deleted_at_index" ON "api-keys" ("entity_id","deleted_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "api-keys_key_index" ON "api-keys" ("key");

--- a/apps/api-key-service/migrations/meta/0000_snapshot.json
+++ b/apps/api-key-service/migrations/meta/0000_snapshot.json
@@ -1,0 +1,99 @@
+{
+  "id": "196c8f4f-6acb-40da-9c7e-a89fcbdad67e",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "api-keys": {
+      "name": "api-keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_updated_at": {
+          "name": "state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api-keys_deleted_at_index": {
+          "name": "api-keys_deleted_at_index",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "api-keys_entity_id_deleted_at_index": {
+          "name": "api-keys_entity_id_deleted_at_index",
+          "columns": [
+            "entity_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "api-keys_key_index": {
+          "name": "api-keys_key_index",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api-key-service/migrations/meta/_journal.json
+++ b/apps/api-key-service/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1712879413323,
+      "tag": "0000_broad_justin_hammer",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api-key-service/package.json
+++ b/apps/api-key-service/package.json
@@ -11,11 +11,16 @@
     "dev": "tsup --watch --onSuccess 'node dist/run.js'",
     "build": "tsup",
     "start": "node dist/run.js",
+    "docker:services:up": "docker compose up -d postgres",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
     "lint:ci": "eslint \"**/*.{ts,tsx}\" --quiet && pnpm prettier --check \"**/*.{ts,tsx}\"",
-    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn"
+    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn",
+    "drizzle:studio": "pnpm drizzle-kit studio",
+    "migrations:generate": "drizzle-kit generate:pg",
+    "migrations:execute": "pnpm ts-node ./scripts/db-migrate",
+    "migrations:dev": "pnpm migrations:generate && pnpm migrations:execute"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.5",
@@ -24,10 +29,12 @@
     "@types/express-serve-static-core": "4.17.41",
     "@types/morgan": "^1.9.9",
     "@types/node": "^20.10.0",
+    "@types/pg": "^8.11.2",
     "@types/qs": "6.9.11",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "dotenv-cli": "^6.0.0",
+    "drizzle-kit": "^0.20.14",
     "eslint": "^8.53.0",
     "prettier": "^3.1.0",
     "ts-node": "^10.9.1",
@@ -40,9 +47,11 @@
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
+    "drizzle-orm": "^0.30.1",
     "express": "^4.18.2",
     "express-prom-bundle": "^7.0.0",
     "morgan": "^1.10.0",
+    "pg": "^8.11.3",
     "pino": "^8.19.0",
     "prom-client": "^15.1.0",
     "superjson": "^1.12.2",
@@ -50,6 +59,6 @@
     "zod": "^3.22.4"
   },
   "files": [
-    "build"
+    "dist"
   ]
 }

--- a/apps/api-key-service/scripts/db-migrate.ts
+++ b/apps/api-key-service/scripts/db-migrate.ts
@@ -1,0 +1,55 @@
+import 'dotenv/config'
+
+import { drizzle } from 'drizzle-orm/node-postgres'
+import { migrate } from 'drizzle-orm/node-postgres/migrator'
+import { Pool } from 'pg'
+
+const DATABASE_MIGRATION_FOLDER = 'migrations'
+
+const migrateDBUser = process.env.MIGRATE_DB_USER ?? 'postgres'
+const migrateDBPassword = process.env.MIGRATE_DB_PASSWORD ?? ''
+const dbHost = process.env.DB_HOST ?? 'localhost'
+const dbPort = process.env.DB_HOST ? Number(process.env.DB_PORT) : 5432
+const dbName = process.env.DB_NAME ?? 'api-key-service'
+
+const connectionOptions = {
+  connectionString: `postgresql://${migrateDBUser}:${migrateDBPassword}@${dbHost}:${dbPort}/${dbName}`,
+  max: 1,
+}
+
+const migrationOptions = {
+  migrationsFolder: DATABASE_MIGRATION_FOLDER,
+}
+
+/**
+ * This will run all migrations under the migrations folder one by one
+ * until the database is on the latest schema version. In order to
+ * generate migrations after creating models run the below command.
+ *
+ * pnpm nx run @eth-optimism/api-key-service:migrations:generate
+ *
+ **/
+async function main() {
+  const db = drizzle(new Pool(connectionOptions))
+  await migrate(db, migrationOptions)
+}
+
+function handleError(e: unknown) {
+  if (e instanceof Error) {
+    console.error(e) // eslint-disable-line no-console
+  }
+  process.exit(-1)
+}
+
+;(async () => {
+  try {
+    console.log('Starting...') // eslint-disable-line no-console
+    await main()
+    console.log('success') // eslint-disable-line no-console
+    process.exit(0)
+  } catch (e: any) {
+    handleError(e)
+  }
+})().catch((e: unknown) => {
+  handleError(e)
+})

--- a/apps/api-key-service/setup-local-db.sql
+++ b/apps/api-key-service/setup-local-db.sql
@@ -1,0 +1,35 @@
+CREATE USER "api-key-service@oplabs-local-web.iam";
+
+CREATE ROLE read_only;
+CREATE ROLE read_write;
+
+CREATE DATABASE "api-key-service";
+
+\c "api-key-service"
+
+GRANT read_write TO postgres;
+GRANT read_write TO "api-key-service@oplabs-local-web.iam";
+
+-- read_only
+GRANT CONNECT ON DATABASE "api-key-service" TO read_only;
+
+GRANT USAGE ON SCHEMA public TO read_only;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO read_only;
+
+ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO read_only;
+
+-- read_write
+GRANT CREATE, CONNECT ON DATABASE "api-key-service" TO read_write;
+
+GRANT USAGE, CREATE ON SCHEMA public TO read_write;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO read_write;
+
+ALTER DEFAULT PRIVILEGES GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO read_write;
+
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO read_write;
+
+ALTER DEFAULT PRIVILEGES GRANT USAGE ON SEQUENCES TO read_write;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE read_write GRANT SELECT ON TABLES TO read_only;

--- a/apps/api-key-service/src/models/apiKeys.ts
+++ b/apps/api-key-service/src/models/apiKeys.ts
@@ -1,0 +1,35 @@
+import {
+  index,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core'
+
+export type ApiKeyState = 'enabled' | 'disabled'
+
+export const apiKeys = pgTable(
+  'api-keys',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    entityId: uuid('entity_id').notNull(),
+    key: varchar('key').notNull(),
+    state: varchar('state').$type<ApiKeyState>().notNull(),
+    stateUpdatedAt: timestamp('state_updated_at', { withTimezone: true }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => {
+    return {
+      deletedAtIdx: index().on(table.deletedAt),
+      entityDeletedAtIdx: index().on(table.entityId, table.deletedAt),
+      keyIdx: uniqueIndex().on(table.key), // cannot allow duplicate keys
+    }
+  },
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       dotenv:
         specifier: ^16.4.1
         version: 16.4.1
+      drizzle-orm:
+        specifier: ^0.30.1
+        version: 0.30.1(@types/pg@8.11.2)(pg@8.11.3)
       express:
         specifier: ^4.18.2
         version: 4.19.2
@@ -53,6 +56,9 @@ importers:
       morgan:
         specifier: ^1.10.0
         version: 1.10.0
+      pg:
+        specifier: ^8.11.3
+        version: 8.11.3
       pino:
         specifier: ^8.19.0
         version: 8.19.0
@@ -87,6 +93,9 @@ importers:
       '@types/node':
         specifier: ^20.10.0
         version: 20.11.30
+      '@types/pg':
+        specifier: ^8.11.2
+        version: 8.11.2
       '@types/qs':
         specifier: 6.9.11
         version: 6.9.11
@@ -99,6 +108,9 @@ importers:
       dotenv-cli:
         specifier: ^6.0.0
         version: 6.0.0
+      drizzle-kit:
+        specifier: ^0.20.14
+        version: 0.20.14
       eslint:
         specifier: ^8.53.0
         version: 8.57.0
@@ -16353,8 +16365,8 @@ packages:
       chalk: 5.3.0
       commander: 9.5.0
       env-paths: 3.0.0
-      esbuild: 0.19.7
-      esbuild-register: 3.5.0(esbuild@0.19.7)
+      esbuild: 0.19.12
+      esbuild-register: 3.5.0(esbuild@0.19.12)
       glob: 8.1.0
       hanji: 0.0.5
       json-diff: 0.9.0
@@ -16772,17 +16784,6 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       esbuild: 0.19.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /esbuild-register@3.5.0(esbuild@0.19.7):
-    resolution: {integrity: sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==}
-    peerDependencies:
-      esbuild: '>=0.12 <1'
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-      esbuild: 0.19.7
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
adds a `api-keys` table to the api-key-service db
- not running any runtime migrations right now, will add logic to do this once deployment is set up

```
    id: uuid('id').defaultRandom().primaryKey(),
    entityId: uuid('entity_id').notNull(),
    key: varchar('key').notNull(),
    state: varchar('state').$type<ApiKeyState>().notNull(),
    stateUpdatedAt: timestamp('state_updated_at', { withTimezone: true }),
    deletedAt: timestamp('deleted_at', { withTimezone: true }),
    createdAt: timestamp('created_at', { withTimezone: true })
      .defaultNow()
      .notNull(),
    updatedAt: timestamp('updated_at', { withTimezone: true })
      .defaultNow()
      .notNull(),
```

