### PR TITLE
feat(paymaster-proxy): add mainnet support

### DIFF
--- a/apps/paymaster-proxy/src/adminApi/createAdminRouter.ts
+++ b/apps/paymaster-proxy/src/adminApi/createAdminRouter.ts
@@ -2,12 +2,18 @@ import type { ApiKey } from '@eth-optimism/api-key-service'
 import type { Router } from 'express'
 import express from 'express'
 import type { Logger } from 'pino'
-import { baseSepolia, optimismSepolia, sepolia, zoraSepolia } from 'viem/chains'
+import {
+  baseSepolia,
+  optimism,
+  optimismSepolia,
+  sepolia,
+  zoraSepolia,
+} from 'viem/chains'
 import { z } from 'zod'
 
 import type { ApiKeyServiceClient } from '@/apiKeyService/createApiKeyServiceClient'
 import type { ChainConfig } from '@/config/ChainConfig'
-import type { SupportedTestnetChainId } from '@/config/chainConfigByChainId'
+import type { SupportedChainId } from '@/config/chainConfigByChainId'
 import { chainConfigByChainId } from '@/config/chainConfigByChainId'
 import { fraxtalSepolia } from '@/constants/fraxtalSepolia'
 import type { Database } from '@/db/Database'
@@ -26,14 +32,12 @@ const supportedChainIdSchema = z
   .number()
   .int()
   .refine(
-    (chainId): chainId is SupportedTestnetChainId =>
+    (chainId): chainId is SupportedChainId =>
       !!(chainConfigByChainId as Record<number, ChainConfig>)[chainId],
     {
       message: 'Unsupported chainId',
     },
   )
-
-type SupportedChainId = keyof typeof chainConfigByChainId
 
 const getAlchemyGasManagerClient = (chainId: SupportedChainId) => {
   const chainConfig = chainConfigByChainId[chainId]
@@ -61,6 +65,7 @@ export const createAdminRouter = ({
     [zoraSepolia.id]: getAlchemyGasManagerClient(zoraSepolia.id),
     [baseSepolia.id]: getAlchemyGasManagerClient(baseSepolia.id),
     [fraxtalSepolia.id]: getAlchemyGasManagerClient(fraxtalSepolia.id),
+    [optimism.id]: getAlchemyGasManagerClient(optimism.id),
   } as const
 
   const router = express.Router()

--- a/apps/paymaster-proxy/src/api/createV1ApiRouter.ts
+++ b/apps/paymaster-proxy/src/api/createV1ApiRouter.ts
@@ -1,55 +1,28 @@
 import type { Router } from 'express'
 import express from 'express'
 import type { Logger } from 'pino'
-import { baseSepolia, optimismSepolia, sepolia, zoraSepolia } from 'viem/chains'
+import {
+  baseSepolia,
+  optimism,
+  optimismSepolia,
+  sepolia,
+  zoraSepolia,
+} from 'viem/chains'
 
 import type { ApiKeyServiceClient } from '@/apiKeyService/createApiKeyServiceClient'
-import type { TestnetChainConfig } from '@/config/ChainConfig'
+import type {
+  MainnetChainConfig,
+  TestnetChainConfig,
+} from '@/config/ChainConfig'
 import { chainConfigByChainId } from '@/config/chainConfigByChainId'
 import { fraxtalSepolia } from '@/constants/fraxtalSepolia'
 import type { Database } from '@/db/Database'
 import { createExpressRouterFromJsonRpcRouter } from '@/jsonRpc/createExpressRouterFromJsonRpcRouter'
 import type { Metrics } from '@/monitoring/metrics'
+import { createMainnetJsonRpcRouterWithAlchemyPaymasterProvider } from '@/paymasterProvider/alchemy/createMainnetJsonRpcRouterWithAlchemyPaymasterProvider'
 import { createTestnetJsonRpcRouterWithAlchemyPaymasterProvider } from '@/paymasterProvider/alchemy/createTestnetJsonRpcRouterWithAlchemyPaymasterProvider'
 
 export const V1_API_BASE_PATH = '/v1'
-
-const registerTestnetWithAlchemyPaymasterProvider = (
-  router: express.Router,
-  {
-    chainConfig,
-    database,
-    apiKeyServiceClient,
-    metrics,
-    logger,
-  }: {
-    chainConfig: TestnetChainConfig
-    database: Database
-    apiKeyServiceClient: ApiKeyServiceClient
-    metrics: Metrics
-    logger: Logger
-  },
-) => {
-  const { chain } = chainConfig
-  const defaultMetricLabels = { apiVersion: 'v1', chainId: chain.id }
-
-  const jsonRpcRouter = createTestnetJsonRpcRouterWithAlchemyPaymasterProvider({
-    chainConfig,
-    database,
-    apiKeyServiceClient,
-    metrics,
-    defaultMetricLabels,
-    logger,
-  })
-
-  const path = `/${chain.id}/rpc`
-
-  logger.info(
-    `Registering testnet paymaster RPC route at ${V1_API_BASE_PATH}${path}: ${chain.name}`,
-  )
-
-  router.use(path, createExpressRouterFromJsonRpcRouter(jsonRpcRouter))
-}
 
 export const createV1ApiRouter = ({
   metrics,
@@ -104,5 +77,86 @@ export const createV1ApiRouter = ({
     logger,
   })
 
+  registerMainnetWithAlchemyPaymasterProvider(router, {
+    chainConfig: chainConfigByChainId[optimism.id],
+    database,
+    apiKeyServiceClient,
+    metrics,
+    logger,
+  })
+
   return router
+}
+
+const registerTestnetWithAlchemyPaymasterProvider = (
+  router: express.Router,
+  {
+    chainConfig,
+    database,
+    apiKeyServiceClient,
+    metrics,
+    logger,
+  }: {
+    chainConfig: TestnetChainConfig
+    database: Database
+    apiKeyServiceClient: ApiKeyServiceClient
+    metrics: Metrics
+    logger: Logger
+  },
+) => {
+  const { chain } = chainConfig
+  const defaultMetricLabels = { apiVersion: 'v1', chainId: chain.id }
+
+  const jsonRpcRouter = createTestnetJsonRpcRouterWithAlchemyPaymasterProvider({
+    chainConfig,
+    database,
+    apiKeyServiceClient,
+    metrics,
+    defaultMetricLabels,
+    logger,
+  })
+
+  const path = `/${chain.id}/rpc`
+
+  logger.info(
+    `Registering testnet paymaster RPC route at ${V1_API_BASE_PATH}${path}: ${chain.name}`,
+  )
+
+  router.use(path, createExpressRouterFromJsonRpcRouter(jsonRpcRouter))
+}
+
+const registerMainnetWithAlchemyPaymasterProvider = (
+  router: express.Router,
+  {
+    chainConfig,
+    database,
+    apiKeyServiceClient,
+    metrics,
+    logger,
+  }: {
+    chainConfig: MainnetChainConfig
+    database: Database
+    apiKeyServiceClient: ApiKeyServiceClient
+    metrics: Metrics
+    logger: Logger
+  },
+) => {
+  const { chain } = chainConfig
+
+  const jsonRpcRouter = createMainnetJsonRpcRouterWithAlchemyPaymasterProvider({
+    chainConfig,
+    database,
+    apiKeyServiceClient,
+    metrics,
+    defaultMetricLabels: { apiVersion: 'v1', chainId: chain.id },
+    logger,
+  })
+
+  const path = `/${chain.id}/rpc`
+
+  logger.info(
+    `Registering mainnet paymaster RPC route at ${V1_API_BASE_PATH}${path}: ${chain.name}`,
+  )
+
+  router.use(path, createExpressRouterFromJsonRpcRouter(jsonRpcRouter))
 }

--- a/apps/paymaster-proxy/src/config/chainConfigByChainId.ts
+++ b/apps/paymaster-proxy/src/config/chainConfigByChainId.ts
@@ -1,6 +1,15 @@
-import { baseSepolia, optimismSepolia, sepolia, zoraSepolia } from 'viem/chains'
+import {
+  baseSepolia,
+  optimism,
+  optimismSepolia,
+  sepolia,
+  zoraSepolia,
+} from 'viem/chains'
 
-import type { TestnetChainConfig } from '@/config/ChainConfig'
+import type {
+  MainnetChainConfig,
+  TestnetChainConfig,
+} from '@/config/ChainConfig'
 import { fraxtalSepolia } from '@/constants/fraxtalSepolia'
 import { envVars } from '@/envVars'
 
@@ -57,8 +66,23 @@ export const testnetChainConfigByChainId = {
   },
 } as const satisfies Record<number, TestnetChainConfig>
 
+export const mainnetChainConfigByChainId = {
+  [optimism.id]: {
+    chain: optimism,
+    paymasterProviderConfig: {
+      type: 'alchemy',
+      gasManagerAccessKey: envVars.ALCHEMY_GAS_MANAGER_ACCESS_KEY,
+      appId: envVars.ALCHEMY_APP_ID_OP_MAINNET,
+      rpcUrl: envVars.ALCHEMY_RPC_URL_OP_MAINNET,
+    },
+  },
+} as const satisfies Record<number, MainnetChainConfig>
+
 export type SupportedTestnetChainId = keyof typeof testnetChainConfigByChainId
 
-export const chainConfigByChainId = { ...testnetChainConfigByChainId } as const
+export const chainConfigByChainId = {
+  ...testnetChainConfigByChainId,
+  ...mainnetChainConfigByChainId,
+} as const
 
 export type SupportedChainId = keyof typeof chainConfigByChainId

--- a/apps/paymaster-proxy/src/envVarsSchema.ts
+++ b/apps/paymaster-proxy/src/envVarsSchema.ts
@@ -115,6 +115,24 @@ export const envVarsSchema = inferSchemas({
       test: 'https://screening-service.localhost',
     },
   },
+  ALCHEMY_RPC_URL_OP_MAINNET: {
+    schema: z.string(),
+    defaults: {
+      test: 'https://opt.g.alchemy.com/v2/testapikey',
+    },
+  },
+  ALCHEMY_GAS_MANAGER_POLICY_ID_OP_MAINNET: {
+    schema: z.string(),
+    defaults: {
+      test: 'test-policy-id',
+    },
+  },
+  ALCHEMY_APP_ID_OP_MAINNET: {
+    schema: z.string(),
+    defaults: {
+      test: 'test-op-mainnet-app-id',
+    },
+  },
   ALCHEMY_RPC_URL_SEPOLIA: {
     schema: z.string(),
     defaults: {

--- a/apps/paymaster-proxy/src/paymasterProvider/alchemy/createMainnetJsonRpcRouterWithAlchemyPaymasterProvider.ts
+++ b/apps/paymaster-proxy/src/paymasterProvider/alchemy/createMainnetJsonRpcRouterWithAlchemyPaymasterProvider.ts
@@ -1,0 +1,101 @@
+import type { ClientWithAlchemyMethods } from '@alchemy/aa-alchemy'
+import { createBundlerClient } from '@alchemy/aa-core'
+import type { Logger } from 'pino'
+import { http } from 'viem'
+import { z } from 'zod'
+
+import type { ApiKeyServiceClient } from '@/apiKeyService/createApiKeyServiceClient'
+import type { MainnetChainConfig } from '@/config/ChainConfig'
+import type { Database } from '@/db/Database'
+import { InvalidPolicyIdError } from '@/errors/InvalidPolicyIdError'
+import { SanctionedAddressError } from '@/errors/SanctionedAddressError'
+import { handleScreenAddress } from '@/jsonRpc/handleScreenAddress'
+import { handleVerifyApiKey } from '@/jsonRpc/handleVerifyApiKey'
+import { JsonRpcRouter } from '@/jsonRpc/JsonRpcRouter'
+import { getSponsorshipPolicyForApiKeyId } from '@/models/sponsorshipPolicies'
+import type {
+  DefaultMetricsNamespaceLabels,
+  Metrics,
+} from '@/monitoring/metrics'
+import { handleAlchemySponsorUserOperation } from '@/paymasterProvider/alchemy/handleAlchemySponsorUserOperation'
+import { addressSchema } from '@/schemas/addressSchema'
+import { paymasterContextSchema } from '@/schemas/paymasterContextSchema'
+import { userOperationSchema } from '@/schemas/userOperationSchema'
+
+export const createMainnetJsonRpcRouterWithAlchemyPaymasterProvider = ({
+  chainConfig,
+  database,
+  apiKeyServiceClient,
+  metrics,
+  defaultMetricLabels,
+  logger,
+}: {
+  chainConfig: MainnetChainConfig
+  database: Database
+  apiKeyServiceClient: ApiKeyServiceClient
+  metrics: Metrics
+  defaultMetricLabels: DefaultMetricsNamespaceLabels
+  logger: Logger
+}) => {
+  const { chain } = chainConfig
+  const { rpcUrl } = chainConfig.paymasterProviderConfig
+
+  const alchemyClient = createBundlerClient({
+    chain,
+    transport: http(rpcUrl),
+  }) as ClientWithAlchemyMethods
+
+  const monitoringCtx = {
+    logger,
+    metrics,
+    defaultMetricLabels,
+  }
+  const jsonRpcRouter = new JsonRpcRouter()
+
+  jsonRpcRouter.method(
+    'pm_sponsorUserOperation',
+    z.tuple([userOperationSchema, addressSchema, paymasterContextSchema]),
+    async ([userOperation, entryPoint, paymasterContext]) => {
+      // check if address is sanctioned
+      const isAddressSanctioned = await handleScreenAddress(
+        monitoringCtx,
+        userOperation.sender,
+      )
+      if (isAddressSanctioned === true) {
+        metrics.sanctionedAddressBlocked.inc(defaultMetricLabels)
+        logger.info({
+          message: 'Screened address',
+          address: userOperation.sender,
+        })
+        throw new SanctionedAddressError()
+      }
+
+      const verificationResult = await handleVerifyApiKey(monitoringCtx, {
+        apiKeyServiceClient,
+        key: paymasterContext.policyId,
+      })
+
+      if (!verificationResult.isVerified) {
+        throw new InvalidPolicyIdError()
+      }
+
+      const policy = await getSponsorshipPolicyForApiKeyId(
+        database,
+        verificationResult.apiKey!.id,
+      )
+
+      if (!policy || policy.providerType !== 'alchemy') {
+        throw new InvalidPolicyIdError()
+      }
+
+      return await handleAlchemySponsorUserOperation(monitoringCtx, {
+        alchemyClient,
+        alchemyPolicyId: policy.providerMetadata.policyId,
+        userOperation,
+        entryPoint,
+      })
+    },
+  )
+
+  return jsonRpcRouter
+}


### PR DESCRIPTION
adds OP Mainnet support for creating / using policies. Main difference between testnet chains vs mainnet chains is that mainnet chains REQUIRES a policyId vs. for testnet it's optional

- will add other chains in a separte PR
