### PR TITLE
Updates feature flags to support labs emails

### DIFF
--- a/apps/dapp-console/app/components/Header/SignInButton.tsx
+++ b/apps/dapp-console/app/components/Header/SignInButton.tsx
@@ -16,7 +16,7 @@ import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 import { RiArrowDownSLine, RiUser3Fill } from '@remixicon/react'
 import { trackSignInClick } from '@/app/event-tracking/mixpanel'
 import { routes } from '@/app/constants'
-import { useFeature } from '@/app/hooks/useFeatureFlag'
+import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
 import { apiClient } from '@/app/helpers/apiClient'
 import { captureError } from '@/app/helpers/errorReporting'
 import { toast } from '@eth-optimism/ui-components'
@@ -69,7 +69,9 @@ type AccountDropdownProps = {
 }
 
 const AccountDropdown = ({ logout }: AccountDropdownProps) => {
-  const shouldShowSettings = useFeature('enable_console_settings')
+  const shouldShowSettings = useFeatureFlag('enable_console_settings', {
+    allowDevs: true,
+  })
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const dropdownItemClasses =

--- a/apps/dapp-console/app/console/components/Announcements.tsx
+++ b/apps/dapp-console/app/console/components/Announcements.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { DeploymentRebateBanner } from '@/app/components/Banner/DeploymentRebateBanner'
-import { useFeature } from '@/app/hooks/useFeatureFlag'
+import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
 
 export const Announcements = () => {
-  const isSettingsEnabled = useFeature('enable_console_settings')
+  const isSettingsEnabled = useFeatureFlag('enable_console_settings')
 
   return isSettingsEnabled ? (
     <div className="flex flex-col w-full mt-4 md:mt-10 lg:mt-16">

--- a/apps/dapp-console/app/console/components/LaunchSection.tsx
+++ b/apps/dapp-console/app/console/components/LaunchSection.tsx
@@ -13,11 +13,11 @@ import { useDialogContent } from '@/app/console/useDialogContent'
 import { externalRoutes } from '@/app/constants'
 import { openWindow } from '@/app/helpers'
 import { trackCardClick } from '@/app/event-tracking/mixpanel'
-import { useFeature } from '@/app/hooks/useFeatureFlag'
+import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
 
 const LaunchSection = () => {
   const [dialogContent, setDialogContent] = useState<React.ReactNode>()
-  const isSettingsEnabled = useFeature('enable_console_settings')
+  const isSettingsEnabled = useFeatureFlag('enable_console_settings')
   const { deploymentRebateContent, mainnetPaymasterContent, megaphoneContent } =
     useDialogContent()
 

--- a/apps/dapp-console/app/console/useDialogContent.tsx
+++ b/apps/dapp-console/app/console/useDialogContent.tsx
@@ -22,7 +22,7 @@ import {
   bwareMetadata,
 } from '@/app/console/constants'
 import { DialogClose } from '@eth-optimism/ui-components/src/components/ui/dialog/dialog'
-import { useFeature } from '@/app/hooks/useFeatureFlag'
+import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
 import {
   DialogMetadata,
   StandardDialogContent,
@@ -31,7 +31,7 @@ import { trackSignInModalClick } from '@/app/event-tracking/mixpanel'
 
 const useDialogContent = () => {
   const { authenticated, login } = usePrivy()
-  const isSettingsEnabled = useFeature('enable_console_settings')
+  const isSettingsEnabled = useFeatureFlag('enable_console_settings')
 
   const loginButton = (label: string, trackingLabel: string) => {
     return (

--- a/apps/dapp-console/app/helpers/errorReporting.ts
+++ b/apps/dapp-console/app/helpers/errorReporting.ts
@@ -9,6 +9,7 @@ export type ContractActionContext =
   | 'completeContractVerification'
 export type AuthActionContext = 'loginUser' | 'logoutUser'
 export type PrivyActionContext = 'privyLogin'
+export type FeatureFlagInvalid = 'invalidFeatureFlag'
 
 export type ErrorActionContext =
   | WalletActionContext
@@ -16,6 +17,7 @@ export type ErrorActionContext =
   | ContractActionContext
   | AuthActionContext
   | PrivyActionContext
+  | FeatureFlagInvalid
 
 export const captureError = (exception: unknown, action: ErrorActionContext) =>
   captureException(exception, { data: { action } })

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -15,7 +15,7 @@ import {
   SettingsCardTitle,
 } from '@/app/settings/components/SettingsCard'
 import { SettingsTabType, SettingsTab } from '@/app/settings/types'
-import { useFeature } from '@/app/hooks/useFeatureFlag'
+import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
 import { WalletVerificationMethods } from '@/app/settings/components/WalletVerificationMethods'
 import { RebateDialog } from '@/app/settings/components/RebateDialog'
 
@@ -64,7 +64,9 @@ export default function SettingsLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const shouldShowSettings = useFeature('enable_console_settings')
+  const shouldShowSettings = useFeatureFlag('enable_console_settings', {
+    allowDevs: true,
+  })
   const pathname = usePathname()
   const tab = useMemo(() => getActiveTab(pathname), [pathname])
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Updates feature flags to support labs emails, you can now pass along a `allowDevs` option so even if the flag is disabled labs employees will still be able to see it and test it
* Renames `useFeature` -> `useFeatureFlag` to avoid export collision with growthbook
* Sends error to sentry if the feature flag value is not valid
