### PR TITLE
Dev Console Anvil State

### DIFF
--- a/packages/contracts-ecosystem/.gitignore
+++ b/packages/contracts-ecosystem/.gitignore
@@ -6,6 +6,7 @@ out/
 !/broadcast
 /broadcast/*/31337/
 /broadcast/**/dry-run/
+/broadcast/DeployConsoleApiTestEnv.s.sol
 
 # Docs
 docs/

--- a/packages/contracts-ecosystem/script/DeployConsoleApiTestEnv.s.sol
+++ b/packages/contracts-ecosystem/script/DeployConsoleApiTestEnv.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {SimpleNFT} from "../src/SimpleNFT.sol";
+
+contract DeployConsoleApiTestEnv is Script {
+    function setUp() public {}
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+        bytes32 salt = keccak256(bytes("TestSalt"));
+        
+        console.log("Deploying contracts with create");
+        deployContracts();
+
+        console.log("Deploying contracts with create2");
+        deployCreate2Contracts(salt);
+
+        vm.stopBroadcast();
+    }
+
+    function deployContracts() internal {
+        for (uint256 i = 0; i < 10; i++) {
+            new SimpleNFT();
+        }
+    }
+
+    function deployCreate2Contracts(bytes32 salt) internal {
+        new SimpleNFT{salt: salt}();
+    }
+}

--- a/packages/contracts-ecosystem/script/DeployConsoleApiTestEnv.s.sol
+++ b/packages/contracts-ecosystem/script/DeployConsoleApiTestEnv.s.sol
@@ -13,7 +13,7 @@ contract DeployConsoleApiTestEnv is Script {
 
         vm.startBroadcast(deployerPrivateKey);
         bytes32 salt = keccak256(bytes("TestSalt"));
-        
+
         console.log("Deploying contracts with create");
         deployContracts();
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds a forge script called `DeployConsoleApiTestEnv.s.sol` this will deploy 10 create contracts, and a single create2 contract.

Set `DEPLOYER_PRIVATE_KEY` in the `contracts-ecosystem`  `env` file to the deployer address you want. I used the one at index 0 in anvil https://github.com/ethereum-optimism/ecosystem/blob/8bef0131a48cdb21b7207d34803898c92396ddf3/packages/op-app/src/test-utils/anvil.ts#L33

**Run Script**
```
forge script ./script/DeployConsoleApiTestEnv.s.sol --broadcast --rpc-url http://localhost:8545
```