### PR TITLE
feat(dapp-console-api): update pg columns holding uint256 values to numeric data type

### DIFF
--- a/apps/dapp-console-api/migrations/0012_lucky_captain_universe.sql
+++ b/apps/dapp-console-api/migrations/0012_lucky_captain_universe.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "deploymentRebates" ALTER COLUMN "rebate_amount" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "block_number" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "gas_used" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "gas_price" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "blob_gas_price" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "blob_gas_used" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "max_fee_per_blob_gas" SET DATA TYPE numeric(78, 0);--> statement-breakpoint
+ALTER TABLE "transactions" ALTER COLUMN "value" SET DATA TYPE numeric(78, 0);

--- a/apps/dapp-console-api/migrations/meta/0012_snapshot.json
+++ b/apps/dapp-console-api/migrations/meta/0012_snapshot.json
@@ -1,0 +1,902 @@
+{
+  "id": "77782a34-26d1-4cb8-b2aa-5b51a15c5744",
+  "prevId": "d00657ca-b123-4a24-8229-d0755d3f871d",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "apps_entity_id_index": {
+          "name": "apps_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "apps_name_index": {
+          "name": "apps_name_index",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apps_entity_id_entities_id_fk": {
+          "name": "apps_entity_id_entities_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reponse": {
+          "name": "reponse",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "challenges_entity_id_index": {
+          "name": "challenges_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_contract_id_index": {
+          "name": "challenges_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_address_index": {
+          "name": "challenges_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        },
+        "challenges_entity_id_address_index": {
+          "name": "challenges_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "challenges_entity_id_entities_id_fk": {
+          "name": "challenges_entity_id_entities_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenges_contract_id_contracts_id_fk": {
+          "name": "challenges_contract_id_contracts_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer_address": {
+          "name": "deployer_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_verified'"
+        }
+      },
+      "indexes": {
+        "contracts_entity_id_chain_id_contract_address_index": {
+          "name": "contracts_entity_id_chain_id_contract_address_index",
+          "columns": [
+            "entity_id",
+            "chain_id",
+            "contract_address"
+          ],
+          "isUnique": true
+        },
+        "contracts_entity_id_index": {
+          "name": "contracts_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_app_id_index": {
+          "name": "contracts_app_id_index",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_contract_address_index": {
+          "name": "contracts_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_deployer_address_index": {
+          "name": "contracts_deployer_address_index",
+          "columns": [
+            "deployer_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_entity_id_created_at_index": {
+          "name": "contracts_entity_id_created_at_index",
+          "columns": [
+            "entity_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contracts_entity_id_entities_id_fk": {
+          "name": "contracts_entity_id_entities_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contracts_app_id_apps_id_fk": {
+          "name": "contracts_app_id_apps_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deploymentRebates": {
+      "name": "deploymentRebates",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_approval'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_tx_hash": {
+          "name": "rebate_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_amount": {
+          "name": "rebate_amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "deploymentRebates_entity_id_index": {
+          "name": "deploymentRebates_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_id_index": {
+          "name": "deploymentRebates_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_address_chain_id_index": {
+          "name": "deploymentRebates_contract_address_chain_id_index",
+          "columns": [
+            "contract_address",
+            "chain_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deploymentRebates_entity_id_entities_id_fk": {
+          "name": "deploymentRebates_entity_id_entities_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deploymentRebates_contract_id_contracts_id_fk": {
+          "name": "deploymentRebates_contract_id_contracts_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "privy_did": {
+          "name": "privy_did",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entities_privy_did_unique": {
+          "name": "entities_privy_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_did"
+          ]
+        }
+      }
+    },
+    "transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_gas_price": {
+          "name": "blob_gas_price",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_gas_used": {
+          "name": "blob_gas_used",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_event": {
+          "name": "transaction_event",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fee_per_blob_gas": {
+          "name": "max_fee_per_blob_gas",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transactions_chain_id_transaction_hash_index": {
+          "name": "transactions_chain_id_transaction_hash_index",
+          "columns": [
+            "chain_id",
+            "transaction_hash"
+          ],
+          "isUnique": true
+        },
+        "transactions_from_address_index": {
+          "name": "transactions_from_address_index",
+          "columns": [
+            "from_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_to_address_index": {
+          "name": "transactions_to_address_index",
+          "columns": [
+            "to_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_contract_address_index": {
+          "name": "transactions_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_entity_id_block_timestamp_index": {
+          "name": "transactions_entity_id_block_timestamp_index",
+          "columns": [
+            "entity_id",
+            "block_timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_contract_id_contracts_id_fk": {
+          "name": "transactions_contract_id_contracts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'privy'"
+        },
+        "verifications": {
+          "name": "verifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "unlinked_at": {
+          "name": "unlinked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sanctioned_at": {
+          "name": "sanctioned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallets_entity_id_address_index": {
+          "name": "wallets_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": true
+        },
+        "wallets_created_at_index": {
+          "name": "wallets_created_at_index",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "wallets_entity_id_index": {
+          "name": "wallets_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "wallets_address_index": {
+          "name": "wallets_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wallets_entity_id_entities_id_fk": {
+          "name": "wallets_entity_id_entities_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/dapp-console-api/migrations/meta/_journal.json
+++ b/apps/dapp-console-api/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1712869244848,
       "tag": "0011_absurd_salo",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1712871251784,
+      "tag": "0012_lucky_captain_universe",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dapp-console-api/src/models/deploymentRebates.ts
+++ b/apps/dapp-console-api/src/models/deploymentRebates.ts
@@ -1,7 +1,7 @@
 import {
-  bigint,
   index,
   integer,
+  numeric,
   pgTable,
   timestamp,
   uuid,
@@ -11,6 +11,7 @@ import type { Address, Hash } from 'viem'
 
 import { contracts } from './contracts'
 import { entities } from './entities'
+import { UINT256_PRECISION } from './utils'
 
 enum DeploymentRebateState {
   APPROVED = 'approved',
@@ -46,7 +47,10 @@ export const deploymentRebates = pgTable(
       .notNull(),
     rejectionReason: varchar('rejection_reason').$type<RejectionReason>(),
     rebateTxHash: varchar('rebate_tx_hash').$type<Hash>(),
-    rebateAmount: bigint('rebate_amount', { mode: 'bigint' }),
+    rebateAmount: numeric('rebate_amount', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     recipientAddress: varchar('recipient_address').$type<Address>(),
   },
   (table) => {

--- a/apps/dapp-console-api/src/models/transactions.ts
+++ b/apps/dapp-console-api/src/models/transactions.ts
@@ -1,7 +1,7 @@
 import {
-  bigint,
   index,
   integer,
+  numeric,
   pgTable,
   timestamp,
   uniqueIndex,
@@ -12,6 +12,7 @@ import type { Address, Hash } from 'viem'
 
 import { contracts } from './contracts'
 import { entities } from './entities'
+import { UINT256_PRECISION } from './utils'
 
 enum TransactionEvent {
   CONTRACT_DEPLOYMENT = 'contract_deployment',
@@ -37,7 +38,10 @@ export const transactions = pgTable(
     /** Hash of this transaction */
     transactionHash: varchar('transaction_hash').$type<Hash>().notNull(),
     /** Number of block containing this transaction */
-    blockNumber: bigint('block_number', { mode: 'bigint' }).notNull(),
+    blockNumber: numeric('block_number', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }).notNull(),
     /** Transaction sender */
     fromAddress: varchar('from_address').$type<Address>().notNull(),
     /** Transaction recipient or `null` if deploying a contract */
@@ -45,13 +49,25 @@ export const transactions = pgTable(
     /** Address of new contract or `null` if no contract was created */
     contractAddress: varchar('contract_address').$type<Address>(),
     /** Gas used by this transaction */
-    gasUsed: bigint('gas_used', { mode: 'bigint' }).notNull(),
+    gasUsed: numeric('gas_used', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }).notNull(),
     /** Equal to the actual gas price paid for inclusion. */
-    gasPrice: bigint('gas_price', { mode: 'bigint' }).notNull(),
+    gasPrice: numeric('gas_price', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }).notNull(),
     /** The actual value per gas deducted from the sender's account for blob gas. Only specified for blob transactions as defined by EIP-4844. */
-    blobGasPrice: bigint('blob_gas_price', { mode: 'bigint' }),
+    blobGasPrice: numeric('blob_gas_price', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     /** The amount of blob gas used. Only specified for blob transactions as defined by EIP-4844. */
-    blobGasUsed: bigint('blob_gas_used', { mode: 'bigint' }),
+    blobGasUsed: numeric('blob_gas_used', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     /** Transaction type */
     transactionType: varchar('transaction_type')
       .$type<'legacy' | 'eip2930' | 'eip1559' | 'eip4844'>()
@@ -59,13 +75,25 @@ export const transactions = pgTable(
     /** Used for tracking the kind of transaction this was */
     transactionEvent: varchar('transaction_event').$type<TransactionEvent>(),
     /** The maximum total fee per gas the sender is willing to pay for blob gas (in wei). */
-    maxFeePerBlobGas: bigint('max_fee_per_blob_gas', { mode: 'bigint' }),
+    maxFeePerBlobGas: numeric('max_fee_per_blob_gas', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     /** Total fee per gas in wei (gasPrice/baseFeePerGas + maxPriorityFeePerGas). */
-    maxFeePerGas: bigint('max_fee_per_blob_gas', { mode: 'bigint' }),
+    maxFeePerGas: numeric('max_fee_per_blob_gas', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     /** Max priority fee per gas (in wei). */
-    maxPriorityFeePerGas: bigint('max_fee_per_blob_gas', { mode: 'bigint' }),
+    maxPriorityFeePerGas: numeric('max_fee_per_blob_gas', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     /** Value in wei sent with this transaction */
-    value: bigint('value', { mode: 'bigint' }),
+    value: numeric('value', {
+      precision: UINT256_PRECISION,
+      scale: 0,
+    }),
     /** `success` if this transaction was successful or `reverted` if it failed */
     status: varchar('status').$type<'success' | 'reverted'>().notNull(),
     /** Unix timestamp of when this block was collated */

--- a/apps/dapp-console-api/src/models/utils.ts
+++ b/apps/dapp-console-api/src/models/utils.ts
@@ -3,6 +3,8 @@ import { and, asc, desc, eq, gte, lte, or } from 'drizzle-orm'
 
 import type { Database } from '@/db'
 
+export const UINT256_PRECISION = 78
+
 /**
  * Queries the next set of results using @param cursor.
  * @param db database to query


### PR DESCRIPTION
The postgres `bigint` data type only stores up to 8bytes. In order to store uint256 values we should update the data type for any columns that store a uint256 value to `numeric` data type with a precision of 78: [postgres docs](https://www.postgresql.org/docs/current/datatype-numeric.html)