### PR TITLE
feat(dapp-console): add list wallets endpoint

### DIFF
--- a/apps/dapp-console-api/migrations/0008_absurd_magdalene.sql
+++ b/apps/dapp-console-api/migrations/0008_absurd_magdalene.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "wallets_created_at_index" ON "wallets" ("created_at");

--- a/apps/dapp-console-api/migrations/meta/0008_snapshot.json
+++ b/apps/dapp-console-api/migrations/meta/0008_snapshot.json
@@ -1,0 +1,858 @@
+{
+  "id": "ab716689-1450-431c-b508-81fbe5139e86",
+  "prevId": "ae16d398-0490-4b2b-ab32-6ac79139c56a",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "apps_entity_id_index": {
+          "name": "apps_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apps_entity_id_entities_id_fk": {
+          "name": "apps_entity_id_entities_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reponse": {
+          "name": "reponse",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "challenges_entity_id_index": {
+          "name": "challenges_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_contract_id_index": {
+          "name": "challenges_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_address_index": {
+          "name": "challenges_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        },
+        "challenges_entity_id_address_index": {
+          "name": "challenges_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "challenges_entity_id_entities_id_fk": {
+          "name": "challenges_entity_id_entities_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenges_contract_id_contracts_id_fk": {
+          "name": "challenges_contract_id_contracts_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployer_address": {
+          "name": "deployer_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_verified'"
+        }
+      },
+      "indexes": {
+        "contracts_entity_id_index": {
+          "name": "contracts_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_app_id_index": {
+          "name": "contracts_app_id_index",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_contract_address_index": {
+          "name": "contracts_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_deployer_address_index": {
+          "name": "contracts_deployer_address_index",
+          "columns": [
+            "deployer_address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contracts_entity_id_entities_id_fk": {
+          "name": "contracts_entity_id_entities_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contracts_app_id_apps_id_fk": {
+          "name": "contracts_app_id_apps_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deploymentRebates": {
+      "name": "deploymentRebates",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_approval'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_tx_hash": {
+          "name": "rebate_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_amount": {
+          "name": "rebate_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "deploymentRebates_entity_id_index": {
+          "name": "deploymentRebates_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_id_index": {
+          "name": "deploymentRebates_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_address_chain_id_index": {
+          "name": "deploymentRebates_contract_address_chain_id_index",
+          "columns": [
+            "contract_address",
+            "chain_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deploymentRebates_entity_id_entities_id_fk": {
+          "name": "deploymentRebates_entity_id_entities_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deploymentRebates_contract_id_contracts_id_fk": {
+          "name": "deploymentRebates_contract_id_contracts_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "privy_did": {
+          "name": "privy_did",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entities_privy_did_unique": {
+          "name": "entities_privy_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_did"
+          ]
+        }
+      }
+    },
+    "transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_gas_price": {
+          "name": "blob_gas_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_gas_used": {
+          "name": "blob_gas_used",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_event": {
+          "name": "transaction_event",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fee_per_blob_gas": {
+          "name": "max_fee_per_blob_gas",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transactions_chain_id_transaction_hash_index": {
+          "name": "transactions_chain_id_transaction_hash_index",
+          "columns": [
+            "chain_id",
+            "transaction_hash"
+          ],
+          "isUnique": true
+        },
+        "transactions_from_address_index": {
+          "name": "transactions_from_address_index",
+          "columns": [
+            "from_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_to_address_index": {
+          "name": "transactions_to_address_index",
+          "columns": [
+            "to_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_contract_address_index": {
+          "name": "transactions_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_contract_id_contracts_id_fk": {
+          "name": "transactions_contract_id_contracts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'privy'"
+        },
+        "verifications": {
+          "name": "verifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "unlinked_at": {
+          "name": "unlinked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sanctioned_at": {
+          "name": "sanctioned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallets_entity_id_address_index": {
+          "name": "wallets_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": true
+        },
+        "wallets_created_at_index": {
+          "name": "wallets_created_at_index",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "wallets_entity_id_index": {
+          "name": "wallets_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "wallets_address_index": {
+          "name": "wallets_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wallets_entity_id_entities_id_fk": {
+          "name": "wallets_entity_id_entities_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/dapp-console-api/migrations/meta/_journal.json
+++ b/apps/dapp-console-api/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1711665770252,
       "tag": "0007_even_sharon_ventura",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1712689795795,
+      "tag": "0008_absurd_magdalene",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dapp-console-api/src/api/index.ts
+++ b/apps/dapp-console-api/src/api/index.ts
@@ -1,3 +1,6 @@
 export * from './Api'
 export * from './ApiV0'
+export * from './listHelpers'
 export * from './Middleware'
+export * from './types'
+export * from './zodHelpers'

--- a/apps/dapp-console-api/src/api/listHelpers.ts
+++ b/apps/dapp-console-api/src/api/listHelpers.ts
@@ -1,0 +1,20 @@
+import type { Cursor, ListResponse } from './types'
+
+export const generateListResponse = <
+  TRecord extends { [key in keyof Cursor]: Cursor[key] },
+>(
+  records: TRecord[],
+  limit: number,
+  prevCursor?: Cursor,
+): ListResponse<TRecord> => {
+  let nextCursor: Cursor | undefined
+  if (records.length > limit) {
+    const { createdAt, id } = records.pop()!
+    nextCursor = { createdAt, id }
+  }
+  return {
+    nextCursor,
+    prevCursor,
+    records,
+  }
+}

--- a/apps/dapp-console-api/src/api/types.ts
+++ b/apps/dapp-console-api/src/api/types.ts
@@ -1,0 +1,13 @@
+import type { z } from 'zod'
+
+import type { zodCursor, zodListRequest } from './zodHelpers'
+
+export type ListRequest = z.infer<ReturnType<typeof zodListRequest>>
+
+export type Cursor = z.infer<typeof zodCursor>
+
+export type ListResponse<T> = {
+  nextCursor?: Cursor
+  prevCursor?: Cursor
+  records: T[]
+}

--- a/apps/dapp-console-api/src/api/zodHelpers.ts
+++ b/apps/dapp-console-api/src/api/zodHelpers.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const zodCursor = z.object({
+  createdAt: z.date(),
+  id: z.string(),
+})
+
+export const zodListRequest = (limit?: number) =>
+  z.object({
+    cursor: zodCursor.optional(),
+    limit: z
+      .number()
+      .min(0)
+      .max(limit ?? 100)
+      .optional(),
+  })

--- a/apps/dapp-console-api/src/models/utils.ts
+++ b/apps/dapp-console-api/src/models/utils.ts
@@ -1,0 +1,69 @@
+import type { Column, SQLWrapper, Table } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, lte, or } from 'drizzle-orm'
+
+import type { Database } from '@/db'
+
+/**
+ * Queries the next set of results using @param cursor.
+ * @param db database to query
+ * @param table table to query
+ * @param filters filters to apply to query
+ * @param limit number of results for query
+ * @param orderBy sorting order for results
+ * @param idColumnKey key of the id column on the table
+ * @param cursor the cursor to start the query from
+ * @returns the next set of results from the @param cursor.
+ */
+export const generateCursorSelect = async <
+  TTable extends Table,
+  OrderKey extends keyof TTable['$inferSelect'],
+  IdKey extends keyof TTable['$inferSelect'],
+>(input: {
+  db: Database
+  table: TTable
+  filters: Array<SQLWrapper | undefined>
+  limit: number
+  orderBy: {
+    direction: 'desc' | 'asc'
+    column: OrderKey
+  }
+  idColumnKey: IdKey
+  cursor?: {
+    [key in OrderKey | IdKey]: key extends OrderKey
+      ? TTable['$inferSelect'][OrderKey]
+      : TTable['$inferSelect'][IdKey]
+  }
+}) => {
+  const { db, table, filters, limit, orderBy, idColumnKey, cursor } = input
+  const tableOrderByColumn = table[orderBy.column] as Column
+  const tableIdColumn = table[idColumnKey] as Column
+
+  const cursorFilter = cursor
+    ? or(
+        orderBy.direction === 'desc'
+          ? lte(tableOrderByColumn, cursor[orderBy.column])
+          : gte(tableOrderByColumn, cursor[orderBy.column]),
+        and(
+          eq(tableOrderByColumn, cursor[orderBy.column]),
+          gte(tableIdColumn, cursor[idColumnKey]),
+        ),
+      )
+    : undefined
+
+  return (
+    db
+      .select()
+      .from(table)
+      .where(and(...filters, cursorFilter))
+      // Get one above the page size in order to retrieve the next cursor.
+      .limit(limit + 1)
+      .orderBy(
+        ...[
+          orderBy.direction === 'desc'
+            ? desc(tableOrderByColumn)
+            : asc(tableOrderByColumn),
+          asc(tableIdColumn),
+        ],
+      )
+  )
+}

--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -21,4 +21,8 @@ export const metrics = {
     name: 'privy_sync_wallets_error_count',
     help: 'Total number of errors encountered while attempting to sync linked privy wallets',
   }),
+  listWalletsErrorCount: new Counter({
+    name: 'list_wallets_error_count',
+    help: 'Total number of errors encountered while attempting to fetch wallets from db',
+  }),
 }

--- a/apps/dapp-console-api/src/routes/constants.ts
+++ b/apps/dapp-console-api/src/routes/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PAGE_LIMIT = 100

--- a/apps/dapp-console-api/src/routes/index.ts
+++ b/apps/dapp-console-api/src/routes/index.ts
@@ -1,1 +1,2 @@
+export * from './constants'
 export * from './Route'

--- a/apps/dapp-console-api/src/routes/wallets/WalletsRoute.ts
+++ b/apps/dapp-console-api/src/routes/wallets/WalletsRoute.ts
@@ -1,8 +1,11 @@
+import { generateListResponse, zodListRequest } from '@/api'
 import { isPrivyAuthed } from '@/middleware'
+import { getActiveWalletsForEntityByCursor } from '@/models'
 import { metrics } from '@/monitoring/metrics'
 import { Trpc } from '@/Trpc'
 import { fetchAndSyncPrivyWallets } from '@/utils'
 
+import { DEFAULT_PAGE_LIMIT } from '../constants'
 import { Route } from '../Route'
 
 export class WalletsRoute extends Route {
@@ -37,7 +40,46 @@ export class WalletsRoute extends Route {
       }
     })
 
+  public readonly listWallets = 'listWallets' as const
+  /**
+   * Returns a list of wallets associated with the entity.
+   */
+  public readonly listWalletsController = this.trpc.procedure
+    .use(isPrivyAuthed(this.trpc))
+    .input(zodListRequest())
+    .query(async ({ ctx, input }) => {
+      try {
+        const { user } = ctx.session
+        const limit = input.limit ?? DEFAULT_PAGE_LIMIT
+
+        if (!user) {
+          throw Trpc.handleStatus(401, 'user not authenticated')
+        }
+
+        const activeWallets = await getActiveWalletsForEntityByCursor(
+          this.trpc.database,
+          user.entityId,
+          limit,
+          input.cursor,
+        )
+
+        return generateListResponse(activeWallets, limit, input.cursor)
+      } catch (err) {
+        metrics.listWalletsErrorCount.inc()
+        this.logger?.error(
+          {
+            error: err,
+            entityId: ctx.session.user?.entityId,
+            privyDid: ctx.session.user?.privyDid,
+          },
+          'error fetching wallets from db',
+        )
+        throw Trpc.handleStatus(500, 'error fetching wallets')
+      }
+    })
+
   public readonly handler = this.trpc.router({
     [this.syncWallets]: this.syncWalletsController,
+    [this.listWallets]: this.listWalletsController,
   })
 }


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/890

Adds a `listWallets` endpoint. This endpoint returns a list of active wallets associated with an account based on a `cursor` and `maxPageSize`