### PR TITLE
feat(dapp-console-api): `deleteContract` endpoint

### DIFF
--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -122,4 +122,12 @@ export const metrics = {
     name: 'trace_tx_error_count',
     help: 'Total number of times the server failed to trace a transaction',
   }),
+  deleteContractErrorCount: new Counter({
+    name: 'delete_contract_error_count',
+    help: 'Total number of times the server failed to delete a contract',
+  }),
+  restoreDeletedContractErrorCount: new Counter({
+    name: 'restore_deleted_contract_error_count',
+    help: 'Total number of times a deleted contract failed to be restored',
+  }),
 }

--- a/apps/dapp-console-api/src/routes/rebates/RebatesRoute.ts
+++ b/apps/dapp-console-api/src/routes/rebates/RebatesRoute.ts
@@ -21,8 +21,8 @@ import type { DeploymentRebate } from '@/models'
 import {
   ContractState,
   DeploymentRebateState,
+  getActiveContract,
   getCompletedRebatesForEntityByCursor,
-  getContract,
   getDeploymentRebateByContractId,
   getTotalRebatesClaimed,
   getWalletVerifications,
@@ -120,7 +120,7 @@ export class RebatesRoute extends Route {
 
       assertUserAuthenticated(user)
 
-      const contract = await getContract({
+      const contract = await getActiveContract({
         db: this.trpc.database,
         contractId,
         entityId: user.entityId,

--- a/apps/dapp-console/app/types/api.ts
+++ b/apps/dapp-console/app/types/api.ts
@@ -18,7 +18,7 @@ export type Contract = {
   contractAddress: Address
   createdAt: Date
   updatedAt: Date
-  state: 'not_verified' | 'verified'
+  state: 'not_verified' | 'verified' | 'deleted'
   entityId: string
   appId: string
   deployerAddress: Address


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecopod/issues/891

`deleteContract` endpoint performs a soft delete on the contract in the db. This pr also updates the `createContract` endpoint to check if the contract has previously been deleted when creating a new contract.