### PR TITLE
feat(dapp-console-api): add `listContractsForApp` endpoint

### DIFF
--- a/apps/dapp-console-api/src/Service.ts
+++ b/apps/dapp-console-api/src/Service.ts
@@ -25,6 +25,7 @@ import { connectToDatabase, runMigrations } from './db'
 import { metrics } from './monitoring/metrics'
 import { AppsRoute } from './routes/apps'
 import { AuthRoute } from './routes/auth'
+import { ContractsRoute } from './routes/contracts'
 import { WalletsRoute } from './routes/wallets'
 import { Trpc } from './Trpc'
 import { retryWithBackoff } from './utils'
@@ -127,11 +128,17 @@ export class Service {
     const authRoute = new AuthRoute(trpc)
     const walletsRoute = new WalletsRoute(trpc)
     const appsRoute = new AppsRoute(trpc)
+    const contractsRoute = new ContractsRoute(trpc)
 
     /**
      * The apiServer simply assmbles the routes into a TRPC Server
      */
-    const apiServer = new ApiV0(trpc, { authRoute, walletsRoute, appsRoute })
+    const apiServer = new ApiV0(trpc, {
+      authRoute,
+      walletsRoute,
+      appsRoute,
+      contractsRoute,
+    })
     apiServer.setLoggingServer(logger)
 
     const adminServer = new AdminApi(trpc, {})

--- a/apps/dapp-console-api/src/api/ApiV0.ts
+++ b/apps/dapp-console-api/src/api/ApiV0.ts
@@ -1,5 +1,6 @@
 import type { AppsRoute } from '@/routes/apps'
 import type { AuthRoute } from '@/routes/auth'
+import type { ContractsRoute } from '@/routes/contracts'
 import type { WalletsRoute } from '@/routes/wallets'
 
 import { MajorApiVersion } from '../constants'
@@ -34,6 +35,7 @@ export class ApiV0 extends Api {
     [this.routes.authRoute.name]: this.routes.authRoute.handler,
     [this.routes.walletsRoute.name]: this.routes.walletsRoute.handler,
     [this.routes.appsRoute.name]: this.routes.appsRoute.handler,
+    [this.routes.contractsRoute.name]: this.routes.contractsRoute.handler,
   })
 
   /**
@@ -45,6 +47,7 @@ export class ApiV0 extends Api {
       authRoute: AuthRoute
       walletsRoute: WalletsRoute
       appsRoute: AppsRoute
+      contractsRoute: ContractsRoute
     },
   ) {
     super(trpc)

--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -29,4 +29,8 @@ export const metrics = {
     name: 'list_apps_error_count',
     help: 'Total number of errors encountered while attempting to fetch apps from db',
   }),
+  listContractsErrorCount: new Counter({
+    name: 'list_contracts_error_count',
+    help: 'Total number of errors encountered while attempting to fetch contracts from db',
+  }),
 }

--- a/apps/dapp-console-api/src/routes/contracts/ContractsRoute.ts
+++ b/apps/dapp-console-api/src/routes/contracts/ContractsRoute.ts
@@ -1,0 +1,54 @@
+import { isPrivyAuthed } from '@/middleware'
+import { getContractsForApp } from '@/models'
+import { metrics } from '@/monitoring/metrics'
+import { Trpc } from '@/Trpc'
+
+import { Route } from '../Route'
+
+export class ContractsRoute extends Route {
+  public readonly name = 'Contracts' as const
+
+  public readonly listContractsForApp = 'listContractsForApp' as const
+  /**
+   * Returns a list of contracts associated with an app.
+   */
+  public readonly listContractsForAppController = this.trpc.procedure
+    .use(isPrivyAuthed(this.trpc))
+    .input(
+      this.z.object({
+        appId: this.z.string(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const { user } = ctx.session
+
+        if (!user) {
+          throw Trpc.handleStatus(401, 'user not authenticated')
+        }
+
+        const contracts = await getContractsForApp({
+          db: this.trpc.database,
+          entityId: user.entityId,
+          appId: input.appId,
+        })
+
+        return contracts
+      } catch (err) {
+        metrics.listContractsErrorCount.inc()
+        this.logger?.error(
+          {
+            error: err,
+            entityId: ctx.session.user?.entityId,
+            privyDid: ctx.session.user?.privyDid,
+          },
+          'error fetching contracts from db',
+        )
+        throw Trpc.handleStatus(500, 'error fetching contracts')
+      }
+    })
+
+  public readonly handler = this.trpc.router({
+    [this.listContractsForApp]: this.listContractsForAppController,
+  })
+}

--- a/apps/dapp-console-api/src/routes/contracts/index.ts
+++ b/apps/dapp-console-api/src/routes/contracts/index.ts
@@ -1,0 +1,1 @@
+export * from './ContractsRoute'


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/891

Adds `listContractsForApp` endpoint, which returns a paginated list of contracts associated with a given `appId` and `entityId`