### PR TITLE
feat(dapp-console-api): `totalRebatesClaimed` endpoint

### DIFF
--- a/apps/dapp-console-api/src/Service.ts
+++ b/apps/dapp-console-api/src/Service.ts
@@ -26,6 +26,7 @@ import { metrics } from './monitoring/metrics'
 import { AppsRoute } from './routes/apps'
 import { AuthRoute } from './routes/auth'
 import { ContractsRoute } from './routes/contracts'
+import { RebatesRoute } from './routes/rebates/RebatesRoute'
 import { WalletsRoute } from './routes/wallets'
 import { Trpc } from './Trpc'
 import { retryWithBackoff } from './utils'
@@ -129,6 +130,7 @@ export class Service {
     const walletsRoute = new WalletsRoute(trpc)
     const appsRoute = new AppsRoute(trpc)
     const contractsRoute = new ContractsRoute(trpc)
+    const rebatesRoute = new RebatesRoute(trpc)
 
     /**
      * The apiServer simply assmbles the routes into a TRPC Server
@@ -138,6 +140,7 @@ export class Service {
       walletsRoute,
       appsRoute,
       contractsRoute,
+      rebatesRoute,
     })
     apiServer.setLoggingServer(logger)
 

--- a/apps/dapp-console-api/src/api/ApiV0.ts
+++ b/apps/dapp-console-api/src/api/ApiV0.ts
@@ -1,6 +1,7 @@
 import type { AppsRoute } from '@/routes/apps'
 import type { AuthRoute } from '@/routes/auth'
 import type { ContractsRoute } from '@/routes/contracts'
+import type { RebatesRoute } from '@/routes/rebates'
 import type { WalletsRoute } from '@/routes/wallets'
 
 import { MajorApiVersion } from '../constants'
@@ -36,6 +37,7 @@ export class ApiV0 extends Api {
     [this.routes.walletsRoute.name]: this.routes.walletsRoute.handler,
     [this.routes.appsRoute.name]: this.routes.appsRoute.handler,
     [this.routes.contractsRoute.name]: this.routes.contractsRoute.handler,
+    [this.routes.rebatesRoute.name]: this.routes.rebatesRoute.handler,
   })
 
   /**
@@ -48,6 +50,7 @@ export class ApiV0 extends Api {
       walletsRoute: WalletsRoute
       appsRoute: AppsRoute
       contractsRoute: ContractsRoute
+      rebatesRoute: RebatesRoute
     },
   ) {
     super(trpc)

--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -70,4 +70,8 @@ export const metrics = {
     name: 'complete_challenge_error_count',
     help: 'Total number of times the server failed to mark a challenge as complete',
   }),
+  fetchTotalRebatesClaimedErrorCount: new Counter({
+    name: 'fetch_total_rebates_claimed_error_count',
+    help: 'Total number of errors encountered while fetching total rebates claimed',
+  }),
 }

--- a/apps/dapp-console-api/src/routes/rebates/RebatesRoute.ts
+++ b/apps/dapp-console-api/src/routes/rebates/RebatesRoute.ts
@@ -1,0 +1,39 @@
+import { isPrivyAuthed } from '@/middleware'
+import { getTotalRebatesClaimedByEntity } from '@/models'
+import { metrics } from '@/monitoring/metrics'
+import { Trpc } from '@/Trpc'
+
+import { Route } from '../Route'
+import { assertUserAuthenticated } from '../utils'
+
+export class RebatesRoute extends Route {
+  public readonly name = 'Rebates' as const
+
+  public readonly totalRebatesClaimed = 'totalRebatesClaimed' as const
+  public readonly totalRebatesClaimedController = this.trpc.procedure
+    .use(isPrivyAuthed(this.trpc))
+    .query(async ({ ctx }) => {
+      const { user } = ctx.session
+
+      assertUserAuthenticated(user)
+
+      return await getTotalRebatesClaimedByEntity({
+        db: this.trpc.database,
+        entityId: user.entityId,
+      }).catch((err) => {
+        metrics.fetchTotalRebatesClaimedErrorCount.inc()
+        this.logger?.error(
+          {
+            error: err,
+            entityId: user.entityId,
+          },
+          'error fetching total rebates claimed from db',
+        )
+        throw Trpc.handleStatus(500, 'error fetching total rebates claimed')
+      })
+    })
+
+  public readonly handler = this.trpc.router({
+    [this.totalRebatesClaimed]: this.totalRebatesClaimedController,
+  })
+}

--- a/apps/dapp-console-api/src/routes/rebates/index.ts
+++ b/apps/dapp-console-api/src/routes/rebates/index.ts
@@ -1,0 +1,1 @@
+export * from './RebatesRoute'


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/895

This `totalRebatesClaimed` endpoint returns the total amount of rebates that an entity has claimed.