### PR TITLE
add privy token to authorization header

### DIFF
--- a/apps/dapp-console-api/src/middleware/isPrivyAuthed.ts
+++ b/apps/dapp-console-api/src/middleware/isPrivyAuthed.ts
@@ -15,7 +15,7 @@ export const isPrivyAuthed = (trpc: Trpc) => {
         req.headers['Authorization'] as string,
       )
     }
-    console.log('TOK', accessToken)
+
     if (!accessToken) {
       throw Trpc.handleStatus(401, `user not signed in to privy`)
     }

--- a/apps/dapp-console-api/src/middleware/isPrivyAuthed.ts
+++ b/apps/dapp-console-api/src/middleware/isPrivyAuthed.ts
@@ -8,22 +8,27 @@ import { Trpc } from '@/Trpc'
 export const isPrivyAuthed = (trpc: Trpc) => {
   return trpc.middleware(async ({ ctx, next }) => {
     const { req, session } = ctx
-    const cookieAccessToken = req.cookies[PRIVY_TOKEN_COOKIE_KEY]
 
-    if (!cookieAccessToken) {
+    let accessToken = req.cookies[PRIVY_TOKEN_COOKIE_KEY]
+    if (!accessToken && req.headers && req.headers['Authorization']) {
+      accessToken = parseAuthorizationHeader(
+        req.headers['Authorization'] as string,
+      )
+    }
+    console.log('TOK', accessToken)
+    if (!accessToken) {
       throw Trpc.handleStatus(401, `user not signed in to privy`)
     }
 
-    const hashedCookieAccessToken = await hashAccessToken(cookieAccessToken)
+    const hashedAccessToken = await hashAccessToken(accessToken)
 
     if (
       !session.user ||
-      session.user.privyAccessToken !== hashedCookieAccessToken ||
+      session.user.privyAccessToken !== hashedAccessToken ||
       session.user.privyAccessTokenExpiration < Date.now()
     ) {
       try {
-        const verifiedPrivy =
-          await trpc.privy.verifyAuthToken(cookieAccessToken)
+        const verifiedPrivy = await trpc.privy.verifyAuthToken(accessToken)
 
         let entity = await getEntityByPrivyDid(
           trpc.database,
@@ -36,7 +41,7 @@ export const isPrivyAuthed = (trpc: Trpc) => {
         }
 
         session.user = {
-          privyAccessToken: hashedCookieAccessToken,
+          privyAccessToken: hashedAccessToken,
           // verifiedPrivy.expiration is in seconds
           privyAccessTokenExpiration: verifiedPrivy.expiration * 1000,
           privyDid: verifiedPrivy.userId,
@@ -55,4 +60,8 @@ export const isPrivyAuthed = (trpc: Trpc) => {
 
 const hashAccessToken = (accessToken: string) => {
   return bcrypt.hash(accessToken, envVars.PRIVY_ACCESS_TOKEN_SALT)
+}
+
+const parseAuthorizationHeader = (value: string) => {
+  return value.replace('Bearer', '').trim()
 }

--- a/apps/dapp-console-api/src/testhelpers/auth.ts
+++ b/apps/dapp-console-api/src/testhelpers/auth.ts
@@ -12,20 +12,35 @@ import type { Session } from '@/constants/session'
 
 import { mockUserSession } from './session'
 
+export type AccessTokenLocation = 'header' | 'cookie'
+
 export const mockPrivyAccessToken = 'privy_token'
 
 export const createSignedInCaller = <T extends AnyRouter>(
   router: T,
   session: Awaited<ReturnType<typeof getIronSession<SessionData>>>,
   privyAccessToken?: string,
+  tokenLocation: AccessTokenLocation = 'cookie',
 ) => {
   const callerFactory = createCallerFactory()
   const createCaller = callerFactory(router)
+
+  const headers: Record<string, string> = {}
+  const cookies: Record<string, string> = {}
+
+  if (tokenLocation === 'cookie') {
+    cookies[PRIVY_TOKEN_COOKIE_KEY] = privyAccessToken || mockPrivyAccessToken
+  }
+
+  if (tokenLocation === 'header') {
+    headers['Authorization'] =
+      `Bearer ${privyAccessToken || mockPrivyAccessToken}`
+  }
+
   return createCaller({
     req: {
-      cookies: {
-        [PRIVY_TOKEN_COOKIE_KEY]: privyAccessToken || mockPrivyAccessToken,
-      } as any,
+      headers,
+      cookies,
     } as Request,
     res: {} as Response,
     session: session,

--- a/apps/dapp-console/app/helpers/apiClient.ts
+++ b/apps/dapp-console/app/helpers/apiClient.ts
@@ -19,11 +19,12 @@ export const apiClient = createTRPCNext<ApiV0['handler']>({
         httpBatchLink({
           url: `${ENV_VARS.API_URL}/api/v0`,
           fetch: (url, options) => {
-            let headers: Record<string, string> = {}
+            const headers: Record<string, string> = {}
 
             const accessToken = localStorage.getItem('privy:token')
             if (accessToken) {
-              headers['Authorization'] = `Bearer ${parseAccessToken(accessToken)}`
+              headers['Authorization'] =
+                `Bearer ${parseAccessToken(accessToken)}`
             }
 
             return fetch(url, {

--- a/apps/dapp-console/app/helpers/apiClient.ts
+++ b/apps/dapp-console/app/helpers/apiClient.ts
@@ -8,6 +8,10 @@ import type { ApiV0 } from '@eth-optimism/dapp-console-api'
 
 import { ENV_VARS } from '@/app/constants/envVars'
 
+function parseAccessToken(accessToken: string) {
+  return JSON.parse(accessToken)
+}
+
 export const apiClient = createTRPCNext<ApiV0['handler']>({
   config: () => {
     return {
@@ -19,7 +23,7 @@ export const apiClient = createTRPCNext<ApiV0['handler']>({
 
             const accessToken = localStorage.getItem('privy:token')
             if (accessToken) {
-              headers['Authorization'] = `Bearer ${accessToken}`
+              headers['Authorization'] = `Bearer ${parseAccessToken(accessToken)}`
             }
 
             return fetch(url, {

--- a/apps/dapp-console/app/helpers/apiClient.ts
+++ b/apps/dapp-console/app/helpers/apiClient.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createTRPCNext } from '@trpc/next'
 import { httpBatchLink } from '@trpc/client'
 import superjson from 'superjson'
@@ -13,8 +15,16 @@ export const apiClient = createTRPCNext<ApiV0['handler']>({
         httpBatchLink({
           url: `${ENV_VARS.API_URL}/api/v0`,
           fetch: (url, options) => {
+            let headers: Record<string, string> = {}
+
+            const accessToken = localStorage.getItem('privy:token')
+            if (accessToken) {
+              headers['Authorization'] = `Bearer ${accessToken}`
+            }
+
             return fetch(url, {
               ...options,
+              headers,
               credentials: 'include',
             })
           },


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Update the FE & BE to support an `Authorization` header flow. Our deploy previews aren't on the same domain as the backend so the cookie flow won't work on deploy previews, updating our auth flow to support pulling the token from localStorage and passing it up in the `Authorization` header will get us around this.