### PR TITLE
feat(dapp-console-api): `startVerification` endpoint

### DIFF
--- a/apps/dapp-console-api/migrations/0013_crazy_stardust.sql
+++ b/apps/dapp-console-api/migrations/0013_crazy_stardust.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "challenges" DROP COLUMN IF EXISTS "challenge";--> statement-breakpoint
+ALTER TABLE "challenges" DROP COLUMN IF EXISTS "reponse";

--- a/apps/dapp-console-api/migrations/meta/0013_snapshot.json
+++ b/apps/dapp-console-api/migrations/meta/0013_snapshot.json
@@ -1,0 +1,890 @@
+{
+  "id": "5448197a-46e3-4584-b24b-a3544d8be087",
+  "prevId": "77782a34-26d1-4cb8-b2aa-5b51a15c5744",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "apps_entity_id_index": {
+          "name": "apps_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "apps_name_index": {
+          "name": "apps_name_index",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apps_entity_id_entities_id_fk": {
+          "name": "apps_entity_id_entities_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "challenges_entity_id_index": {
+          "name": "challenges_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_contract_id_index": {
+          "name": "challenges_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_address_index": {
+          "name": "challenges_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        },
+        "challenges_entity_id_address_index": {
+          "name": "challenges_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "challenges_entity_id_entities_id_fk": {
+          "name": "challenges_entity_id_entities_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenges_contract_id_contracts_id_fk": {
+          "name": "challenges_contract_id_contracts_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer_address": {
+          "name": "deployer_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_verified'"
+        }
+      },
+      "indexes": {
+        "contracts_entity_id_chain_id_contract_address_index": {
+          "name": "contracts_entity_id_chain_id_contract_address_index",
+          "columns": [
+            "entity_id",
+            "chain_id",
+            "contract_address"
+          ],
+          "isUnique": true
+        },
+        "contracts_entity_id_index": {
+          "name": "contracts_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_app_id_index": {
+          "name": "contracts_app_id_index",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_contract_address_index": {
+          "name": "contracts_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_deployer_address_index": {
+          "name": "contracts_deployer_address_index",
+          "columns": [
+            "deployer_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_entity_id_created_at_index": {
+          "name": "contracts_entity_id_created_at_index",
+          "columns": [
+            "entity_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contracts_entity_id_entities_id_fk": {
+          "name": "contracts_entity_id_entities_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contracts_app_id_apps_id_fk": {
+          "name": "contracts_app_id_apps_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deploymentRebates": {
+      "name": "deploymentRebates",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_approval'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_tx_hash": {
+          "name": "rebate_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_amount": {
+          "name": "rebate_amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "deploymentRebates_entity_id_index": {
+          "name": "deploymentRebates_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_id_index": {
+          "name": "deploymentRebates_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_address_chain_id_index": {
+          "name": "deploymentRebates_contract_address_chain_id_index",
+          "columns": [
+            "contract_address",
+            "chain_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deploymentRebates_entity_id_entities_id_fk": {
+          "name": "deploymentRebates_entity_id_entities_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deploymentRebates_contract_id_contracts_id_fk": {
+          "name": "deploymentRebates_contract_id_contracts_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "privy_did": {
+          "name": "privy_did",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entities_privy_did_unique": {
+          "name": "entities_privy_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_did"
+          ]
+        }
+      }
+    },
+    "transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_gas_price": {
+          "name": "blob_gas_price",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_gas_used": {
+          "name": "blob_gas_used",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_event": {
+          "name": "transaction_event",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fee_per_blob_gas": {
+          "name": "max_fee_per_blob_gas",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transactions_chain_id_transaction_hash_index": {
+          "name": "transactions_chain_id_transaction_hash_index",
+          "columns": [
+            "chain_id",
+            "transaction_hash"
+          ],
+          "isUnique": true
+        },
+        "transactions_from_address_index": {
+          "name": "transactions_from_address_index",
+          "columns": [
+            "from_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_to_address_index": {
+          "name": "transactions_to_address_index",
+          "columns": [
+            "to_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_contract_address_index": {
+          "name": "transactions_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        },
+        "transactions_entity_id_block_timestamp_index": {
+          "name": "transactions_entity_id_block_timestamp_index",
+          "columns": [
+            "entity_id",
+            "block_timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_contract_id_contracts_id_fk": {
+          "name": "transactions_contract_id_contracts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'privy'"
+        },
+        "verifications": {
+          "name": "verifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "unlinked_at": {
+          "name": "unlinked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sanctioned_at": {
+          "name": "sanctioned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallets_entity_id_address_index": {
+          "name": "wallets_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": true
+        },
+        "wallets_created_at_index": {
+          "name": "wallets_created_at_index",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "wallets_entity_id_index": {
+          "name": "wallets_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "wallets_address_index": {
+          "name": "wallets_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wallets_entity_id_entities_id_fk": {
+          "name": "wallets_entity_id_entities_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/dapp-console-api/migrations/meta/_journal.json
+++ b/apps/dapp-console-api/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1712871251784,
       "tag": "0012_lucky_captain_universe",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "5",
+      "when": 1713200095956,
+      "tag": "0013_crazy_stardust",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dapp-console-api/src/models/challenges.ts
+++ b/apps/dapp-console-api/src/models/challenges.ts
@@ -1,25 +1,14 @@
-import {
-  index,
-  jsonb,
-  pgTable,
-  timestamp,
-  uuid,
-  varchar,
-} from 'drizzle-orm/pg-core'
-import type { Address, Hex } from 'viem'
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+import { and, eq, ne } from 'drizzle-orm'
+import { index, pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
+import { type Address, getAddress } from 'viem'
+
+import type { Database } from '@/db'
 
 import { contracts } from './contracts'
 import { entities } from './entities'
 
-type Challenge = {
-  message: string
-}
-
-type ChallengeResponse = {
-  signature: Hex
-}
-
-enum ChallengeState {
+export enum ChallengeState {
   PENDING = 'pending',
   VERIFIED = 'verified',
   EXPIRED = 'expired',
@@ -47,9 +36,6 @@ export const challenges = pgTable(
       .$type<ChallengeState>()
       .default(ChallengeState.PENDING)
       .notNull(),
-    /** Challenge is null if the entity has already completed a challenge for the address */
-    challenge: jsonb('challenge').$type<Challenge>(),
-    response: jsonb('reponse').$type<ChallengeResponse>(),
   },
   (table) => {
     return {
@@ -60,3 +46,45 @@ export const challenges = pgTable(
     }
   },
 )
+
+export type Challenge = InferSelectModel<typeof challenges>
+export type InsertChallenge = InferInsertModel<typeof challenges>
+
+export const getUnexpiredChallenge = async (input: {
+  db: Database
+  contractId: Challenge['contractId']
+  entityId: Challenge['entityId']
+}): Promise<Challenge | null> => {
+  const { db, contractId, entityId } = input
+
+  const results = await db
+    .select()
+    .from(challenges)
+    .where(
+      and(
+        eq(challenges.contractId, contractId),
+        eq(challenges.entityId, entityId),
+        ne(challenges.state, ChallengeState.EXPIRED),
+      ),
+    )
+
+  return results[0] || null
+}
+
+export const insertChallenge = async (input: {
+  db: Database
+  challenge: InsertChallenge
+}) => {
+  const { db, challenge } = input
+
+  const normalizedChallenge = {
+    ...challenge,
+    address: getAddress(challenge.address),
+  }
+  const results = await db
+    .insert(challenges)
+    .values(normalizedChallenge)
+    .returning()
+
+  return results[0]
+}

--- a/apps/dapp-console-api/src/models/contracts.ts
+++ b/apps/dapp-console-api/src/models/contracts.ts
@@ -80,6 +80,21 @@ export const getContractsForApp = async (input: {
     .orderBy(asc(contracts.createdAt))
 }
 
+export const getContract = async (input: {
+  db: Database
+  contractId: Contract['id']
+  entityId: Contract['entityId']
+}) => {
+  const { db, contractId, entityId } = input
+
+  const results = await db
+    .select()
+    .from(contracts)
+    .where(and(eq(contracts.id, contractId), eq(contracts.entityId, entityId)))
+
+  return results[0] || null
+}
+
 export const insertContract = async (input: {
   db: Database
   contract: InsertContract

--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -33,6 +33,10 @@ export const metrics = {
     name: 'list_contracts_error_count',
     help: 'Total number of errors encountered while attempting to fetch contracts from db',
   }),
+  fetchContractErrorCount: new Counter({
+    name: 'fetch_contract_error_count',
+    help: 'Total number of errors encountered while attempting to fetch a single contract from db',
+  }),
   fetchActiveAppsCountErrorCount: new Counter({
     name: 'fetch_active_apps_count_error_count',
     help: 'Total number of errors encountered while fetching count of active apps',
@@ -53,5 +57,13 @@ export const metrics = {
   insertContractErrorCount: new Counter({
     name: 'insert_contract_error_count',
     help: 'Total number of errors encountered while inserting a new contract',
+  }),
+  fetchChallengeErrorCount: new Counter({
+    name: 'fetch_challenge_error_count',
+    help: 'Total number of errors encountered while attempting to fetch a single challenge from db',
+  }),
+  insertChallengeErrorCount: new Counter({
+    name: 'insert_challenge_error_count',
+    help: 'Total number of errors encountered while inserting a new challenge',
   }),
 }

--- a/apps/dapp-console-api/src/utils/challenges.ts
+++ b/apps/dapp-console-api/src/utils/challenges.ts
@@ -1,0 +1,5 @@
+import type { Address } from 'viem'
+
+export const generateChallenge = (address: Address) => {
+  return `I verify that I am the owner of ${address}, and I'm an optimist`
+}

--- a/apps/dapp-console-api/src/utils/index.ts
+++ b/apps/dapp-console-api/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './challenges'
 export * from './helpers'
 export * from './privy'


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/891

Adds `startVerification` endpoint to the `contracts` route. This endpoint handles creating a challenge for the user when they are going through the contract verification flow.