### PR TITLE
Deployment Rebate Banner

### DIFF
--- a/apps/dapp-console/app/components/Banner/DeploymentRebateBanner.tsx
+++ b/apps/dapp-console/app/components/Banner/DeploymentRebateBanner.tsx
@@ -1,0 +1,15 @@
+import { routes } from '@/app/constants'
+import { Text } from '@eth-optimism/ui-components'
+import { RiStarFill } from '@remixicon/react'
+import Link from 'next/link'
+
+export const DeploymentRebateBanner = () => (
+  <div className="flex flex-row w-full min-h-[60px] items-center bg-blue-500/20 rounded-lg px-4 text-blue-600/80 cursor-pointer">
+    <Link className="flex flex-row w-full" href={routes.CONTRACTS.path}>
+      <RiStarFill />
+      <Text as="p" className="ml-2 font-semibold cursor-pointer">
+        New: Launch anywhere on the Superchain for free
+      </Text>
+    </Link>
+  </div>
+)

--- a/apps/dapp-console/app/console/components/Announcements.tsx
+++ b/apps/dapp-console/app/console/components/Announcements.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { DeploymentRebateBanner } from '@/app/components/Banner/DeploymentRebateBanner'
+import { useFeature } from '@/app/hooks/useFeatureFlag'
+
+export const Announcements = () => {
+  const isSettingsEnabled = useFeature('enable_console_settings')
+
+  return isSettingsEnabled ? (
+    <div className="flex flex-col w-full mt-4 md:mt-10 lg:mt-16">
+      <DeploymentRebateBanner />
+    </div>
+  ) : null
+}

--- a/apps/dapp-console/app/console/components/LaunchSection.tsx
+++ b/apps/dapp-console/app/console/components/LaunchSection.tsx
@@ -13,11 +13,14 @@ import { useDialogContent } from '@/app/console/useDialogContent'
 import { externalRoutes } from '@/app/constants'
 import { openWindow } from '@/app/helpers'
 import { trackCardClick } from '@/app/event-tracking/mixpanel'
+import { useFeature } from '@/app/hooks/useFeatureFlag'
 
 const LaunchSection = () => {
   const [dialogContent, setDialogContent] = useState<React.ReactNode>()
+  const isSettingsEnabled = useFeature('enable_console_settings')
   const { deploymentRebateContent, mainnetPaymasterContent, megaphoneContent } =
     useDialogContent()
+
   return (
     <div>
       <Text as="h3" className="text-2xl font-semibold mb-4">
@@ -33,7 +36,13 @@ const LaunchSection = () => {
                 trackCardClick('Deployment Rebate')
                 setDialogContent(deploymentRebateContent)
               }}
-              badge={<Badge variant="secondary">Coming soon</Badge>}
+              badge={
+                isSettingsEnabled ? (
+                  <Badge>Featured</Badge>
+                ) : (
+                  <Badge variant="secondary">Coming soon</Badge>
+                )
+              }
             />
           </DialogTrigger>
           <DialogTrigger asChild>

--- a/apps/dapp-console/app/page.tsx
+++ b/apps/dapp-console/app/page.tsx
@@ -17,6 +17,7 @@ import { externalRoutes } from '@/app/constants'
 import { Banner } from '@/app/components/Banner'
 import { Metadata } from 'next'
 import { homeMetadata } from '@/app/seo'
+import { Announcements } from '@/app/console/components/Announcements'
 
 export const metadata: Metadata = homeMetadata
 
@@ -46,6 +47,7 @@ export default function Page() {
           </CardDescription>
           <div className="pt-6">
             <ProjectIconLinks />
+            <Announcements />
           </div>
         </CardHeader>
         <CardContent className="pt-0 flex flex-col gap-16 md:px-10 md:pb-10 lg:px-16 lg:pb-16">

--- a/apps/dapp-console/app/settings/wallets/page.tsx
+++ b/apps/dapp-console/app/settings/wallets/page.tsx
@@ -27,7 +27,7 @@ export default function Wallets() {
     const wallets = user?.linkedAccounts.filter(
       (account) => account.type === 'wallet',
     ) as Wallet[]
-    return new Set(wallets.map((wallet) => wallet.address.toLowerCase()))
+    return new Set(wallets?.map((wallet) => wallet.address.toLowerCase()))
   }, [user])
 
   const linkedWallets = useMemo(() => {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds announcement section to home page that will display the deployment rebate banner if the FF is enabled
* Updates deployment rebate card to say "Featured" when the FF is enabled

**Dark Mode**
<img width="1271" alt="Screenshot 2024-05-07 at 4 07 03 PM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/431b253e-ad10-42c1-8699-69d50eee12c2">

**Light Mode**
<img width="1290" alt="Screenshot 2024-05-07 at 4 05 25 PM" src="https://github.com/ethereum-optimism/ecosystem/assets/1761993/b2526283-0a08-44ff-91a1-07290e8ca740">
