### PR TITLE
feat(paymaster-proxy): create admin routes for creating policies

### DIFF
--- a/apps/api-key-service/src/index.ts
+++ b/apps/api-key-service/src/index.ts
@@ -1,1 +1,2 @@
 export { ApiV0 } from './api'
+export type { ApiKey } from './models/apiKeys'

--- a/apps/api-key-service/src/routes/keys/KeysRoute.ts
+++ b/apps/api-key-service/src/routes/keys/KeysRoute.ts
@@ -33,7 +33,7 @@ export class KeysRoute extends Route {
           .min(10)
           .max(200)
           .optional()
-          .default(crypto.randomUUID()),
+          .default(() => crypto.randomUUID()),
       }),
     )
     .mutation(async ({ input }) => {

--- a/apps/paymaster-proxy/docker-compose.yml
+++ b/apps/paymaster-proxy/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     env_file: .env
     environment:
       - REDIS_URL=redis://redis:6379
+      - API_KEY_SERVICE_CLIENT=http://0.0.0.0:7330
     healthcheck:
       test: wget localhost:7310/healthz -q -O - > /dev/null 2>&1
     volumes:

--- a/apps/paymaster-proxy/src/adminApi/createAdminRouter.ts
+++ b/apps/paymaster-proxy/src/adminApi/createAdminRouter.ts
@@ -1,0 +1,186 @@
+import type { ApiKey } from '@eth-optimism/api-key-service'
+import type { Router } from 'express'
+import express from 'express'
+import type { Logger } from 'pino'
+import { optimismSepolia } from 'viem/chains'
+import { z } from 'zod'
+
+import type { ApiKeyServiceClient } from '@/apiKeyService/createApiKeyServiceClient'
+import type { Database } from '@/db/Database'
+import { envVars } from '@/envVars'
+import {
+  createSponsorshipPolicy,
+  getSponsorshipPolicyForApiKeyId,
+} from '@/models/sponsorshipPolicies'
+import type { AlchemyGasManagerPolicy } from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
+import { AlchemyGasManagerAdminClient } from '@/paymasterProvider/alchemy/AlchemyGasManagerAdminClient'
+import { getAlchemyGasManagerDefaultRules } from '@/paymasterProvider/alchemy/getAlchemyGasManagerDefaultRules'
+
+export const ADMIN_API_BASE_PATH = '/admin'
+
+type ChainConfig = {
+  alchemyGasManagerAdminClient: AlchemyGasManagerAdminClient
+}
+
+export const createAdminRouter = ({
+  database,
+  apiKeyServiceClient,
+  logger,
+}: {
+  database: Database
+  apiKeyServiceClient: ApiKeyServiceClient
+  logger: Logger
+}): Router => {
+  const chainConfigByChainId: Record<number, ChainConfig> = {
+    [optimismSepolia.id]: {
+      alchemyGasManagerAdminClient: new AlchemyGasManagerAdminClient({
+        accessKey: envVars.ALCHEMY_GAS_MANAGER_ACCESS_KEY,
+        appId: envVars.ALCHEMY_APP_ID_OP_SEPOLIA,
+      }),
+    },
+  } as const
+
+  const router = express.Router()
+
+  router.use(express.json())
+
+  router.post('/createPaymasterApiKey', async (req, res) => {
+    const paramsParseResult = z
+      .object({
+        chainId: z
+          .number()
+          .int()
+          .refine((chainId) => !!chainConfigByChainId[chainId], {
+            message: 'Unsupported chainId',
+          }),
+        entityId: z.string(),
+      })
+      .safeParse(req.body)
+
+    if (!paramsParseResult.success) {
+      return res.status(400).json({
+        error: 'Invalid params',
+      })
+    }
+
+    const alchemyGasManagerAdminClient =
+      chainConfigByChainId[paramsParseResult.data.chainId]
+        .alchemyGasManagerAdminClient
+
+    const { chainId, entityId } = paramsParseResult.data
+
+    // create new API key
+    let newApiKey: ApiKey
+    try {
+      const createApiKeyResponse =
+        await apiKeyServiceClient.keys.createApiKey.mutate({
+          entityId,
+          state: 'enabled',
+        })
+      newApiKey = createApiKeyResponse.apiKey
+    } catch (e) {
+      logger.error(e, 'Failed to create API key')
+      return res.status(500).json({
+        error: 'Failed to create API key',
+      })
+    }
+
+    // create new policy on Alchemy
+    let newPaymasterProviderPolicy: AlchemyGasManagerPolicy
+    try {
+      newPaymasterProviderPolicy =
+        await alchemyGasManagerAdminClient.createPolicy({
+          policyName: `paymaster-proxy:${envVars.DEPLOYMENT_ENV}:${chainId}:${newApiKey.id}`,
+          policyType: 'sponsorship',
+          rules: getAlchemyGasManagerDefaultRules(),
+        })
+    } catch (e) {
+      logger.error(e, 'Failed to create Alchemy Gas Manager policy')
+      return res.status(500).json({
+        error: 'Failed to create Alchemy Gas Manager policy',
+      })
+    }
+
+    // save policy ID and API key in DB
+    try {
+      await createSponsorshipPolicy(database, {
+        apiKeyId: newApiKey.id,
+        chainId: chainId.toString(),
+        providerType: 'alchemy',
+        providerMetadata: {
+          policyId: newPaymasterProviderPolicy.policyId,
+        },
+      })
+    } catch (e) {
+      logger.error(e, 'Failed to save policy ID and API key in DB')
+      return res.status(500).json({
+        error: 'Failed to save policy ID and API key in DB',
+      })
+    }
+
+    return res.json({
+      apiKey: newApiKey.key,
+    })
+  })
+
+  router.post('/deletePaymasterApiKey', async (req, res) => {
+    const paramsParseResult = z
+      .object({
+        chainId: z
+          .number()
+          .int()
+          .refine((chainId) => !!chainConfigByChainId[chainId], {
+            message: 'Unsupported chainId',
+          }),
+        apiKey: z.string(),
+      })
+      .safeParse(req.body)
+
+    if (!paramsParseResult.success) {
+      return res.status(400).json({
+        error: 'Invalid params',
+      })
+    }
+
+    const alchemyGasManagerAdminClient =
+      chainConfigByChainId[paramsParseResult.data.chainId]
+        .alchemyGasManagerAdminClient
+
+    const { apiKey } = paramsParseResult.data
+
+    const verifyApiKeyResult =
+      await apiKeyServiceClient.keys.verifyApiKey.query({
+        key: apiKey,
+      })
+
+    if (!verifyApiKeyResult || !verifyApiKeyResult.apiKey) {
+      return res.status(400).json({
+        error: 'Invalid API key',
+      })
+    }
+    const apiKeyId = verifyApiKeyResult.apiKey.id
+
+    const sponsorshipPolicy = await getSponsorshipPolicyForApiKeyId(
+      database,
+      apiKeyId,
+    )
+
+    if (!sponsorshipPolicy) {
+      return res.status(400).json({
+        error: 'No policy found for API key',
+      })
+    }
+
+    await alchemyGasManagerAdminClient.deletePolicy(
+      sponsorshipPolicy.providerMetadata.policyId,
+    )
+
+    await apiKeyServiceClient.keys.deleteApiKey.mutate({
+      id: sponsorshipPolicy.apiKeyId,
+    })
+
+    return res.status(200).send()
+  })
+
+  return router
+}

--- a/apps/paymaster-proxy/src/apiKeyService/createApiKeyServiceClient.ts
+++ b/apps/paymaster-proxy/src/apiKeyService/createApiKeyServiceClient.ts
@@ -7,8 +7,10 @@ export const createApiKeyServiceClient = ({ url }: { url: string }) => {
     transformer: SuperJSON,
     links: [
       httpBatchLink({
-        url,
+        url: `${url}/api/v0`,
       }),
     ],
   })
 }
+
+export type ApiKeyServiceClient = ReturnType<typeof createApiKeyServiceClient>

--- a/apps/paymaster-proxy/src/envVarsSchema.ts
+++ b/apps/paymaster-proxy/src/envVarsSchema.ts
@@ -34,6 +34,12 @@ export const envVarsSchema = inferSchemas({
       test: false,
     },
   },
+  API_KEY_SERVICE_URL: {
+    schema: z.string(),
+    defaults: {
+      test: 'http://0.0.0.0:7330',
+    },
+  },
   REDIS_URL: {
     schema: z.string(),
     defaults: {
@@ -167,6 +173,18 @@ export const envVarsSchema = inferSchemas({
     schema: z.string(),
     defaults: {
       test: 'test-policy-id',
+    },
+  },
+  ALCHEMY_APP_ID_OP_SEPOLIA: {
+    schema: z.string(),
+    defaults: {
+      test: 'test-app-id',
+    },
+  },
+  ALCHEMY_GAS_MANAGER_ACCESS_KEY: {
+    schema: z.string(),
+    defaults: {
+      test: 'test-gas-manager-access-key',
     },
   },
 })

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/AlchemyGasManagerAdminClient.ts
@@ -1,6 +1,7 @@
 import type { AlchemyGasManagerPolicyRules } from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
 import {
   createAlchemyGasManagerPolicy,
+  deleteAlchemyGasManagerPolicy,
   getAlchemyGasManagerPolicy,
 } from '@/paymasterProvider/alchemy/alchemyGasManagerAdminActions'
 
@@ -33,6 +34,13 @@ export class AlchemyGasManagerAdminClient {
 
   public async getPolicy(policyId: string) {
     return await getAlchemyGasManagerPolicy({
+      accessKey: this.accessKey,
+      policyId,
+    })
+  }
+
+  public async deletePolicy(policyId: string) {
+    return await deleteAlchemyGasManagerPolicy({
       accessKey: this.accessKey,
       policyId,
     })


### PR DESCRIPTION
closes https://github.com/ethereum-optimism/ecopod/issues/954

### `/admin/createPaymasterApiKey` 
- used to issue one-off API keys

### `/admin/deletePaymasterApiKey`
- delete existing API key by key 
