### PR TITLE
feat(paymaster-proxy): Alchemy gas manager API helper functions

### DIFF
--- a/apps/paymaster-proxy/.gitignore
+++ b/apps/paymaster-proxy/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .env
+.env.e2e
 
 # Editor directories and files
 .vscode/*

--- a/apps/paymaster-proxy/src/e2eTests/alchemyGasManager.spec.ts
+++ b/apps/paymaster-proxy/src/e2eTests/alchemyGasManager.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'vitest'
+
+import {
+  createAlchemyGasManagerPolicy,
+  getAlchemyGasManagerPolicy,
+} from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
+import { getAlchemyGasManagerDefaultRules } from '@/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules'
+
+describe('test Alchemy Gas Manager API calls', async () => {
+  it('create and get', async () => {
+    const createResult = await createAlchemyGasManagerPolicy({
+      accessKey: process.env.ALCHEMY_GAS_MANAGER_ACCESS_KEY!,
+      appId: process.env.ALCHEMY_GAS_MANAGER_APP_ID!,
+      policyName: 'e2e-test',
+      policyType: 'sponsorship',
+      rules: getAlchemyGasManagerDefaultRules(),
+    })
+    console.log(createResult)
+
+    const getResult = await getAlchemyGasManagerPolicy({
+      accessKey: process.env.ALCHEMY_GAS_MANAGER_ACCESS_KEY!,
+      policyId: createResult.policyId,
+    })
+
+    console.log(getResult)
+  })
+})

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.spec.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createAlchemyGasManagerPolicy,
+  getAlchemyGasManagerPolicy,
+} from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
+import { AlchemyGasManagerAdminClient } from '@/paymasterProvider/alchemy/AlchemyGasManagerAdminClient'
+import { mockAlchemyGasManagerPolicy } from '@/testUtils/mockAlchemyGasManagerPolicy'
+
+const MOCK_ACCESS_KEY = 'fake-key'
+const MOCK_APP_ID = 'fake-app-id'
+const MOCK_POLICY = mockAlchemyGasManagerPolicy
+
+vi.mock('@/paymasterProvider/alchemy/alchemyGasManagerAdminActions', () => {
+  return {
+    createAlchemyGasManagerPolicy: vi.fn(),
+    getAlchemyGasManagerPolicy: vi.fn(),
+  }
+})
+
+describe(AlchemyGasManagerAdminClient.name, async () => {
+  const alchemyGasManagerAdminClient = new AlchemyGasManagerAdminClient({
+    appId: MOCK_APP_ID,
+    accessKey: MOCK_ACCESS_KEY,
+  })
+
+  it('sends request to create policy', async () => {
+    await alchemyGasManagerAdminClient.createPolicy({
+      policyName: MOCK_POLICY.policyName,
+      policyType: MOCK_POLICY.policyType,
+      rules: MOCK_POLICY.rules,
+    })
+
+    expect(createAlchemyGasManagerPolicy).toHaveBeenCalledWith({
+      accessKey: MOCK_ACCESS_KEY,
+      appId: MOCK_APP_ID,
+      policyName: MOCK_POLICY.policyName,
+      policyType: MOCK_POLICY.policyType,
+      rules: MOCK_POLICY.rules,
+    })
+  })
+
+  it('sends request to get policy', async () => {
+    await alchemyGasManagerAdminClient.getPolicy(MOCK_POLICY.policyId)
+
+    expect(getAlchemyGasManagerPolicy).toHaveBeenCalledWith({
+      accessKey: MOCK_ACCESS_KEY,
+      policyId: MOCK_POLICY.policyId,
+    })
+  })
+})

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.ts
@@ -1,0 +1,40 @@
+import type { AlchemyGasManagerPolicyRules } from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
+import {
+  createAlchemyGasManagerPolicy,
+  getAlchemyGasManagerPolicy,
+} from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
+
+export class AlchemyGasManagerAdminClient {
+  private appId: string
+  private accessKey: string
+
+  constructor({ appId, accessKey }: { appId: string; accessKey: string }) {
+    this.appId = appId
+    this.accessKey = accessKey
+  }
+
+  public async createPolicy({
+    policyName,
+    policyType,
+    rules,
+  }: {
+    policyName: string
+    policyType: string
+    rules: AlchemyGasManagerPolicyRules
+  }) {
+    return await createAlchemyGasManagerPolicy({
+      accessKey: this.accessKey,
+      policyName,
+      policyType,
+      appId: this.appId,
+      rules,
+    })
+  }
+
+  public async getPolicy(policyId: string) {
+    return await getAlchemyGasManagerPolicy({
+      accessKey: this.accessKey,
+      policyId,
+    })
+  }
+}

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/alchemyGasManagerAdminActions.spec.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/alchemyGasManagerAdminActions.spec.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ZodError } from 'zod'
+
+import {
+  createAlchemyGasManagerPolicy,
+  deleteAlchemyGasManagerPolicy,
+  getAlchemyGasManagerHeaders,
+  getAlchemyGasManagerPolicy,
+} from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
+import { mockAlchemyGasManagerPolicy } from '@/testUtils/mockAlchemyGasManagerPolicy'
+import {
+  mockDeleteSuccess,
+  mockGetError,
+  mockGetErrorWithReturnJson,
+  mockGetSuccessJson,
+  mockPostError,
+  mockPostErrorWithReturnJson,
+  mockPostSuccessJson,
+} from '@/testUtils/mswServer'
+
+const MOCK_ACCESS_KEY = 'fake-key'
+
+const MOCK_POLICY = mockAlchemyGasManagerPolicy
+
+describe(getAlchemyGasManagerHeaders.name, async () => {
+  it('returns headers with access key', async () => {
+    const headers = getAlchemyGasManagerHeaders(MOCK_ACCESS_KEY)
+
+    expect(headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${MOCK_ACCESS_KEY}`,
+    })
+  })
+})
+
+describe(createAlchemyGasManagerPolicy.name, async () => {
+  it('sends correct POST request to Alchemy', async () => {
+    vi.spyOn(global, 'fetch')
+
+    mockPostSuccessJson('https://manage.g.alchemy.com/api/gasManager/policy', {
+      data: { policy: MOCK_POLICY },
+    })
+
+    const newPolicy = await createAlchemyGasManagerPolicy({
+      accessKey: MOCK_ACCESS_KEY,
+      policyName: MOCK_POLICY.policyName,
+      policyType: MOCK_POLICY.policyType,
+      appId: MOCK_POLICY.appId,
+      rules: MOCK_POLICY.rules,
+    })
+
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledWith(
+      'https://manage.g.alchemy.com/api/gasManager/policy',
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${MOCK_ACCESS_KEY}`,
+        },
+        method: 'POST',
+        body: JSON.stringify({
+          policyName: MOCK_POLICY.policyName,
+          policyType: MOCK_POLICY.policyType,
+          appId: MOCK_POLICY.appId,
+          rules: MOCK_POLICY.rules,
+        }),
+      },
+    )
+
+    expect(MOCK_POLICY).toMatchObject(newPolicy)
+  })
+
+  it('throws error if response is not successful', async () => {
+    mockPostErrorWithReturnJson(
+      'https://manage.g.alchemy.com/api/gasManager/policy',
+      401,
+      {
+        message: 'Not allowed',
+      },
+    )
+
+    await expect(
+      createAlchemyGasManagerPolicy({
+        accessKey: MOCK_ACCESS_KEY,
+        policyName: MOCK_POLICY.policyName,
+        policyType: MOCK_POLICY.policyType,
+        appId: MOCK_POLICY.appId,
+        rules: MOCK_POLICY.rules,
+      }),
+    ).rejects.toThrowError(
+      /Failed to create Alchemy Gas Manager policy: \[401: Unauthorized\] Not allowed/,
+    )
+  })
+
+  it('throws error if response is not JSON', async () => {
+    mockPostError('https://manage.g.alchemy.com/api/gasManager/policy', 400)
+
+    await expect(
+      createAlchemyGasManagerPolicy({
+        accessKey: MOCK_ACCESS_KEY,
+        policyName: MOCK_POLICY.policyName,
+        policyType: MOCK_POLICY.policyType,
+        appId: MOCK_POLICY.appId,
+        rules: MOCK_POLICY.rules,
+      }),
+    ).rejects.toThrowError(/Failed to create Alchemy Gas Manager policy:/)
+  })
+
+  it('throws error if response is not valid policy', async () => {
+    mockPostSuccessJson('https://manage.g.alchemy.com/api/gasManager/policy', {
+      data: { policy: { somethingWrong: true } },
+    })
+
+    await expect(
+      createAlchemyGasManagerPolicy({
+        accessKey: MOCK_ACCESS_KEY,
+        policyName: MOCK_POLICY.policyName,
+        policyType: MOCK_POLICY.policyType,
+        appId: MOCK_POLICY.appId,
+        rules: MOCK_POLICY.rules,
+      }),
+    ).rejects.toThrow(ZodError)
+  })
+})
+
+describe(getAlchemyGasManagerPolicy.name, async () => {
+  it('sends correct GET request to Alchemy', async () => {
+    vi.spyOn(global, 'fetch')
+
+    mockGetSuccessJson('https://manage.g.alchemy.com/api/gasManager/policy/*', {
+      data: { policy: MOCK_POLICY },
+    })
+
+    const policy = await getAlchemyGasManagerPolicy({
+      accessKey: MOCK_ACCESS_KEY,
+      policyId: MOCK_POLICY.policyId,
+    })
+
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledWith(
+      `https://manage.g.alchemy.com/api/gasManager/policy/${MOCK_POLICY.policyId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${MOCK_ACCESS_KEY}`,
+        },
+      },
+    )
+
+    expect(MOCK_POLICY).toMatchObject(policy)
+  })
+
+  it('throws error if response is not successful', async () => {
+    mockGetErrorWithReturnJson(
+      'https://manage.g.alchemy.com/api/gasManager/policy/*',
+      400,
+      {
+        message: 'Invalid policy ID',
+      },
+    )
+
+    await expect(
+      getAlchemyGasManagerPolicy({
+        accessKey: MOCK_ACCESS_KEY,
+        policyId: MOCK_POLICY.policyId,
+      }),
+    ).rejects.toThrowError(
+      /Failed to get Alchemy Gas Manager policy with policyId/,
+    )
+  })
+
+  it('throws error if response is not JSON', async () => {
+    mockGetError('https://manage.g.alchemy.com/api/gasManager/policy/*', 400)
+
+    await expect(
+      getAlchemyGasManagerPolicy({
+        accessKey: MOCK_ACCESS_KEY,
+        policyId: MOCK_POLICY.policyId,
+      }),
+    ).rejects.toThrowError(
+      /Failed to get Alchemy Gas Manager policy with policyId/,
+    )
+  })
+
+  it('throws error if response is not valid policy', async () => {
+    mockGetSuccessJson('https://manage.g.alchemy.com/api/gasManager/policy/*', {
+      data: { policy: { unknownParams: 'haha' } },
+    })
+
+    await expect(
+      getAlchemyGasManagerPolicy({
+        accessKey: MOCK_ACCESS_KEY,
+        policyId: MOCK_POLICY.policyId,
+      }),
+    ).rejects.toThrow(ZodError)
+  })
+})
+
+describe(deleteAlchemyGasManagerPolicy.name, async () => {
+  it('sends correct DELETE request to Alchemy', async () => {
+    vi.spyOn(global, 'fetch')
+
+    mockDeleteSuccess('https://manage.g.alchemy.com/api/gasManager/policy/*')
+
+    await deleteAlchemyGasManagerPolicy({
+      accessKey: MOCK_ACCESS_KEY,
+      policyId: MOCK_POLICY.policyId,
+    })
+
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch).toHaveBeenCalledWith(
+      `https://manage.g.alchemy.com/api/gasManager/policy/${MOCK_POLICY.policyId}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${MOCK_ACCESS_KEY}`,
+        },
+        method: 'DELETE',
+      },
+    )
+  })
+})

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/alchemyGasManagerAdminActions.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/alchemyGasManagerAdminActions.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod'
+
+import { addressSchema } from '@/schemas/addressSchema'
+
+const alchemyGasManagerPolicyRulesSchema = z.object({
+  maxSpendUsd: z.number().nullable(),
+  maxSpendPerSenderUsd: z.number().nullable(),
+  maxCount: z.number().nullable(),
+  maxCountPerSender: z.number().nullable(),
+  senderAllowlist: z.array(addressSchema).nullable(),
+  senderBlocklist: z.array(addressSchema).nullable(),
+  startTimeUnix: z.string(),
+  endTimeUnix: z.string(),
+  maxSpendPerUoUsd: z.number().nullable(),
+  sponsorshipExpiryMs: z.string(),
+})
+
+export type AlchemyGasManagerPolicyRules = z.infer<
+  typeof alchemyGasManagerPolicyRulesSchema
+>
+
+const alchemyGasManagerPolicySchema = z.object({
+  policyId: z.string(),
+  appId: z.string(),
+  status: z.union([z.literal('active'), z.literal('inactive')]),
+  rules: alchemyGasManagerPolicyRulesSchema,
+  policyName: z.string(),
+  lastUpdatedUnix: z.string(),
+  policyType: z.literal('sponsorship'),
+  policyState: z.union([z.literal('ongoing'), z.literal('expired')]),
+  network: z.string(),
+})
+
+export type AlchemyGasManagerPolicy = z.infer<
+  typeof alchemyGasManagerPolicySchema
+>
+
+const failureResponseSchema = z.object({
+  message: z.string(),
+})
+
+const getFailureResponseMessage = async (response: Response) => {
+  return await response
+    .json()
+    .then((data) => {
+      const parsedErrorResult = failureResponseSchema.safeParse(data)
+      return parsedErrorResult.success
+        ? parsedErrorResult.data.message
+        : 'Unknown error'
+    })
+    .catch((e) => 'Unknown error')
+}
+
+export const getAlchemyGasManagerHeaders = (accessKey: string) => ({
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${accessKey}`,
+})
+
+const createPolicySuccessResponseSchema = z.object({
+  data: z.object({
+    policy: alchemyGasManagerPolicySchema,
+  }),
+})
+
+export const createAlchemyGasManagerPolicy = async ({
+  accessKey,
+  policyName,
+  policyType,
+  appId,
+  rules,
+}: {
+  accessKey: string
+  policyName: string
+  policyType: string
+  appId: string
+  rules: AlchemyGasManagerPolicyRules
+}) => {
+  const result = await fetch(
+    'https://manage.g.alchemy.com/api/gasManager/policy',
+    {
+      method: 'POST',
+      headers: getAlchemyGasManagerHeaders(accessKey),
+      body: JSON.stringify({
+        policyName: policyName,
+        policyType: policyType,
+        appId: appId,
+        rules: rules,
+      }),
+    },
+  )
+
+  if (!result.ok) {
+    throw new Error(
+      `Failed to create Alchemy Gas Manager policy: [${result.status}: ${result.statusText}] ${await getFailureResponseMessage(result)}`,
+    )
+  }
+
+  const jsonResponse = await result.json()
+
+  return createPolicySuccessResponseSchema.parse(jsonResponse).data.policy
+}
+
+const getPolicySuccessResponseSchema = z.object({
+  data: z.object({
+    policy: alchemyGasManagerPolicySchema,
+  }),
+})
+
+export const getAlchemyGasManagerPolicy = async ({
+  accessKey,
+  policyId,
+}: {
+  accessKey: string
+  policyId: string
+}) => {
+  const result = await fetch(
+    `https://manage.g.alchemy.com/api/gasManager/policy/${policyId}`,
+    {
+      headers: getAlchemyGasManagerHeaders(accessKey),
+    },
+  )
+
+  if (!result.ok) {
+    throw new Error(
+      `Failed to get Alchemy Gas Manager policy with policyId ${policyId}: [${result.status}: ${result.statusText}] ${await getFailureResponseMessage(result)}`,
+    )
+  }
+
+  const jsonResponse = await result.json()
+
+  return getPolicySuccessResponseSchema.parse(jsonResponse).data.policy
+}
+
+export const deleteAlchemyGasManagerPolicy = async ({
+  accessKey,
+  policyId,
+}: {
+  accessKey: string
+  policyId: string
+}) => {
+  const result = await fetch(
+    `https://manage.g.alchemy.com/api/gasManager/policy/${policyId}`,
+    {
+      method: 'DELETE',
+      headers: getAlchemyGasManagerHeaders(accessKey),
+    },
+  )
+
+  if (!result.ok) {
+    throw new Error(
+      `Failed to delete Alchemy Gas Manager policy with policyId ${policyId}: [${result.status}: ${result.statusText}] ${await getFailureResponseMessage(result)}`,
+    )
+  }
+}

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules.spec.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAlchemyGasManagerDefaultRules } from '@/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules'
+import { getCurrentUnixTimestamp } from '@/utils/getCurrentUnixTimestamp'
+
+describe(getAlchemyGasManagerDefaultRules.name, async () => {
+  it('applies 1 month duration from create time', () => {
+    const rules = getAlchemyGasManagerDefaultRules()
+
+    expect(Number(rules.endTimeUnix) - Number(rules.startTimeUnix)).toBe(
+      30 * 24 * 60 * 60,
+    )
+  })
+  it('start time around current time', () => {
+    const rules = getAlchemyGasManagerDefaultRules()
+
+    expect(Number(rules.startTimeUnix)).toBeCloseTo(getCurrentUnixTimestamp())
+  })
+})

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules.ts
@@ -1,0 +1,24 @@
+import { getCurrentUnixTimestamp } from '@/utils/getCurrentUnixTimestamp'
+
+const NON_DURATION_RULES = {
+  maxSpendUsd: 10.0,
+  maxSpendPerSenderUsd: 1.0,
+  maxSpendPerUoUsd: 1.0,
+  maxCount: 1000,
+  maxCountPerSender: 100,
+  senderAllowlist: null,
+  senderBlocklist: null,
+  sponsorshipExpiryMs: '300000', // 5 minutes
+} as const
+
+const DEFAULT_DURATION = 60 * 60 * 24 * 30 // 30 days
+
+export const getAlchemyGasManagerDefaultRules = () => {
+  const currentUnixTimestamp = getCurrentUnixTimestamp()
+
+  return {
+    ...NON_DURATION_RULES,
+    startTimeUnix: currentUnixTimestamp.toString(),
+    endTimeUnix: (currentUnixTimestamp + DEFAULT_DURATION).toString(),
+  }
+}

--- a/apps/paymaster-proxy/src/testUtils/mockAlchemyGasManagerPolicy.ts
+++ b/apps/paymaster-proxy/src/testUtils/mockAlchemyGasManagerPolicy.ts
@@ -1,0 +1,27 @@
+import crypto from 'crypto'
+
+import { getRandomAddress } from '@/testUtils/getRandomAddress'
+
+export const mockAlchemyGasManagerPolicy = {
+  policyId: crypto.randomUUID(),
+  appId: 'dkdskdsaflk12k1l',
+  status: 'active',
+  rules: {
+    maxSpendUsd: 5000,
+    maxSpendPerSenderUsd: 100,
+    maxCount: 100,
+    maxCountPerSender: 2,
+    senderAllowlist: [getRandomAddress(), getRandomAddress()],
+    senderBlocklist: null,
+    startTimeUnix: '1600000000',
+    endTimeUnix: '1650000000',
+    maxSpendPerUoUsd: 20,
+    sponsorshipExpiryMs: '600000',
+  },
+  policyName: 'fake-policy',
+  lastUpdatedUnix: '1700000000',
+  policyVersion: 0,
+  policyType: 'sponsorship',
+  policyState: 'ongoing',
+  network: 'OPT_SEPOLIA',
+}

--- a/apps/paymaster-proxy/src/testUtils/mswServer.ts
+++ b/apps/paymaster-proxy/src/testUtils/mswServer.ts
@@ -34,3 +34,75 @@ export const mockPostErrorWithReturnJson = (
     }),
   )
 }
+
+export const mockGetSuccessJson = (route: string, response: any) => {
+  mswServer.use(
+    http.get(route, () => {
+      return HttpResponse.json(response)
+    }),
+  )
+}
+
+export const mockGetError = (route: string, status: number) => {
+  mswServer.use(
+    http.get(route, () => {
+      return new HttpResponse(null, {
+        status,
+      })
+    }),
+  )
+}
+
+export const mockGetErrorWithReturnJson = (
+  route: string,
+  status: number,
+  body: any,
+) => {
+  mswServer.use(
+    http.get(route, () => {
+      return HttpResponse.json(body, {
+        status,
+      })
+    }),
+  )
+}
+
+export const mockDeleteSuccess = (route: string) => {
+  mswServer.use(
+    http.delete(route, () => {
+      return HttpResponse.json(null)
+    }),
+  )
+}
+
+export const mockDeleteSuccessJson = (route: string, response: any) => {
+  mswServer.use(
+    http.delete(route, () => {
+      return HttpResponse.json(response)
+    }),
+  )
+}
+
+export const mockDeleteError = (route: string, status: number) => {
+  mswServer.use(
+    http.delete(route, () => {
+      return new HttpResponse(null, {
+        status,
+      })
+    }),
+  )
+}
+
+export const mockDeleteErrorWithReturnJson = (
+  route: string,
+  status: number,
+  body: any,
+) => {
+  mswServer.use(
+    http.delete(route, () => {
+      return HttpResponse.json(body, {
+        status,
+      })
+    }),
+  )
+}

--- a/apps/paymaster-proxy/src/testUtils/setupE2eEnv.ts
+++ b/apps/paymaster-proxy/src/testUtils/setupE2eEnv.ts
@@ -1,0 +1,5 @@
+import { config } from 'dotenv'
+
+config({
+  path: '.env.e2e',
+})

--- a/apps/paymaster-proxy/src/utils/getCurrentUnixTimestamp.ts
+++ b/apps/paymaster-proxy/src/utils/getCurrentUnixTimestamp.ts
@@ -1,0 +1,3 @@
+export const getCurrentUnixTimestamp = () => {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/paymaster-proxy/vitest.e2e.config.ts
+++ b/apps/paymaster-proxy/vitest.e2e.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   test: {
     allowOnly: true,
     include: ['**/e2eTests/*.spec.ts'],
-    setupFiles: ['./src/testUtils/setupExtendedMatchers.ts'],
+    setupFiles: [
+      './src/testUtils/setupE2eEnv.ts',
+      './src/testUtils/setupExtendedMatchers.ts',
+    ],
   },
 })


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/ecopod/issues/951

added helper functions for interacting with Alchemy Gas Manager

https://docs.alchemy.com/reference/gas-manager-admin-api-endpoints
- createAlchemyGasManagerPolicy
- getAlchemyGasManagerPolicy

`apps/paymaster-proxy/src/paymasterProvider/alchemy/alchemyGasManagerAdminActions.ts`
- where majority of functionality is

`apps/paymaster-proxy/src/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules.ts`
- the default policy - still TBD based on product requirements


`apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.ts`
- thin wrapper to help with dependency injection