### PR TITLE
Adds loading states to create contract, claim rebate, and verification flows

### DIFF
--- a/apps/dapp-console/app/console/constants.tsx
+++ b/apps/dapp-console/app/console/constants.tsx
@@ -149,7 +149,9 @@ export const deploymentRebateM2Metadata: DialogMetadata = {
   primaryButton: (
     <Button id="deployment-rebate-add-contracts" size="lg" asChild>
       <Link href={routes.CONTRACTS.path}>
-        <Text as="span">Add Contracts</Text>
+        <Text as="span" className="cursor-pointer">
+          Add Contracts
+        </Text>
       </Link>
     </Button>
   ),
@@ -161,7 +163,9 @@ export const deploymentRebateM2Metadata: DialogMetadata = {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <Text as="span">See Terms</Text>
+        <Text as="span" className="cursor-pointer">
+          See Terms
+        </Text>
       </Link>
     </Button>
   ),

--- a/apps/dapp-console/app/helpers/apiClient.ts
+++ b/apps/dapp-console/app/helpers/apiClient.ts
@@ -23,7 +23,8 @@ export const apiClient = createTRPCNext<ApiV0['handler']>({
 
             const accessToken = localStorage.getItem('privy:token')
             if (accessToken) {
-              headers['Authorization'] = parseAccessToken(accessToken)
+              headers['Authorization'] =
+                `Bearer ${parseAccessToken(accessToken)}`
             }
 
             return fetch(url, {

--- a/apps/dapp-console/app/helpers/apiClient.ts
+++ b/apps/dapp-console/app/helpers/apiClient.ts
@@ -23,13 +23,15 @@ export const apiClient = createTRPCNext<ApiV0['handler']>({
 
             const accessToken = localStorage.getItem('privy:token')
             if (accessToken) {
-              headers['Authorization'] =
-                `Bearer ${parseAccessToken(accessToken)}`
+              headers['Authorization'] = parseAccessToken(accessToken)
             }
 
             return fetch(url, {
               ...options,
-              headers,
+              headers: {
+                ...options?.headers,
+                ...headers,
+              },
               credentials: 'include',
             })
           },

--- a/apps/dapp-console/app/lib/utils.ts
+++ b/apps/dapp-console/app/lib/utils.ts
@@ -1,5 +1,8 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import type { Chain } from 'viem'
+import { optimism, optimismSepolia } from 'viem/chains'
+import { superchainIdMap } from '../constants/superchain'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -11,4 +14,15 @@ export function getDateString(date: Date) {
     day: '2-digit',
     year: 'numeric',
   })
+}
+
+export function getRebateBlockExplorerUrl(chainId: number) {
+  const config = superchainIdMap[chainId]
+
+  if (!config) {
+    throw new Error('Cannot find chainId')
+  }
+
+  const chain = [config.mainnet, ...config.testnets].find((chain) => chain?.id === chainId)
+  return chain?.testnet ? optimismSepolia.blockExplorers.default.url : optimism.blockExplorers.default.url
 }

--- a/apps/dapp-console/app/lib/utils.ts
+++ b/apps/dapp-console/app/lib/utils.ts
@@ -1,8 +1,7 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
-import type { Chain } from 'viem'
 import { optimism, optimismSepolia } from 'viem/chains'
-import { superchainIdMap } from '../constants/superchain'
+import { superchainIdMap } from '@/app/constants/superchain'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -23,6 +22,10 @@ export function getRebateBlockExplorerUrl(chainId: number) {
     throw new Error('Cannot find chainId')
   }
 
-  const chain = [config.mainnet, ...config.testnets].find((chain) => chain?.id === chainId)
-  return chain?.testnet ? optimismSepolia.blockExplorers.default.url : optimism.blockExplorers.default.url
+  const chain = [config.mainnet, ...config.testnets].find(
+    (chain) => chain?.id === chainId,
+  )
+  return chain?.testnet
+    ? optimismSepolia.blockExplorers.default.url
+    : optimism.blockExplorers.default.url
 }

--- a/apps/dapp-console/app/settings/account/page.tsx
+++ b/apps/dapp-console/app/settings/account/page.tsx
@@ -4,29 +4,14 @@ import {
   Button,
   Input,
   Label,
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  Separator,
 } from '@eth-optimism/ui-components'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 
 import { usePrivy } from '@privy-io/react-auth'
-import { RiAlertFill, RiEdit2Fill } from '@remixicon/react'
-import { useCallback, useState } from 'react'
+import { RiEdit2Fill } from '@remixicon/react'
 
 export default function Account() {
-  const [isOpen, setOpen] = useState(false)
   const { user, updateEmail } = usePrivy()
-
-  const handleDeleteAccount = useCallback(() => {
-    // TODO: add backend call here
-
-    // hard refresh after deleting user
-    window.location.href = '/'
-  }, [])
-
-  const handleCancel = useCallback(() => setOpen(false), [setOpen])
 
   if (!user) {
     return
@@ -43,7 +28,7 @@ export default function Account() {
           type="email"
           className="bg-secondary cursor-default mr-2"
           value={user.email?.address ?? ''}
-          disabled={true}
+          readOnly
         />
         <Button variant="secondary" onClick={updateEmail}>
           <Text as="span" className="hidden md:flex">
@@ -52,35 +37,6 @@ export default function Account() {
           <RiEdit2Fill className="flex md:hidden" />
         </Button>
       </div>
-
-      <Separator />
-
-      <Dialog open={isOpen} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          <Button variant="ghost" className="mt-8 self-start">
-            <Text as="span" className="text-red-800">
-              Delete account
-            </Text>
-          </Button>
-        </DialogTrigger>
-        <DialogContent>
-          <div className="w-full flex flex-col items-center">
-            <RiAlertFill className="rounded" size={64} />
-          </div>
-          <Text
-            as="p"
-            className="cursor-default mt-4 mb-2 text-center text-lg font-semibold"
-          >
-            Are you sure you want to delete your account?
-          </Text>
-          <Button className="w-full" onClick={handleDeleteAccount}>
-            Delete account
-          </Button>
-          <Button className="w-full" variant="outline" onClick={handleCancel}>
-            Cancel
-          </Button>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/apps/dapp-console/app/settings/account/page.tsx
+++ b/apps/dapp-console/app/settings/account/page.tsx
@@ -1,10 +1,6 @@
 'use client'
 
-import {
-  Button,
-  Input,
-  Label,
-} from '@eth-optimism/ui-components'
+import { Button, Input, Label } from '@eth-optimism/ui-components'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 
 import { usePrivy } from '@privy-io/react-auth'
@@ -26,12 +22,12 @@ export default function Account() {
       <div className="flex flex-row mb-10">
         <Input
           type="email"
-          className="bg-secondary cursor-default mr-2"
+          className="cursor-default focus-visible:ring-0 mr-2"
           value={user.email?.address ?? ''}
           readOnly
         />
         <Button variant="secondary" onClick={updateEmail}>
-          <Text as="span" className="hidden md:flex">
+          <Text as="span" className="hidden md:flex cursor-pointer">
             Edit
           </Text>
           <RiEdit2Fill className="flex md:hidden" />

--- a/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
@@ -5,6 +5,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
+  toast,
 } from '@eth-optimism/ui-components'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 import { Hash, formatEther } from 'viem'
@@ -16,6 +17,9 @@ import { Contract } from '@/app/types/api'
 import { Network } from '@/app/components/Network'
 import { optimism } from 'viem/chains'
 import { apiClient } from '@/app/helpers/apiClient'
+import { cn, getRebateBlockExplorerUrl } from '@/app/lib/utils'
+import { RiLoader4Line } from '@remixicon/react'
+import { LONG_DURATION } from '@/app/constants/toast'
 
 export type ClaimRebateDialogProps = {
   open: boolean
@@ -32,7 +36,7 @@ export const ClaimRebateDialog = ({
 }: ClaimRebateDialogProps) => {
   const [rebateTxHash, setRebateTxHash] = useState<Hash | undefined>()
 
-  const { mutateAsync: claimRebate } =
+  const { mutateAsync: claimRebate, isLoading: isLoadingClaimRebate } =
     apiClient.Rebates.claimDeploymentRebate.useMutation()
 
   const { data: wallets } = apiClient.wallets.listWallets.useQuery({})
@@ -65,20 +69,30 @@ export const ClaimRebateDialog = ({
   }, [contract])
 
   const handleClaim = useCallback(async () => {
+    if (isLoadingClaimRebate) {
+      return
+    }
+
     const { txHash } = await claimRebate({
       contractId: contract.id,
       recipientAddress: contract.deployerAddress,
     })
+
+    toast({
+      description: 'Rebate Claimed',
+      duration: LONG_DURATION,
+    })
+
     setRebateTxHash(txHash)
     onRebateClaimed(contract)
   }, [setRebateTxHash, onRebateClaimed])
 
   const handleViewTransaction = useCallback(() => {
     window.open(
-      `${optimism.blockExplorers.default.url}/tx/${rebateTxHash}`,
+      `${getRebateBlockExplorerUrl(contract.chainId)}/tx/${rebateTxHash}`,
       '_blank',
     )
-  }, [rebateTxHash])
+  }, [contract, rebateTxHash])
 
   const handleCancel = useCallback(() => onOpenChange(false), [onOpenChange])
 
@@ -155,6 +169,8 @@ export const ClaimRebateDialog = ({
               <Text as="span">
                 {rebateTxHash ? 'View Transaction' : 'Claim Rebate'}
               </Text>
+
+              {isLoadingClaimRebate ? <RiLoader4Line className="ml-2 animate-spin" /> : null}
             </Button>
           ) : (
             <Button className="h-[48px]" asChild>

--- a/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
@@ -148,7 +148,7 @@ export const ClaimRebateDialog = ({
               >
                 To
               </Text>
-              <Network chainId={optimism.id} />
+              <Network chainId={optimism.id} className="cursor-default" />
             </div>
             <Text as="p" className="text-right">
               {shortenAddress(contract.transaction!.fromAddress)}
@@ -166,7 +166,7 @@ export const ClaimRebateDialog = ({
               className="h-[48px]"
               onClick={rebateTxHash ? handleViewTransaction : handleClaim}
             >
-              <Text as="span">
+              <Text as="span" className="cursor-pointer">
                 {rebateTxHash ? 'View Transaction' : 'Claim Rebate'}
               </Text>
 
@@ -192,7 +192,9 @@ export const ClaimRebateDialog = ({
             className="mt-2 h-[48px]"
             onClick={handleCancel}
           >
-            <Text as="span">Cancel</Text>
+            <Text as="span" className="cursor-pointer">
+              Cancel
+            </Text>
           </Button>
         </div>
       </DialogContent>

--- a/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
@@ -17,7 +17,7 @@ import { Contract } from '@/app/types/api'
 import { Network } from '@/app/components/Network'
 import { optimism } from 'viem/chains'
 import { apiClient } from '@/app/helpers/apiClient'
-import { cn, getRebateBlockExplorerUrl } from '@/app/lib/utils'
+import { getRebateBlockExplorerUrl } from '@/app/lib/utils'
 import { RiLoader4Line } from '@remixicon/react'
 import { LONG_DURATION } from '@/app/constants/toast'
 
@@ -170,7 +170,9 @@ export const ClaimRebateDialog = ({
                 {rebateTxHash ? 'View Transaction' : 'Claim Rebate'}
               </Text>
 
-              {isLoadingClaimRebate ? <RiLoader4Line className="ml-2 animate-spin" /> : null}
+              {isLoadingClaimRebate ? (
+                <RiLoader4Line className="ml-2 animate-spin" />
+              ) : null}
             </Button>
           ) : (
             <Button className="h-[48px]" asChild>

--- a/apps/dapp-console/app/settings/components/ClaimedRebates.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimedRebates.tsx
@@ -12,8 +12,7 @@ import { shortenAddress } from '@eth-optimism/op-app'
 import { RiArrowRightSLine } from '@remixicon/react'
 import Link from 'next/link'
 import { apiClient } from '@/app/helpers/apiClient'
-import { optimism } from 'viem/chains'
-import { getDateString } from '@/app/lib/utils'
+import { getDateString, getRebateBlockExplorerUrl } from '@/app/lib/utils'
 
 export const ClaimedRebates = () => {
   const { data: rebateResp } = apiClient.Rebates.listCompletedRebates.useQuery(
@@ -38,7 +37,7 @@ export const ClaimedRebates = () => {
             {rebates.map((rebate) => (
               <div key={rebate.id} className="flex flex-col w-full">
                 <Link
-                  href={`${optimism.blockExplorers.default.url}/tx/${rebate.rebateTxHash}`}
+                  href={`${getRebateBlockExplorerUrl(rebate.chainId)}/tx/${rebate.rebateTxHash}`}
                   target="_blank"
                 >
                   <div className="flex flex-row w-full justify-between items-center">

--- a/apps/dapp-console/app/settings/components/ClaimedRebates.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimedRebates.tsx
@@ -30,8 +30,10 @@ export const ClaimedRebates = () => {
     <div className="flex flex-col w-full">
       <Accordion type="single" collapsible>
         <AccordionItem value="rebates" className="border-none">
-          <AccordionTrigger className="hover:no-underline justify-start">
-            <Text className="font-semibold mr-1">See transactions</Text>
+          <AccordionTrigger className="hover:no-underline justify-start max-w-[150px]">
+            <Text className="font-semibold mr-1 cursor-pointer">
+              See transactions
+            </Text>
           </AccordionTrigger>
           <AccordionContent>
             {rebates.map((rebate) => (
@@ -42,16 +44,19 @@ export const ClaimedRebates = () => {
                 >
                   <div className="flex flex-row w-full justify-between items-center">
                     <div className="flex flex-col py-8">
-                      <Text as="p" className="font-semibold">
+                      <Text as="p" className="font-semibold cursor-pointer">
                         {rebate.rebateTxTimestamp &&
                           getDateString(rebate.rebateTxTimestamp)}
                       </Text>
-                      <Text as="p" className="text-muted-foreground">
+                      <Text
+                        as="p"
+                        className="text-muted-foreground cursor-pointer"
+                      >
                         Contract: {shortenAddress(rebate.contractAddress)}
                       </Text>
                     </div>
                     <div className="flex flex-row items-center">
-                      <Text as="span" className="font-semibold">
+                      <Text as="span" className="font-semibold cursor-pointer">
                         {formatEther(BigInt(rebate.rebateAmount ?? 0), 'wei')}{' '}
                         ETH
                       </Text>

--- a/apps/dapp-console/app/settings/components/IneligibleRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/IneligibleRebateDialog.tsx
@@ -92,7 +92,9 @@ export const IneligibleRebateDialog = ({
           </Text>
 
           <Button className="mt-6 h-[48px]" onClick={handleClose}>
-            <Text as="span">Close</Text>
+            <Text as="span" className="cursor-pointer">
+              Close
+            </Text>
           </Button>
         </div>
       </DialogContent>

--- a/apps/dapp-console/app/settings/components/LinkedWallet.tsx
+++ b/apps/dapp-console/app/settings/components/LinkedWallet.tsx
@@ -39,7 +39,11 @@ export const LinkedWallet = ({ address, onUnlink }: LinkedWalletProps) => {
 
   return (
     <div className="flex flex-row gap-2">
-      <Input value={address} disabled />
+      <Input
+        value={address}
+        readOnly
+        className="cursor-default focus-visible:ring-0"
+      />
       <Button
         variant="secondary"
         size="icon"

--- a/apps/dapp-console/app/settings/components/SettingsMenu.tsx
+++ b/apps/dapp-console/app/settings/components/SettingsMenu.tsx
@@ -41,7 +41,10 @@ const SettingsMenuItem = ({
       ></div>
       <Text
         as="span"
-        className={cn('pl-3 text-base transition', isActive ? 'font-bold' : '')}
+        className={cn(
+          'pl-3 text-base transition cursor-pointer',
+          isActive ? 'font-bold' : '',
+        )}
       >
         {title}
       </Text>

--- a/apps/dapp-console/app/settings/components/WalletVerificationMethods.tsx
+++ b/apps/dapp-console/app/settings/components/WalletVerificationMethods.tsx
@@ -59,8 +59,8 @@ export const WalletVerificationMethods = () => {
   return (
     <Accordion type="single" collapsible>
       <AccordionItem value="wallet-verifications" className="border-none">
-        <AccordionTrigger className="hover:no-underline justify-start">
-          <Text className="text-base font-medium mr-2">
+        <AccordionTrigger className="hover:no-underline justify-start max-w-[215px]">
+          <Text className="text-base font-medium mr-2 cursor-pointer">
             See verification methods
           </Text>
         </AccordionTrigger>

--- a/apps/dapp-console/app/settings/contracts/AddContractForm.tsx
+++ b/apps/dapp-console/app/settings/contracts/AddContractForm.tsx
@@ -174,7 +174,10 @@ export const AddContractForm = ({
           disabled={!form.formState.isValid}
           onClick={handleCreateContract}
         >
-          <Text as="span">Verify</Text> {isLoadingCreateContract ? <RiLoader4Line className="ml-1 animate-spin" /> : null}
+          <Text as="span">Verify</Text>{' '}
+          {isLoadingCreateContract ? (
+            <RiLoader4Line className="ml-1 animate-spin" />
+          ) : null}
         </Button>
       </div>
     </div>

--- a/apps/dapp-console/app/settings/contracts/AddContractForm.tsx
+++ b/apps/dapp-console/app/settings/contracts/AddContractForm.tsx
@@ -24,6 +24,7 @@ import {
   L2NetworkSelect,
   L2NetworkSelectItem,
 } from '@/app/components/Selects/L2NetworkSelect'
+import { RiLoader4Line } from '@remixicon/react'
 
 export type StartVerificationHandler = (
   contract: Contract,
@@ -56,7 +57,7 @@ export const AddContractForm = ({
 }: AddContractFormProps) => {
   const [selectedChainId, setSelectedChainId] = useState<number>(optimism.id)
 
-  const { mutateAsync: createContract } =
+  const { mutateAsync: createContract, isLoading: isLoadingCreateContract } =
     apiClient.Contracts.createContract.useMutation()
 
   const form = useForm<z.infer<typeof addContractSchema>>({
@@ -173,7 +174,7 @@ export const AddContractForm = ({
           disabled={!form.formState.isValid}
           onClick={handleCreateContract}
         >
-          <Text as="span">Verify</Text>
+          <Text as="span">Verify</Text> {isLoadingCreateContract ? <RiLoader4Line className="ml-1 animate-spin" /> : null}
         </Button>
       </div>
     </div>

--- a/apps/dapp-console/app/settings/contracts/DeployedAppContract.tsx
+++ b/apps/dapp-console/app/settings/contracts/DeployedAppContract.tsx
@@ -92,12 +92,12 @@ export const DeployedAppContract = ({
       <div className="flex flex-row justify-between">
         <div className="flex flex-col w-full mr-2">
           <Input
-            className="hidden md:flex"
+            className="hidden md:flex cursor-default focus-visible:ring-0"
             value={contract.contractAddress}
             readOnly
           />
           <Input
-            className="flex md:hidden"
+            className="flex md:hidden cursor-default focus-visible:ring-0"
             value={shortenAddress(contract.contractAddress)}
             readOnly
           />

--- a/apps/dapp-console/app/settings/contracts/StartVerificationDialog/FinishVerificationContent.tsx
+++ b/apps/dapp-console/app/settings/contracts/StartVerificationDialog/FinishVerificationContent.tsx
@@ -26,8 +26,10 @@ export const FinishVerificationContent = () => {
 
   const [signedMessage, setSignedMessage] = useState<string>(signature ?? '')
   const [isSignedMessageValid, setSignedMessageValid] = useState(!!signature)
-  const { mutateAsync: completeVerification, isLoading: isLoadingCompleteVerification } =
-    apiClient.Contracts.completeVerification.useMutation()
+  const {
+    mutateAsync: completeVerification,
+    isLoading: isLoadingCompleteVerification,
+  } = apiClient.Contracts.completeVerification.useMutation()
 
   const handleSignedMessageChange = useCallback(
     (e) => {
@@ -96,8 +98,14 @@ export const FinishVerificationContent = () => {
           Invalid Signature
         </Text>
       )}
-      <Button onClick={handleCompleteVerification} disabled={!isSignedMessageValid}>
-        Continue {isLoadingCompleteVerification ? <RiLoader4Line className="ml-2 animate-spin" /> : null}
+      <Button
+        onClick={handleCompleteVerification}
+        disabled={!isSignedMessageValid}
+      >
+        Continue{' '}
+        {isLoadingCompleteVerification ? (
+          <RiLoader4Line className="ml-2 animate-spin" />
+        ) : null}
       </Button>
       <Button variant="outline">Learn More</Button>
     </>

--- a/apps/dapp-console/app/settings/contracts/StartVerificationDialog/FinishVerificationContent.tsx
+++ b/apps/dapp-console/app/settings/contracts/StartVerificationDialog/FinishVerificationContent.tsx
@@ -10,7 +10,7 @@ import {
   Input,
   Text,
 } from '@eth-optimism/ui-components'
-import { RiArrowLeftLine } from '@remixicon/react'
+import { RiArrowLeftLine, RiLoader4Line } from '@remixicon/react'
 import { captureError } from '@/app/helpers/errorReporting'
 
 export const FinishVerificationContent = () => {
@@ -26,7 +26,7 @@ export const FinishVerificationContent = () => {
 
   const [signedMessage, setSignedMessage] = useState<string>(signature ?? '')
   const [isSignedMessageValid, setSignedMessageValid] = useState(!!signature)
-  const { mutateAsync: completeVerification } =
+  const { mutateAsync: completeVerification, isLoading: isLoadingCompleteVerification } =
     apiClient.Contracts.completeVerification.useMutation()
 
   const handleSignedMessageChange = useCallback(
@@ -45,6 +45,10 @@ export const FinishVerificationContent = () => {
   ) as React.ChangeEventHandler<HTMLInputElement>
 
   const handleCompleteVerification = useCallback(async () => {
+    if (isLoadingCompleteVerification) {
+      return
+    }
+
     try {
       await completeVerification({
         signature: signature as Hash,
@@ -92,7 +96,9 @@ export const FinishVerificationContent = () => {
           Invalid Signature
         </Text>
       )}
-      <Button onClick={handleCompleteVerification}>Continue</Button>
+      <Button onClick={handleCompleteVerification} disabled={!isSignedMessageValid}>
+        Continue {isLoadingCompleteVerification ? <RiLoader4Line className="ml-2 animate-spin" /> : null}
+      </Button>
       <Button variant="outline">Learn More</Button>
     </>
   )

--- a/apps/dapp-console/app/settings/contracts/StartVerificationDialog/StartVerificationContent.tsx
+++ b/apps/dapp-console/app/settings/contracts/StartVerificationDialog/StartVerificationContent.tsx
@@ -4,6 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
   Label,
+  Skeleton,
   Textarea,
   useToast,
 } from '@eth-optimism/ui-components'
@@ -98,11 +99,11 @@ export const StartVerificationContent = () => {
       </DialogHeader>
       <Label>Message to sign</Label>
       <div className="flex flex-col w-full relative">
-        <Textarea
-          value={challenge?.challenge ?? ''}
-          className="pr-16 resize-none cursor-default focus-visible:ring-0"
-          readOnly
-        />
+          <Textarea
+            value={challenge?.challenge ?? ''}
+            className="min-h-[80px] pr-16 resize-none cursor-default focus-visible:ring-0"
+            readOnly
+          />
         <Button
           size="icon"
           variant="ghost"

--- a/apps/dapp-console/app/settings/contracts/StartVerificationDialog/StartVerificationContent.tsx
+++ b/apps/dapp-console/app/settings/contracts/StartVerificationDialog/StartVerificationContent.tsx
@@ -4,7 +4,6 @@ import {
   DialogHeader,
   DialogTitle,
   Label,
-  Skeleton,
   Textarea,
   useToast,
 } from '@eth-optimism/ui-components'
@@ -99,11 +98,11 @@ export const StartVerificationContent = () => {
       </DialogHeader>
       <Label>Message to sign</Label>
       <div className="flex flex-col w-full relative">
-          <Textarea
-            value={challenge?.challenge ?? ''}
-            className="min-h-[80px] pr-16 resize-none cursor-default focus-visible:ring-0"
-            readOnly
-          />
+        <Textarea
+          value={challenge?.challenge ?? ''}
+          className="min-h-[80px] pr-16 resize-none cursor-default focus-visible:ring-0"
+          readOnly
+        />
         <Button
           size="icon"
           variant="ghost"

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -32,7 +32,7 @@ const tabs: Record<SettingsTabType, SettingsTab> = {
         Add your app contracts here. In the future, we’ll scan them for
         insights. For now, we’ll check if they’re eligible for the{' '}
         <RebateDialog>
-          <Text as="span" className="font-semibold">
+          <Text as="span" className="font-semibold cursor-pointer">
             Deployment Rebate.
           </Text>
         </RebateDialog>


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Fixes not passing default trpc headers up with all requests
* Adds a util for getting the rebate block explorer url. It checks to see if the contract is testnet or mainnet then will use op mainnet or sepolia based on that
* Adds loading state to buttons in the create contract, claim rebate, and verification flows
* Adds a min height to the challenge textarea in the verification flow to prevent any sort of bouncing while waiting for the challenge.
* Removes Delete Account Flow
* Input cleanup, prevents the text cursor and outline from appearing on read only inputs
* Cursor cleanup, adds pointer cursor to interactive text