### PR TITLE
feat(dapp-console-api): fix deployment transaction bugs

### DIFF
--- a/apps/dapp-console-api/migrations/0020_crazy_ultimatum.sql
+++ b/apps/dapp-console-api/migrations/0020_crazy_ultimatum.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS "transactions_chain_id_transaction_hash_index";--> statement-breakpoint
+DROP INDEX IF EXISTS "transactions_from_address_index";--> statement-breakpoint
+DROP INDEX IF EXISTS "transactions_to_address_index";--> statement-breakpoint
+DROP INDEX IF EXISTS "transactions_contract_address_index";--> statement-breakpoint
+DROP INDEX IF EXISTS "transactions_entity_id_block_timestamp_index";--> statement-breakpoint
+ALTER TABLE "deploymentRebates" ALTER COLUMN "verified_wallets" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "deploymentRebates" ADD COLUMN "deployment_tx_hash" varchar NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "deploymentRebates_deployment_tx_hash_chain_id_index" ON "deploymentRebates" ("deployment_tx_hash","chain_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transactions_entity_id_index" ON "transactions" ("entity_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "transactions_contract_id_index" ON "transactions" ("contract_id");

--- a/apps/dapp-console-api/migrations/meta/0020_snapshot.json
+++ b/apps/dapp-console-api/migrations/meta/0020_snapshot.json
@@ -1,0 +1,932 @@
+{
+  "id": "489ecd35-cab5-47eb-a2c9-a57edc911553",
+  "prevId": "3264420b-a07f-49b2-aeef-18571948f9be",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "apps_entity_id_index": {
+          "name": "apps_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "apps_name_index": {
+          "name": "apps_name_index",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apps_entity_id_entities_id_fk": {
+          "name": "apps_entity_id_entities_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "challenges_entity_id_index": {
+          "name": "challenges_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_contract_id_index": {
+          "name": "challenges_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "challenges_address_index": {
+          "name": "challenges_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        },
+        "challenges_entity_id_address_index": {
+          "name": "challenges_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "challenges_entity_id_entities_id_fk": {
+          "name": "challenges_entity_id_entities_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenges_contract_id_contracts_id_fk": {
+          "name": "challenges_contract_id_contracts_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployer_address": {
+          "name": "deployer_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_verified'"
+        }
+      },
+      "indexes": {
+        "contracts_entity_id_chain_id_contract_address_index": {
+          "name": "contracts_entity_id_chain_id_contract_address_index",
+          "columns": [
+            "entity_id",
+            "chain_id",
+            "contract_address"
+          ],
+          "isUnique": true
+        },
+        "contracts_entity_id_index": {
+          "name": "contracts_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_app_id_index": {
+          "name": "contracts_app_id_index",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "contracts_contract_address_index": {
+          "name": "contracts_contract_address_index",
+          "columns": [
+            "contract_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_deployer_address_index": {
+          "name": "contracts_deployer_address_index",
+          "columns": [
+            "deployer_address"
+          ],
+          "isUnique": false
+        },
+        "contracts_entity_id_created_at_index": {
+          "name": "contracts_entity_id_created_at_index",
+          "columns": [
+            "entity_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contracts_entity_id_entities_id_fk": {
+          "name": "contracts_entity_id_entities_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contracts_app_id_apps_id_fk": {
+          "name": "contracts_app_id_apps_id_fk",
+          "tableFrom": "contracts",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "deploymentRebates": {
+      "name": "deploymentRebates",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_send'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_tx_hash": {
+          "name": "rebate_tx_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_amount": {
+          "name": "rebate_amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rebate_tx_timestamp": {
+          "name": "rebate_tx_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_wallets": {
+          "name": "verified_wallets",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "deploymentRebates_entity_id_index": {
+          "name": "deploymentRebates_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_id_index": {
+          "name": "deploymentRebates_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_contract_address_chain_id_index": {
+          "name": "deploymentRebates_contract_address_chain_id_index",
+          "columns": [
+            "contract_address",
+            "chain_id"
+          ],
+          "isUnique": true
+        },
+        "deploymentRebates_deployment_tx_hash_chain_id_index": {
+          "name": "deploymentRebates_deployment_tx_hash_chain_id_index",
+          "columns": [
+            "deployment_tx_hash",
+            "chain_id"
+          ],
+          "isUnique": true
+        },
+        "deploymentRebates_verified_wallets_index": {
+          "name": "deploymentRebates_verified_wallets_index",
+          "columns": [
+            "verified_wallets"
+          ],
+          "isUnique": false
+        },
+        "deploymentRebates_entity_id_rebate_tx_timestamp_index": {
+          "name": "deploymentRebates_entity_id_rebate_tx_timestamp_index",
+          "columns": [
+            "entity_id",
+            "rebate_tx_timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deploymentRebates_entity_id_entities_id_fk": {
+          "name": "deploymentRebates_entity_id_entities_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deploymentRebates_contract_id_contracts_id_fk": {
+          "name": "deploymentRebates_contract_id_contracts_id_fk",
+          "tableFrom": "deploymentRebates",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "privy_did": {
+          "name": "privy_did",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sanction_info": {
+          "name": "sanction_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entities_privy_did_unique": {
+          "name": "entities_privy_did_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_did"
+          ]
+        }
+      }
+    },
+    "transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_address": {
+          "name": "contract_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_gas_price": {
+          "name": "blob_gas_price",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blob_gas_used": {
+          "name": "blob_gas_used",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_event": {
+          "name": "transaction_event",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fee_per_blob_gas": {
+          "name": "max_fee_per_blob_gas",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_fee_per_gas": {
+          "name": "max_fee_per_gas",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_priority_fee_per_gas": {
+          "name": "max_priority_fee_per_gas",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_timestamp": {
+          "name": "block_timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transactions_entity_id_index": {
+          "name": "transactions_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "transactions_contract_id_index": {
+          "name": "transactions_contract_id_index",
+          "columns": [
+            "contract_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transactions_entity_id_entities_id_fk": {
+          "name": "transactions_entity_id_entities_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_contract_id_contracts_id_fk": {
+          "name": "transactions_contract_id_contracts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'privy'"
+        },
+        "verifications": {
+          "name": "verifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "unlinked_at": {
+          "name": "unlinked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sanctioned_at": {
+          "name": "sanctioned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallets_entity_id_address_index": {
+          "name": "wallets_entity_id_address_index",
+          "columns": [
+            "entity_id",
+            "address"
+          ],
+          "isUnique": true
+        },
+        "wallets_created_at_index": {
+          "name": "wallets_created_at_index",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "wallets_entity_id_index": {
+          "name": "wallets_entity_id_index",
+          "columns": [
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "wallets_address_index": {
+          "name": "wallets_address_index",
+          "columns": [
+            "address"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wallets_entity_id_entities_id_fk": {
+          "name": "wallets_entity_id_entities_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/dapp-console-api/migrations/meta/_journal.json
+++ b/apps/dapp-console-api/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1713916669274,
       "tag": "0019_first_gladiator",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "5",
+      "when": 1715032715906,
+      "tag": "0020_crazy_ultimatum",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dapp-console-api/src/errors/DappConsoleError.ts
+++ b/apps/dapp-console-api/src/errors/DappConsoleError.ts
@@ -17,6 +17,7 @@ export type DAPP_CONSOLE_ERROR_CODE =
   | 'MAX_REBATE_REACHED'
   | 'FAILED_TO_SEND_REBATE'
   | 'INELIGIBLE_CONTRACT'
+  | 'DUPLICATE_REBATE'
 
 export const ERROR_MESSAGES: Record<DAPP_CONSOLE_ERROR_CODE, string> = {
   DEPLOYMENT_TX_NOT_FOUND: 'deployment transaction could not be located',
@@ -41,6 +42,7 @@ export const ERROR_MESSAGES: Record<DAPP_CONSOLE_ERROR_CODE, string> = {
   MAX_REBATE_REACHED: 'entity has already claimed the max amount of rebates',
   FAILED_TO_SEND_REBATE: 'wallet failed to send rebate to user',
   INELIGIBLE_CONTRACT: 'contract not eligible for deployment rebate',
+  DUPLICATE_REBATE: 'rebate already exists',
 }
 
 export class DappConsoleError extends Error {

--- a/apps/dapp-console-api/src/models/transactions.ts
+++ b/apps/dapp-console-api/src/models/transactions.ts
@@ -6,7 +6,6 @@ import {
   numeric,
   pgTable,
   timestamp,
-  uniqueIndex,
   uuid,
   varchar,
 } from 'drizzle-orm/pg-core'
@@ -108,14 +107,8 @@ export const transactions = pgTable(
   },
   (table) => {
     return {
-      chainIdTransactionHashIdx: uniqueIndex().on(
-        table.chainId,
-        table.transactionHash,
-      ),
-      fromAddressIdx: index().on(table.fromAddress),
-      toAddressIdx: index().on(table.toAddress),
-      contractAddressIdx: index().on(table.contractAddress),
-      entityBlockTimestampIdx: index().on(table.entityId, table.blockTimestamp),
+      entityIdIdx: index().on(table.entityId),
+      contractIdIdx: index().on(table.contractId),
     }
   },
 )

--- a/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
@@ -32,6 +32,8 @@ const errorMessages: Record<string, string> = {
   MAX_REBATE_REACHED: 'Max rebate amount has been reached.',
   REBATE_ALREADY_CLAIMED: 'Rebate has already been claimed.',
   REBATE_PENDING: 'Rebate is already pending.',
+  DUPLICATE_REBATE:
+    'A rebate for this deployment transaction exists on another account.',
   FAILED_TO_SEND_REBATE: 'Failed to send rebate.',
 }
 


### PR DESCRIPTION
This PR fixes the following:
- enables multiple of the same deployment transactions to be added across different entities
- prevents the same deployment transaction hash from being claimed multiple times