### PR TITLE
Hopefully thats it

### DIFF
--- a/apps/dapp-console/app/event-tracking/mixpanel.tsx
+++ b/apps/dapp-console/app/event-tracking/mixpanel.tsx
@@ -42,6 +42,7 @@ enum CUSTOM_TRACKING_PROPERTY {
   DeleteActionType = 'Delete Action Type',
   WalletType = 'Wallet Type',
   VerificationType = 'Verification Type',
+  ChainId = 'Chain Id',
 }
 
 export type ActionType = 'app' | 'contract' | 'wallet'
@@ -136,6 +137,8 @@ export const trackClaimRebateClick = () => {
   mixpanel?.track(TRACKING_EVENT_NAME.ClaimRebateClick)
 }
 
-export const trackClaimRebate = () => {
-  mixpanel?.track(TRACKING_EVENT_NAME.ClaimRebate)
+export const trackClaimRebate = (chainId: number) => {
+  mixpanel?.track(TRACKING_EVENT_NAME.ClaimRebate, {
+    [CUSTOM_TRACKING_PROPERTY.ChainId]: chainId,
+  })
 }

--- a/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
+++ b/apps/dapp-console/app/settings/components/ClaimRebateDialog.tsx
@@ -97,7 +97,7 @@ export const ClaimRebateDialog = ({
         duration: LONG_DURATION,
       })
 
-      trackClaimRebate()
+      trackClaimRebate(contract.chainId)
       setRebateTxHash(txHash)
       onRebateClaimed(contract)
     } catch (e) {

--- a/apps/dapp-console/app/settings/layout.tsx
+++ b/apps/dapp-console/app/settings/layout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { redirect, usePathname } from 'next/navigation'
-import { useEffect, useMemo } from 'react'
+import { usePathname } from 'next/navigation'
+import { useMemo } from 'react'
 
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 
@@ -86,12 +86,6 @@ export default function SettingsLayout({
     () => getActiveTab(pathname, isDeploymentRebateEnabled),
     [pathname, isDeploymentRebateEnabled],
   )
-
-  useEffect(() => {
-    if (!shouldShowSettings) {
-      redirect('/')
-    }
-  }, [shouldShowSettings])
 
   return shouldShowSettings ? (
     <main className="flex justify-center bg-secondary min-h-screen">


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Updates mixpanel tracking to include the contract chain id when claiming a rebate
* Remove redirect on settings page, instead it continues to show an empty page if the flag isn't enabled