### PR TITLE
build(monorepo): remove superchain-registry dep and require pnpm 9

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,8 +3,6 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@v2
-      with:
-        version: 8.6.5
 
     - uses: actions/setup-node@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:18-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+
+# corepack depends on packageManager field in package.json
+COPY package.json ./
+
 RUN corepack enable
 
 ########################################
@@ -40,7 +44,7 @@ RUN pnpm deploy --filter=paymaster-proxy --prod /prod/paymaster-proxy
 # copy built dapp-console-api app & isolated node_modules to prod/dapp-console-api
 RUN pnpm deploy --filter=dapp-console-api --prod /prod/dapp-console-api
 
-RUN pnpm deploy --filter=api-key-service --prod /prod/api-key-service 
+RUN pnpm deploy --filter=api-key-service --prod /prod/api-key-service
 
 ########################################
 # STEP 2: PAYMASTER-PROXY

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "ecosystem",
   "author": "Optimism PBC",
   "license": "MIT",
+  "packageManager": "pnpm@9.0.2",
+  "engines": {
+    "pnpm": "^9.0.0",
+    "node": "^18.0.0"
+  },
   "scripts": {
     "clean": "pnpm recursive run clean",
     "create:app": "cd apps && pnpm create vite --template=react-ts ",

--- a/packages/op-app/package.json
+++ b/packages/op-app/package.json
@@ -25,7 +25,6 @@
     "tsup": "^8.0.1"
   },
   "devDependencies": {
-    "@eth-optimism/superchain-registry": "github:ethereum-optimism/superchain-registry",
     "@tanstack/react-query": "^5.10.0",
     "@testing-library/react": "^14.1.2",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,9 +785,6 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1(ts-node@10.9.1)(typescript@5.3.2)
     devDependencies:
-      '@eth-optimism/superchain-registry':
-        specifier: github:ethereum-optimism/superchain-registry
-        version: github.com/ethereum-optimism/superchain-registry/7ee6b3cb8f7d27a52705f93997604ad146fbcfdc
       '@tanstack/react-query':
         specifier: ^5.10.0
         version: 5.10.0(react@18.2.0)
@@ -27239,9 +27236,3 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
-
-  github.com/ethereum-optimism/superchain-registry/7ee6b3cb8f7d27a52705f93997604ad146fbcfdc:
-    resolution: {tarball: https://codeload.github.com/ethereum-optimism/superchain-registry/tar.gz/7ee6b3cb8f7d27a52705f93997604ad146fbcfdc}
-    name: '@eth-optimism/superchain-registry'
-    version: 0.0.1-alpha.1
-    dev: true


### PR DESCRIPTION
builds were failing post pnpm 9 upgrade because of some change in how github repo packages are fetched. removed the package since we don't use it right now.

to prevent inconsistencies happening with the new pnpm lockfile v9, also require that devs use pnpm 9

1. force devs to use pnpm 9 - see "engine"
2. force corepack to use pnpm 9 - see "packageManager"
3. remove superchain registry dep