### PR TITLE
feat(paymaster-proxy): create JsonRpcRouter

### DIFF
--- a/apps/paymaster-proxy/src/errors/JsonRpcCastableError.ts
+++ b/apps/paymaster-proxy/src/errors/JsonRpcCastableError.ts
@@ -1,0 +1,9 @@
+export abstract class JsonRpcCastableError extends Error {
+  override name = 'JsonRpcCastableError'
+  constructor(
+    readonly jsonRpcErrorCode: number,
+    readonly jsonRpcErrorMessage: string,
+  ) {
+    super(jsonRpcErrorMessage)
+  }
+}

--- a/apps/paymaster-proxy/src/errors/JsonRpcError.ts
+++ b/apps/paymaster-proxy/src/errors/JsonRpcError.ts
@@ -7,7 +7,7 @@ export const invalidParamsErrorCode = -32602 as const
 export const internalErrorCode = -32603 as const
 
 type JsonRpcErrorParams = {
-  id?: number | null
+  id?: number | string | null
   message?: string
 }
 
@@ -22,7 +22,7 @@ export class JsonRpcError extends Error {
 
   static fromPaymasterRpcError(
     error: PaymasterRpcError,
-    id: number,
+    id: number | string,
   ): JsonRpcError {
     return new JsonRpcError(error.code, {
       id,

--- a/apps/paymaster-proxy/src/jsonRpc/JsonRpcRouter.spec.ts
+++ b/apps/paymaster-proxy/src/jsonRpc/JsonRpcRouter.spec.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { JsonRpcCastableError } from '@/errors/JsonRpcCastableError'
+import { JsonRpcRouter } from '@/jsonRpc/JsonRpcRouter'
+
+describe(JsonRpcRouter.name, () => {
+  describe('basic functionality', () => {
+    it('replaces method if a new one is registered with the same name', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.tuple([z.number(), z.number()]),
+        async ([a, b]) => a - b,
+      )
+      jsonRpcRouter.method(
+        'subtract',
+        z.tuple([z.number(), z.number()]),
+        async ([a, b]) => a + b,
+      )
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: [42, 23],
+          id: 1,
+        }),
+      ).toEqual({ jsonrpc: '2.0', result: 65, id: 1 })
+    })
+
+    it('returns correct code and message if handler throws a JsonRpcCastable error', async (async) => {
+      class TestJsonRpcCastableError extends JsonRpcCastableError {
+        constructor() {
+          super(-32033, 'TestJsonRpcCastableError message')
+        }
+      }
+
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.tuple([z.number(), z.number()]),
+        async ([a, b]) => {
+          throw new TestJsonRpcCastableError()
+        },
+      )
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: [42, 23],
+          id: 1,
+        }),
+      ).toEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32033, message: 'TestJsonRpcCastableError message' },
+      })
+    })
+
+    it('returns correct code and message if handler throws a non-JsonRpcCastable error', async (async) => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.tuple([z.number(), z.number()]),
+        async ([a, b]) => {
+          throw new Error()
+        },
+      )
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: [42, 23],
+          id: 1,
+        }),
+      ).toEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32603, message: 'Internal error' },
+      })
+    })
+  })
+
+  describe('example cases from https://www.jsonrpc.org/specification', () => {
+    it('handles rpc call with positional parameters', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.tuple([z.number(), z.number()]),
+        async ([a, b]) => a - b,
+      )
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: [42, 23],
+          id: 1,
+        }),
+      ).toEqual({
+        jsonrpc: '2.0',
+        id: 1,
+        result: 19,
+      })
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: [23, 42],
+          id: 2,
+        }),
+      ).toEqual({ jsonrpc: '2.0', result: -19, id: 2 })
+    })
+
+    it('handles rpc call with named parameters', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.object({
+          subtrahend: z.number(),
+          minuend: z.number(),
+        }),
+        async ({ subtrahend, minuend }) => minuend - subtrahend,
+      )
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: { subtrahend: 23, minuend: 42 },
+          id: 3,
+        }),
+      ).toEqual({ jsonrpc: '2.0', result: 19, id: 3 })
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 'subtract',
+          params: { minuend: 42, subtrahend: 23 },
+          id: 4,
+        }),
+      ).toEqual({ jsonrpc: '2.0', result: 19, id: 4 })
+    })
+
+    it('handles rpc call of non-existent method', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.object({
+          subtrahend: z.number(),
+          minuend: z.number(),
+        }),
+        async ({ subtrahend, minuend }) => minuend - subtrahend,
+      )
+
+      expect(
+        await jsonRpcRouter.handle({ jsonrpc: '2.0', method: 'foobar', id: 1 }),
+      ).toEqual({
+        jsonrpc: '2.0',
+        error: { code: -32601, message: 'Method not found' },
+        id: 1,
+      })
+    })
+
+    it('handles rpc call with invalid request object', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.object({
+          subtrahend: z.number(),
+          minuend: z.number(),
+        }),
+        async ({ subtrahend, minuend }) => minuend - subtrahend,
+      )
+
+      expect(
+        await jsonRpcRouter.handle({
+          jsonrpc: '2.0',
+          method: 1,
+          params: 'bar',
+        }),
+      ).toEqual({
+        jsonrpc: '2.0',
+        error: {
+          code: -32600,
+          message: expect.stringContaining('Invalid request'),
+        },
+        id: null,
+      })
+    })
+
+    it('handles rpc call with an empty array', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.object({
+          subtrahend: z.number(),
+          minuend: z.number(),
+        }),
+        async ({ subtrahend, minuend }) => minuend - subtrahend,
+      )
+
+      expect(await jsonRpcRouter.handle([])).toEqual({
+        jsonrpc: '2.0',
+        error: {
+          code: -32600,
+          message: expect.stringContaining('Invalid request'),
+        },
+        id: null,
+      })
+    })
+
+    it('handles rpc call with an invalid batch (but not empty)', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.object({
+          subtrahend: z.number(),
+          minuend: z.number(),
+        }),
+        async ({ subtrahend, minuend }) => minuend - subtrahend,
+      )
+
+      expect(await jsonRpcRouter.handle([1])).toEqual([
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: expect.stringContaining('Invalid request'),
+          },
+          id: null,
+        },
+      ])
+    })
+
+    it('handles rpc call with invalid Batch', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.object({
+          subtrahend: z.number(),
+          minuend: z.number(),
+        }),
+        async ({ subtrahend, minuend }) => minuend - subtrahend,
+      )
+
+      expect(await jsonRpcRouter.handle([1, 2, 3])).toEqual([
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: expect.stringContaining('Invalid request'),
+          },
+          id: null,
+        },
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: expect.stringContaining('Invalid request'),
+          },
+          id: null,
+        },
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: expect.stringContaining('Invalid request'),
+          },
+          id: null,
+        },
+      ])
+    })
+    it('handles rpc call batch', async () => {
+      const jsonRpcRouter = new JsonRpcRouter()
+      jsonRpcRouter.method(
+        'subtract',
+        z.tuple([z.number(), z.number()]),
+        async ([a, b]) => a - b,
+      )
+
+      jsonRpcRouter.method('sum', z.array(z.number()), async (numbers) =>
+        numbers.reduce((current, a) => current + a, 0),
+      )
+
+      expect(
+        await jsonRpcRouter.handle([
+          { jsonrpc: '2.0', method: 'sum', params: [1, 2, 4], id: '1' },
+          { jsonrpc: '2.0', method: 'subtract', params: [42, 23], id: '2' },
+          { foo: 'boo' },
+          {
+            jsonrpc: '2.0',
+            method: 'foo.get',
+            params: { name: 'myself' },
+            id: '5',
+          },
+        ]),
+      ).toEqual([
+        { jsonrpc: '2.0', result: 7, id: '1' },
+        { jsonrpc: '2.0', result: 19, id: '2' },
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: expect.stringContaining('Invalid request'),
+          },
+          id: null,
+        },
+        {
+          jsonrpc: '2.0',
+          error: { code: -32601, message: 'Method not found' },
+          id: '5',
+        },
+      ])
+    })
+  })
+})

--- a/apps/paymaster-proxy/src/jsonRpc/JsonRpcRouter.ts
+++ b/apps/paymaster-proxy/src/jsonRpc/JsonRpcRouter.ts
@@ -1,0 +1,151 @@
+import { z } from 'zod'
+import { fromZodError } from 'zod-validation-error'
+
+import { JsonRpcCastableError } from '@/errors/JsonRpcCastableError'
+import { processSingleOrMultiple } from '@/helpers/processSingleOrMultiple'
+import { createJsonRpcRequestSchema } from '@/schemas/createJsonRpcRequestSchema'
+
+type JsonRpcResponseError = {
+  error: {
+    code: number
+    message: string
+  }
+}
+
+type JsonRpcResponseResult = {
+  result: unknown
+}
+
+type JsonRpcResponse = {
+  jsonrpc: '2.0'
+  id: number | string | null
+} & (JsonRpcResponseError | JsonRpcResponseResult)
+
+// General JSON-RPC request schema - doesn't validate the specifics method or params
+const genericJsonRpcRequestSchema = createJsonRpcRequestSchema(
+  z.string(),
+  z.unknown(),
+)
+
+export class JsonRpcRouter {
+  private methodByName: Record<
+    string,
+    {
+      paramsValidator: z.ZodTypeAny
+      handler: Function
+    }
+  > = {}
+
+  // registers a new handler, no middleware support
+  method<T extends z.ZodTypeAny, U>(
+    methodName: string,
+    paramsValidator: T,
+    handler: (params: z.infer<T>) => Promise<U>,
+  ) {
+    this.methodByName[methodName] = {
+      paramsValidator,
+      handler,
+    }
+  }
+
+  async handle(
+    request: unknown | unknown[],
+  ): Promise<JsonRpcResponse | JsonRpcResponse[]> {
+    if (Array.isArray(request) && request.length === 0) {
+      return {
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32600,
+          message: 'Invalid request',
+        },
+      }
+    }
+
+    return await processSingleOrMultiple(
+      request,
+      this.__handleSingle.bind(this),
+    )
+  }
+
+  private async __handleSingle(request: unknown): Promise<JsonRpcResponse> {
+    const genericJsonRpcRequestParseResult =
+      genericJsonRpcRequestSchema.safeParse(request)
+
+    if (!genericJsonRpcRequestParseResult.success) {
+      const validationError = fromZodError(
+        genericJsonRpcRequestParseResult.error,
+      )
+      return {
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32600,
+          message: `Invalid request: ${validationError.message}`,
+        },
+      }
+    }
+
+    const { method, params, id } = genericJsonRpcRequestParseResult.data
+
+    if (!this.methodByName[method]) {
+      return {
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32601,
+          message: 'Method not found',
+        },
+      }
+    }
+
+    const { handler, paramsValidator } = this.methodByName[method]
+
+    const paramsValidationResult = paramsValidator.safeParse(params)
+
+    if (!paramsValidationResult.success) {
+      const validationError = fromZodError(paramsValidationResult.error, {
+        maxIssuesInMessage: 1,
+      })
+      return {
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32602,
+          message: `Invalid params: ${validationError.message}`,
+        },
+      }
+    }
+
+    let result: unknown
+    try {
+      result = await handler(params)
+    } catch (e) {
+      if (e instanceof JsonRpcCastableError) {
+        return {
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code: e.jsonRpcErrorCode,
+            message: e.jsonRpcErrorMessage,
+          },
+        }
+      }
+
+      return {
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32603,
+          message: 'Internal error',
+        },
+      }
+    }
+
+    return {
+      jsonrpc: '2.0',
+      id,
+      result,
+    }
+  }
+}

--- a/apps/paymaster-proxy/src/jsonRpc/createExpressRouterFromJsonRpcRouter.spec.ts
+++ b/apps/paymaster-proxy/src/jsonRpc/createExpressRouterFromJsonRpcRouter.spec.ts
@@ -1,0 +1,89 @@
+import express from 'express'
+import supertest from 'supertest'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { createExpressRouterFromJsonRpcRouter } from '@/jsonRpc/createExpressRouterFromJsonRpcRouter'
+import { JsonRpcRouter } from '@/jsonRpc/JsonRpcRouter'
+
+describe(createExpressRouterFromJsonRpcRouter.name, () => {
+  const jsonRpcRouter = new JsonRpcRouter()
+  jsonRpcRouter.method(
+    'subtract',
+    z.tuple([z.number(), z.number()]),
+    async ([a, b]) => {
+      return a - b
+    },
+  )
+  const expressRouter = createExpressRouterFromJsonRpcRouter(jsonRpcRouter)
+  const app = express()
+  app.use('/rpc', expressRouter)
+
+  it('happy path', async () => {
+    const result = await supertest(app)
+      .post('/rpc')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'subtract',
+        params: [5, 3],
+      })
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(200)
+
+    expect(result.body).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: 2,
+    })
+  })
+
+  it('handles unsupported method', async () => {
+    const result = await supertest(app)
+      .post('/rpc')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'crazy-method',
+        params: [5, 3],
+      })
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(200)
+
+    expect(result.body).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      error: {
+        code: -32601,
+        message: 'Method not found',
+      },
+    })
+  })
+
+  it('handles JSON parse error', async () => {
+    const result = await supertest(app)
+      .post('/rpc')
+      .send('{"jsonrpc":"2.0","id":1,"method":"subtract')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+      .expect(200)
+
+    expect(result.body).toMatchObject({
+      jsonrpc: '2.0',
+      id: null,
+      error: {
+        code: -32700,
+        message: 'Parse error',
+      },
+    })
+  })
+
+  it('rejects non-application/json content type', async () => {
+    await supertest(app)
+      .post('/rpc')
+      .send('{"jsonrpc":"2.0","id":1,"method":"subtract","params":[5,3]}')
+      .expect(400)
+  })
+})

--- a/apps/paymaster-proxy/src/jsonRpc/createExpressRouterFromJsonRpcRouter.ts
+++ b/apps/paymaster-proxy/src/jsonRpc/createExpressRouterFromJsonRpcRouter.ts
@@ -1,0 +1,41 @@
+import type { NextFunction, Request, Response } from 'express'
+import express from 'express'
+
+import { JsonRpcError } from '@/errors/JsonRpcError'
+import type { JsonRpcRouter } from '@/jsonRpc/JsonRpcRouter'
+
+export const createExpressRouterFromJsonRpcRouter = (
+  jsonRpcRouter: JsonRpcRouter,
+) => {
+  const router = express.Router()
+
+  router.use('/', (req, res, next) => {
+    // reject non-JSON requests
+    if (req.headers['content-type'] !== 'application/json') {
+      return res.status(400).send()
+    }
+    next()
+  })
+
+  router.use('/', express.json())
+
+  router.post('/', async (req: Request, res: Response) => {
+    const result = await jsonRpcRouter.handle(req.body)
+    return res.json(result)
+  })
+
+  // only handle JSON parsing errors
+  router.use(
+    '/',
+    (err: any, req: Request, res: Response, next: NextFunction) => {
+      if (err.status === 400 && err instanceof SyntaxError && 'body' in err) {
+        // If JSON parsing fails, return a -32700 JSON-RPC error
+        return res.json(JsonRpcError.parseError().response())
+      }
+
+      next(err)
+    },
+  )
+
+  return router
+}

--- a/apps/paymaster-proxy/src/rpc/wrapPaymasterResponseIntoJsonRpcResponse.ts
+++ b/apps/paymaster-proxy/src/rpc/wrapPaymasterResponseIntoJsonRpcResponse.ts
@@ -4,7 +4,7 @@ import type { PaymasterResponse } from '@/paymaster/types'
 
 export const wrapPaymasterResponseIntoJsonRpcResponse = <T>(
   response: PaymasterResponse<T>,
-  id: number,
+  id: number | string,
 ) => {
   if (!response.success) {
     // Pass the RPC error to the user so it can be used for debugging

--- a/apps/paymaster-proxy/src/schemas/createJsonRpcRequestSchema.ts
+++ b/apps/paymaster-proxy/src/schemas/createJsonRpcRequestSchema.ts
@@ -10,7 +10,7 @@ export const createJsonRpcRequestSchema = <
   return z
     .object({
       jsonrpc: z.literal('2.0'),
-      id: z.number(),
+      id: z.union([z.number().int(), z.string()]),
       method: methodSchema,
       params: paramsSchema,
     })


### PR DESCRIPTION
To improve maintainability, will refactor the paymaster-proxy logic to have cleaner separation between JsonRPC handling logic vs. business logic. the following helpers will be used. the refactor will be in a subsequent PR

### JsonRpcRouter

```typescript
const jsonRpcRouter = new JsonRpcRouter()

jsonRpcRouter.method(
  'subtract',
  z.tuple([z.number(), z.number()]),
  async ([a, b]) => a - b,
)

const result = await jsonRpcRouter.handle({
  jsonrpc: '2.0',
  method: 'subtract',
  params: [23, 42],
  id: 2,
}


// result
{ jsonrpc: '2.0', result: -19, id: 2 }

```

- as part of the refactor, introducing a new JsonRpcRouter class that helps set up rpc method handlers in an express-like way. 
- notice that individual method handler (`.method()` ) does not need to return a JSON rpc response, the logic to wrap it into a correct response is handled at the JsonRpcRouter level


### createExpressRouterFromJsonRpcRouter

creates an express router that handles json parsing + error handling.

### JsonRpcCastableError

- all errors encountered during the handlers should throw this type of error so that we can return the correct code + message.
- any other error thrown will just return a -32603 JSON rpc error
- note: JSON rpc calls will always try to return 200, even if the result is an error. Only exceptions that return 500 will be unexpected server errors
