### PR TITLE
use trpc utils to invalidate cache

### DIFF
--- a/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
-  DialogTrigger,
 } from '@eth-optimism/ui-components'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 import { Hash, formatEther } from 'viem'
@@ -19,17 +18,18 @@ import { optimism } from 'viem/chains'
 import { apiClient } from '@/app/helpers/apiClient'
 
 export type ClaimRebateDialogProps = {
+  open: boolean
+  onOpenChange: (isOpen: boolean) => void
   contract: Contract
-  children: React.ReactNode
   onRebateClaimed: (contract: Contract) => void
 }
 
 export const ClaimRebateDialog = ({
+  open,
+  onOpenChange,
   contract,
-  children,
   onRebateClaimed,
 }: ClaimRebateDialogProps) => {
-  const [isOpen, setOpen] = useState(false)
   const [rebateTxHash, setRebateTxHash] = useState<Hash | undefined>()
 
   const { mutateAsync: claimRebate } =
@@ -71,7 +71,7 @@ export const ClaimRebateDialog = ({
     })
     setRebateTxHash(txHash)
     onRebateClaimed(contract)
-  }, [setOpen, setRebateTxHash, onRebateClaimed])
+  }, [setRebateTxHash, onRebateClaimed])
 
   const handleViewTransaction = useCallback(() => {
     window.open(
@@ -80,11 +80,10 @@ export const ClaimRebateDialog = ({
     )
   }, [rebateTxHash])
 
-  const handleCancel = useCallback(() => setOpen(false), [setOpen])
+  const handleCancel = useCallback(() => onOpenChange(false), [onOpenChange])
 
   return (
-    <Dialog open={isOpen} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader className="text-center items-center">
           <Image

--- a/apps/dapp-console/app/settings/components/EligibleForRebateBadge.tsx
+++ b/apps/dapp-console/app/settings/components/EligibleForRebateBadge.tsx
@@ -1,20 +1,21 @@
 import { Badge } from '@eth-optimism/ui-components'
 import { RiArrowRightSLine } from '@remixicon/react'
-import { ClaimRebateDialog } from '@/app/settings/components/ClaimRebateDialog'
 import { Contract } from '@/app/types/api'
 
 export type EligibleForRebateBadgeProps = {
   contract: Contract
-  onRebateClaimed: (contract: Contract) => void
+  onStartClaimRebate: (contract: Contract) => void
 }
 
 export const EligibleForRebateBadge = ({
   contract,
-  onRebateClaimed,
+  onStartClaimRebate,
 }: EligibleForRebateBadgeProps) => (
-  <ClaimRebateDialog contract={contract} onRebateClaimed={onRebateClaimed}>
-    <Badge className="pr-1 max-h-[22px] cursor-pointer" variant="success">
-      Eligible for rebate <RiArrowRightSLine size={16} className="mt-0.5" />
-    </Badge>
-  </ClaimRebateDialog>
+  <Badge
+    className="pr-1 max-h-[22px] cursor-pointer"
+    variant="success"
+    onClick={() => onStartClaimRebate(contract)}
+  >
+    Eligible for rebate <RiArrowRightSLine size={16} className="mt-0.5" />
+  </Badge>
 )

--- a/apps/dapp-console/app/settings/contracts/DeployedAppContract.tsx
+++ b/apps/dapp-console/app/settings/contracts/DeployedAppContract.tsx
@@ -10,20 +10,24 @@ import { NotEligibleForRebateBadge } from '@/app/settings/components/NotEligible
 import { shortenAddress } from '@eth-optimism/op-app'
 import { usePrivy } from '@privy-io/react-auth'
 import { NeedsVerificationBadge } from '@/app/settings/components/NeedsVerificationBadge'
+import { apiClient } from '@/app/helpers/apiClient'
+import { MAX_CLAIMABLE_AMOUNT } from '@/app/constants/rebate'
 
 export type AppContractProps = {
   app: DeployedApp
   contract: Contract
   onStartVerification: (contract: Contract) => void
-  onRebateClaimed: (contract: Contract) => void
+  onStartClaimRebate: (contract: Contract) => void
 }
 
 export const DeployedAppContract = ({
   contract,
   onStartVerification,
-  onRebateClaimed,
+  onStartClaimRebate,
 }: AppContractProps) => {
   const { user } = usePrivy()
+  const { data: totalRebatesClaimed } =
+    apiClient.Rebates.totalRebatesClaimed.useQuery()
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(contract.contractAddress)
@@ -49,13 +53,17 @@ export const DeployedAppContract = ({
       return items
     }
 
+    if (totalRebatesClaimed && totalRebatesClaimed >= MAX_CLAIMABLE_AMOUNT) {
+      return items
+    }
+
     if (contract.state === 'verified') {
       if (contract.isEligibleForRebate) {
         items.push(
           <EligibleForRebateBadge
             key="rebate-badge"
             contract={contract}
-            onRebateClaimed={onRebateClaimed}
+            onStartClaimRebate={onStartClaimRebate}
           />,
         )
       } else {

--- a/apps/dapp-console/app/settings/contracts/page.tsx
+++ b/apps/dapp-console/app/settings/contracts/page.tsx
@@ -13,7 +13,7 @@ export default function Contracts() {
   const { mutate: syncCbVerification } =
     apiClient.wallets.syncCbVerification.useMutation()
 
-  const { data: walletVerifications } =
+  const { data: walletVerifications, isLoading: isLoadingCbVerifiedWallets } =
     apiClient.wallets.walletVerifications.useQuery()
 
   useEffect(() => {
@@ -30,9 +30,10 @@ export default function Contracts() {
 
       <Text className="text-lg font-semibold">Your Rebates</Text>
       <div className="flex flex-col gap-4">
-        {!walletVerifications?.cbVerifiedWallets && (
-          <CoinbaseVerificationBanner />
-        )}
+        {!isLoadingCbVerifiedWallets &&
+          !walletVerifications?.cbVerifiedWallets.length && (
+            <CoinbaseVerificationBanner />
+          )}
         <ClaimedRebateProgressBanner />
         <ClaimedRebates />
       </div>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

I learned today that trpcs react query integration comes with some utilities for helping to manage the cache https://trpc.io/docs/client/react/useUtils. Instead of having to refetch anything from the api we can just use the utils to invalidate the cache and react query will handle the refetching logic.

This PR updates to start using `useUtils` to keep all the different api calls in sync when we make mutations on the contracts page.
