### PR TITLE
Add in filters + add tertiary color to tokens

### DIFF
--- a/apps/dapp-console/app/console/components/PromotionsSection.tsx
+++ b/apps/dapp-console/app/console/components/PromotionsSection.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/app/console/constants'
 import { Button } from '@eth-optimism/ui-components/src/components/ui/button/button'
 import { DialogMetadata } from '@/app/components/StandardDialogContent'
+import { Badge } from '@eth-optimism/ui-components/src/components/ui/badge/badge'
 
 enum PromotionCategory {
   All = 'All',
@@ -155,6 +156,7 @@ const PromotionsSection = () => {
                   setDialogContent(promo.content)
                 }}
                 variant="secondary"
+                badge={<Badge variant="tertiary">{promo.tag}</Badge>}
                 image={
                   <Image
                     src={promo.metadata.image || ''}

--- a/apps/dapp-console/tailwind.config.ts
+++ b/apps/dapp-console/tailwind.config.ts
@@ -29,6 +29,10 @@ module.exports = {
           DEFAULT: 'hsl(var(--secondary))',
           foreground: 'hsl(var(--secondary-foreground))',
         },
+        tertiary: {
+          DEFAULT: 'hsl(var(--tertiary))',
+          foreground: 'hsl(var(--tertiary-foreground))',
+        },
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',

--- a/packages/ui-components/src/components/ui/badge/badge.tsx
+++ b/packages/ui-components/src/components/ui/badge/badge.tsx
@@ -12,6 +12,8 @@ const badgeVariants = cva(
           'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
         secondary:
           'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        tertiary:
+          'border-transparent bg-tertiary text-tertiary-foreground hover:bg-tertiary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
         outline: 'text-foreground',

--- a/packages/ui-components/src/style.css
+++ b/packages/ui-components/src/style.css
@@ -16,6 +16,8 @@
     --primary-foreground: 0 85.7% 97.3%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
+    --tertiary: 229 22% 91%;
+    --tertiary-foreground: 0 0% 30%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
@@ -39,6 +41,8 @@
     --primary-foreground: 0 85.7% 97.3%;
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
+    --tertiary: 0 0% 25%;
+    --tertiary-foreground: 0 0% 75%;
     --muted: 0 0% 14.9%;
     --muted-foreground: 0 0% 63.9%;
     --accent: 0 0% 14.9%;

--- a/packages/ui-components/tailwind.config.js
+++ b/packages/ui-components/tailwind.config.js
@@ -27,6 +27,10 @@ export default {
           DEFAULT: 'hsl(var(--secondary))',
           foreground: 'hsl(var(--secondary-foreground))',
         },
+        tertiary: {
+          DEFAULT: 'hsl(var(--tertiary))',
+          foreground: 'hsl(var(--tertiary-foreground))',
+        },
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',


### PR DESCRIPTION
### TL;DR

In this pull request, a badge feature has been added to the 'PromotionsSection' secondary button in 'dapp-console'. Also, tertiary color has been added to the 'tailwind.config' and 'badge.tsx'.

### Description

Badge feature has been added in secondary button in 'PromotionsSection.tsx'. Further, HSL colors for 'secondary' and 'tertiary' color categories have been created in 'tailwind.config.ts'. Also, tertiary color has been initialized in 'badge.tsx' and 'style.css'.