### PR TITLE
feat(api-key-service): add update, delete, list, verify endpoints

### DIFF
--- a/apps/api-key-service/src/routes/keys/KeysRoute.ts
+++ b/apps/api-key-service/src/routes/keys/KeysRoute.ts
@@ -4,7 +4,14 @@ import { z } from 'zod'
 
 import type { Database } from '@/db/Database'
 import type { ApiKey } from '@/models/apiKeys'
-import { createApiKey, getApiKey } from '@/models/apiKeys'
+import {
+  createApiKey,
+  deleteApiKey,
+  getApiKey,
+  getApiKeyByKey,
+  listApiKeysForEntity,
+  updateApiKeyState,
+} from '@/models/apiKeys'
 import type { Metrics } from '@/monitoring/metrics'
 import { Route } from '@/routes/Route'
 import { Trpc } from '@/Trpc'
@@ -65,9 +72,94 @@ export class KeysRoute extends Route {
       return { apiKey }
     })
 
+  public readonly updateApiKey = 'updateApiKey' as const
+  public readonly updateApiKeyController = this.trpc.procedure
+    .input(
+      z.object({
+        id: z.string(),
+        state: z.union([z.literal('enabled'), z.literal('disabled')]),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      let updatedApiKey: ApiKey | null
+      try {
+        updatedApiKey = await updateApiKeyState(
+          this.database,
+          input.id,
+          input.state,
+        )
+      } catch (e) {
+        throw this.logAndReturnDbError(e, 'Error updating API key state')
+      }
+
+      if (!updatedApiKey) {
+        throw Trpc.handleStatus(404, 'API key not found')
+      }
+
+      return { updatedApiKey: updatedApiKey }
+    })
+
+  public readonly deleteApiKey = 'deleteApiKey' as const
+  public readonly deleteApiKeyController = this.trpc.procedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input }) => {
+      try {
+        await deleteApiKey(this.database, input.id)
+      } catch (e) {
+        throw this.logAndReturnDbError(e, 'Error deleting API key')
+      }
+    })
+
+  // Right now, the endpoint is a simple check for "state" column of an API key
+  // In the future, the verification process may be more resource intensive (verifying a signature, etc.)
+  public readonly verifyApiKey = 'verifyApiKey' as const
+  public readonly verifyApiKeyController = this.trpc.procedure
+    .input(
+      z.object({
+        key: z.string(),
+      }),
+    )
+    .query(async ({ input }) => {
+      let apiKey: ApiKey | null
+      try {
+        apiKey = await getApiKeyByKey(this.database, input.key)
+      } catch (e) {
+        throw this.logAndReturnDbError(e, 'Error getting API key by key')
+      }
+
+      if (!apiKey || apiKey.state !== 'enabled') {
+        return {
+          apiKey: apiKey ? { id: apiKey.id } : null,
+          isVerified: false,
+        }
+      }
+
+      return {
+        apiKey: { id: apiKey.id },
+        isVerified: true,
+      }
+    })
+
+  public readonly listApiKeysForEntity = 'listApiKeysForEntity' as const
+  public readonly listApiKeysForEntityController = this.trpc.procedure
+    .input(z.object({ entityId: z.string() }))
+    .query(async ({ input }) => {
+      let apiKeys: ApiKey[]
+      try {
+        apiKeys = await listApiKeysForEntity(this.database, input.entityId)
+      } catch (e) {
+        throw this.logAndReturnDbError(e, 'Error listing API keys for entityId')
+      }
+      return { apiKeys }
+    })
+
   public readonly handler = this.trpc.router({
     [this.createApiKey]: this.createApiKeyController,
     [this.getApiKey]: this.getApiKeyController,
+    [this.updateApiKey]: this.updateApiKeyController,
+    [this.deleteApiKey]: this.deleteApiKeyController,
+    [this.verifyApiKey]: this.verifyApiKeyController,
+    [this.listApiKeysForEntity]: this.listApiKeysForEntityController,
   })
 
   constructor(


### PR DESCRIPTION
### updateApiKey
- only supports updating the state of the api key, returns updated value

### deleteApiKey
- returns nothing, delete by ID

### verifyApiKey
- checks whether api key is enabled and returns a `{ isVerified: boolean }` 
- right now it's a simple lookup, but in the future it should handle signature verification

### listApiKeysForEntity
- returns all api keys for an entity

* rows are soft deleted, so all lookup queries filter out keys that are deleted