### PR TITLE
chore(trpc-api-generator): add example envvars generation script

### DIFF
--- a/packages/api-plugin/src/generators/trpc-api-generator/files/package.json
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf build types tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "typecheck:ci": "tsc --noEmit --emitDeclarationOnly false",
-    "dev": "tsup --watch --onSuccess 'pnpm kill && pnpm start'",
+    "dev": "tsup --watch --onSuccess 'node build/cmd/run.js'",
     "kill": "npx kill-port 7300",
     "build": "tsup && pnpm tsc && resolve-tspaths",
     "start": "node build/cmd/run.js",
@@ -19,7 +19,8 @@
     "docker:down": "docker compose down",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
     "lint:ci": "eslint \"**/*.{ts,tsx}\" --quiet && pnpm prettier --check \"**/*.{ts,tsx}\"",
-    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn"
+    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn",
+    "env:example:generate": "NODE_ENV=test ts-node scripts/generate-example-env.ts"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -55,6 +56,7 @@
     "prom-client": "^15.1.0",
     "superjson": "^1.12.2",
     "trpc-playground": "^1.0.4",
+    "znv": "^0.4.0",
     "zod": "^3.22.4"
   },
   "files": [

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/scripts/generate-example-env.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/scripts/generate-example-env.ts
@@ -1,0 +1,31 @@
+import fs from 'fs'
+import path from 'path'
+
+import { envVarsSchema } from '../src/constants/envVarsSchema'
+
+// generates an example.env file based on envVarsSchema
+const generateExampleEnv = () => {
+  const output = Object.entries(envVarsSchema)
+    .flatMap(([envVarKey, validator]) => {
+      return [
+        validator.description ? `# ${validator.description}` : undefined,
+        validator.schema.isOptional() ? `# ℹ️ optional` : `# 🔴 REQUIRED`,
+        `${envVarKey}=`,
+        // add newline
+        '',
+      ]
+    })
+    .filter((x) => x !== undefined)
+    .join('\n')
+
+  return `${[
+    '#####################################',
+    '# Environment Variables (generated) #',
+    '#####################################',
+  ].join('\n')} \n\n${output}`
+}
+
+fs.writeFileSync(
+  path.join(__dirname, '..', 'example.env'),
+  generateExampleEnv(),
+)

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/Service.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/Service.ts
@@ -37,11 +37,6 @@ export class Service {
    */
   private metricsRegistry: Registry
 
-  /**
-   * @param state - the state object that stores cached delegate chain data
-   * @param middleware - The middleware specifying cors
-   * @param apiServerV0 - the api server served at /api/v0
-   */
   constructor(
     private readonly apiServerV0: ApiV0,
     private readonly middleware: Middleware,

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/envVars.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/envVars.ts
@@ -1,72 +1,7 @@
 import 'dotenv/config'
 
-import { z } from 'zod'
+import { parseEnv } from 'znv'
 
-const getCommaSeparatedValues = (type: string) => {
-  try {
-    return process.env[type]?.split(',') ?? []
-  } catch (e) {
-    throw new Error(`Unable to parse rpc urls: ${e}`)
-  }
-}
+import { envVarsSchema } from './envVarsSchema'
 
-const envVarSchema = z.object({
-  PORT: z.number(),
-  DEPLOYMENT_ENV: z.enum(['production', 'staging', 'development']),
-  DEV_CORS_ALLOWLIST_REG_EXP: z.custom<RegExp>().array(),
-  CORS_ALLOWLIST_REG_EXP: z.custom<RegExp>().array(),
-  IRON_SESSION_SECRET: z
-    .string()
-    .min(32)
-    .max(32)
-    .describe('32 character iron session secret'),
-  ADMIN_API_PASSWORD: z.string().optional(),
-  ADMIN_API_SALT: z.string().optional(),
-})
-
-const isTest = process.env.NODE_ENV === 'test'
-
-/**
- * A typesafe wrapper around process.env that sets defaults
- */
-export const envVars = envVarSchema.parse(
-  isTest
-    ? {
-        /**
-         * We want the env vars in tests to always be consistent
-         * To change them consider mocking them explicitly in test
-         * rather than using env file
-         * @example
-         * jest.mock('../constants/envVars', () => ({
-         *  envVars: {
-         *      MOCKED_VARIABLE: true
-         * }))
-         */
-        PORT: 7300,
-        DEPLOYMENT_ENV: 'development',
-        DEV_CORS_ALLOWLIST_REG_EXP: getCommaSeparatedValues(
-          'DEV_CORS_ALLOWLIST_REG_EXP',
-        ).map((regExp) => new RegExp(regExp)),
-        CORS_ALLOWLIST_REG_EXP: getCommaSeparatedValues(
-          'CORS_ALLOWLIST_REG_EXP',
-        ).map((regExp) => new RegExp(regExp)),
-        IRON_SESSION_SECRET: 'UNKNOWN_IRON_SESSION_PASSWORD_32',
-      }
-    : {
-        PORT: process.env.PORT
-          ? Number(process.env.PORT)
-          : process.env.SERVER_PORT
-            ? Number(process.env.SERVER_PORT)
-            : 7300,
-        DEPLOYMENT_ENV: process.env.DEPLOYMENT_ENV ?? 'staging',
-        DEV_CORS_ALLOWLIST_REG_EXP: getCommaSeparatedValues(
-          'DEV_CORS_ALLOWLIST_REG_EXP',
-        ).map((regExp) => new RegExp(regExp)),
-        CORS_ALLOWLIST_REG_EXP: getCommaSeparatedValues(
-          'CORS_ALLOWLIST_REG_EXP',
-        ).map((regExp) => new RegExp(regExp)),
-        IRON_SESSION_SECRET: process.env.IRON_SESSION_SECRET,
-        ADMIN_API_PASSWORD: process.env.ADMIN_API_PASSWORD,
-        ADMIN_API_SALT: process.env.ADMIN_API_SALT,
-      },
-)
+export const envVars = parseEnv(process.env, envVarsSchema)

--- a/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/envVarsSchema.ts
+++ b/packages/api-plugin/src/generators/trpc-api-generator/files/src/constants/envVarsSchema.ts
@@ -1,0 +1,46 @@
+import { inferSchemas } from 'znv'
+import { z } from 'zod'
+
+const commaSeparatedRegExpSchema = z
+  .string()
+  .optional()
+  .transform((val) => (val ? val.split(',').map((exp) => new RegExp(exp)) : []))
+
+export const envVarsSchema = inferSchemas({
+  PORT: {
+    schema: z.number(),
+    defaults: {
+      test: 7300,
+    },
+  },
+  DEPLOYMENT_ENV: {
+    schema: z.enum(['production', 'staging', 'development']),
+    defaults: {
+      test: 'development' as const,
+    },
+  },
+  DEV_CORS_ALLOWLIST_REG_EXP: {
+    schema: commaSeparatedRegExpSchema,
+    defaults: {
+      test: '',
+    },
+  },
+  CORS_ALLOWLIST_REG_EXP: {
+    schema: commaSeparatedRegExpSchema,
+    defaults: {
+      test: '',
+    },
+  },
+  IRON_SESSION_SECRET: {
+    schema: z.string().min(32).max(32),
+    defaults: {
+      test: 'UNKNOWN_IRON_SESSION_PASSWORD_32',
+    },
+  },
+  ADMIN_API_PASSWORD: {
+    schema: z.string().optional(),
+  },
+  ADMIN_API_SALT: {
+    schema: z.string().optional(),
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22011,7 +22011,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 


### PR DESCRIPTION
adds the `znv` example envvar generation script to the trpc-api-generator