### PR TITLE
feat(dapp-console-api): add `createApp` endpoint

### DIFF
--- a/apps/dapp-console-api/src/constants/envVars.ts
+++ b/apps/dapp-console-api/src/constants/envVars.ts
@@ -36,6 +36,7 @@ const envVarSchema = z.object({
   DB_MAX_CONNECTIONS: z.number().int().min(1).optional(),
   PRIVY_APP_ID: z.string(),
   PRIVY_APP_SECRET: z.string(),
+  MAX_APPS_COUNT: z.number().min(1).default(20),
 })
 
 const isTest = process.env.NODE_ENV === 'test'
@@ -112,5 +113,6 @@ export const envVars = envVarSchema.parse(
         PRIVY_APP_ID: process.env.PRIVY_APP_ID,
         PRIVY_APP_SECRET: process.env.PRIVY_APP_SECRET,
         PRIVY_ACCESS_TOKEN_SALT: process.env.PRIVY_ACCESS_TOKEN_SALT,
+        MAX_APPS_COUNT: process.env.MAX_APPS_COUNT,
       },
 )

--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -33,4 +33,12 @@ export const metrics = {
     name: 'list_contracts_error_count',
     help: 'Total number of errors encountered while attempting to fetch contracts from db',
   }),
+  fetchActiveAppsCountErrorCount: new Counter({
+    name: 'fetch_active_apps_count_error_count',
+    help: 'Total number of errors encountered while fetching count of active apps',
+  }),
+  createAppErrorCount: new Counter({
+    name: 'create_app_error_count',
+    help: 'Total number of errors encountered while creating an app',
+  }),
 }

--- a/apps/dapp-console-api/src/routes/apps/AppsRoute.ts
+++ b/apps/dapp-console-api/src/routes/apps/AppsRoute.ts
@@ -1,6 +1,13 @@
 import { generateListResponse, zodListRequest, zodNameCursor } from '@/api'
+import { envVars } from '@/constants'
 import { isPrivyAuthed } from '@/middleware'
-import { getActiveAppsForEntityByCursor, getContractsForApp } from '@/models'
+import {
+  AppState,
+  getActiveAppsCount,
+  getActiveAppsForEntityByCursor,
+  getContractsForApp,
+  insertApp,
+} from '@/models'
 import { metrics } from '@/monitoring/metrics'
 import { Trpc } from '@/Trpc'
 
@@ -66,7 +73,61 @@ export class AppsRoute extends Route {
       }
     })
 
+  public readonly createApp = 'createApp' as const
+  public readonly createAppController = this.trpc.procedure
+    .use(isPrivyAuthed(this.trpc))
+    .input(
+      this.z.object({
+        name: this.z.string().min(1).max(120),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { user } = ctx.session
+      const { name } = input
+
+      if (!user) {
+        throw Trpc.handleStatus(401, 'user not authenticated')
+      }
+
+      const activeAppsCount = await getActiveAppsCount({
+        db: this.trpc.database,
+        entityId: user.entityId,
+      }).catch((err) => {
+        metrics.fetchActiveAppsCountErrorCount.inc()
+        this.logger?.error(
+          {
+            error: err,
+            entityId: ctx.session.user?.entityId,
+          },
+          'error fetching active apps count from db',
+        )
+        throw Trpc.handleStatus(500, 'unable to fetch active app count')
+      })
+
+      if (activeAppsCount >= envVars.MAX_APPS_COUNT) {
+        throw Trpc.handleStatus(422, 'max apps reached')
+      }
+
+      const result = await insertApp({
+        db: this.trpc.database,
+        newApp: { name, entityId: user.entityId, state: AppState.ACTIVE },
+      }).catch((err) => {
+        metrics.createAppErrorCount.inc()
+        this.logger?.error(
+          {
+            error: err,
+            entityId: ctx.session.user?.entityId,
+          },
+          'error inserting app in db',
+        )
+        throw Trpc.handleStatus(500, 'unable to create app')
+      })
+
+      return { result }
+    })
+
   public readonly handler = this.trpc.router({
     [this.listApps]: this.listAppsController,
+    [this.createApp]: this.createAppController,
   })
 }


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/925

`createApp` endpoint creates a new app associated with the entity. The client must provide a name for the app. 