### PR TITLE
feat(dapp-console-api): add support for contracts deployed by CREATE2

### DIFF
--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -118,4 +118,8 @@ export const metrics = {
     name: 'fetch_completed_rebates_list_error_count',
     help: 'Total number of times the server failed to fetch the list of completed deployment rebates',
   }),
+  traceTxErrorCount: new Counter({
+    name: 'trace_tx_error_count',
+    help: 'Total number of times the server failed to trace a transaction',
+  }),
 }


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecopod/issues/929

Extends public client to include a `debug_traceTransaction` request so that `CREATE2` contract deployments can be successfully verified.