### PR TITLE
Dial down border radius for ui-components

### DIFF
--- a/apps/dapp-console/app/insights/page.tsx
+++ b/apps/dapp-console/app/insights/page.tsx
@@ -13,7 +13,7 @@ export default function Insights() {
   return (
     <main className="flex justify-center relative">
       <Banner />
-      <Card className="max-w-7xl w-full mt-36 mx-8 mb-16 z-10 p-16 flex flex-col items-center">
+      <Card className="max-w-7xl w-full mt-36 mx-8 mb-16 z-10 p-16 flex flex-col items-center rounded-2xl">
         <RiCompasses2Line size={64} className="mb-4" />
         <Text as="h2" className="text-base mb-1 font-semibold">
           We're still working on insights

--- a/apps/dapp-console/app/page.tsx
+++ b/apps/dapp-console/app/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
   return (
     <main className="flex justify-center relative">
       <Banner />
-      <Card className="max-w-7xl w-full mt-36 mx-8 z-10 mb-16">
+      <Card className="max-w-7xl w-full mt-36 mx-8 z-10 mb-16 rounded-2xl">
         <CardHeader className="md:p-10 lg:p-16">
           <CardTitle>
             <Text as="span" className="text-4xl mb-2">

--- a/packages/ui-components/src/style.css
+++ b/packages/ui-components/src/style.css
@@ -31,7 +31,7 @@
     --success-foreground: 131 85% 35%;
     --contrast: 0 0% 0%;
     --contrast-foreground: 0 0% 100%;
-    --radius: 1rem;
+    --radius: 0.5rem;
   }
 
   .dark {


### PR DESCRIPTION
This PR adjusts the border radius attribute in ui-components' style.css.

### What changed?

The border radius in the style.css file was changed from 1rem to a more refined 0.5rem. This change specifically affects the --radius variable used in the css.

