### PR TITLE
feat(api-key-service): add optional name

### DIFF
--- a/apps/api-key-service/migrations/0001_young_thunderbolt_ross.sql
+++ b/apps/api-key-service/migrations/0001_young_thunderbolt_ross.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "api-keys" ADD COLUMN "name" varchar;

--- a/apps/api-key-service/migrations/meta/0001_snapshot.json
+++ b/apps/api-key-service/migrations/meta/0001_snapshot.json
@@ -1,0 +1,105 @@
+{
+  "id": "65d201a7-292e-4016-8ea9-6236b6f0e86c",
+  "prevId": "196c8f4f-6acb-40da-9c7e-a89fcbdad67e",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "api-keys": {
+      "name": "api-keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_updated_at": {
+          "name": "state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api-keys_deleted_at_index": {
+          "name": "api-keys_deleted_at_index",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "api-keys_entity_id_deleted_at_index": {
+          "name": "api-keys_entity_id_deleted_at_index",
+          "columns": [
+            "entity_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "api-keys_key_index": {
+          "name": "api-keys_key_index",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api-key-service/migrations/meta/_journal.json
+++ b/apps/api-key-service/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1712879413323,
       "tag": "0000_broad_justin_hammer",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1715651824408,
+      "tag": "0001_young_thunderbolt_ross",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api-key-service/src/models/apiKeys.ts
+++ b/apps/api-key-service/src/models/apiKeys.ts
@@ -18,6 +18,7 @@ export const apiKeys = pgTable(
   {
     id: uuid('id').defaultRandom().primaryKey(),
     entityId: uuid('entity_id').notNull(),
+    name: varchar('name'), // optional
     key: varchar('key').notNull(),
     state: varchar('state').$type<ApiKeyState>().notNull(),
     stateUpdatedAt: timestamp('state_updated_at', { withTimezone: true }),

--- a/apps/api-key-service/src/routes/keys/KeysRoute.spec.ts
+++ b/apps/api-key-service/src/routes/keys/KeysRoute.spec.ts
@@ -88,6 +88,63 @@ describe(KeysRoute.name, () => {
       expect(resopnse).toEqual({ apiKey: apiKeyObj })
     })
 
+    it('accepts null name', async () => {
+      const createApiKeyParams = {
+        entityId: crypto.randomUUID(),
+        key: 'test-api-key-0',
+        name: null,
+      }
+
+      const apiKeyObj = toApiKeyObj(createApiKeyParams)
+
+      mockedCreateApiKey.mockResolvedValueOnce(apiKeyObj)
+
+      const resopnse = await caller.createApiKey(createApiKeyParams)
+
+      expect(mockedCreateApiKey).toHaveBeenCalledOnce()
+
+      expect(mockedCreateApiKey.mock.calls[0][1]).toMatchObject({
+        ...createApiKeyParams,
+        state: 'disabled',
+      })
+
+      expect(resopnse).toEqual({ apiKey: apiKeyObj })
+    })
+
+    it('happy path', async () => {
+      const createApiKeyParams = {
+        entityId: crypto.randomUUID(),
+        key: 'test-api-key-0',
+        name: 'something',
+      }
+
+      const apiKeyObj = toApiKeyObj(createApiKeyParams)
+
+      mockedCreateApiKey.mockResolvedValueOnce(apiKeyObj)
+
+      const resopnse = await caller.createApiKey(createApiKeyParams)
+
+      expect(mockedCreateApiKey).toHaveBeenCalledOnce()
+
+      expect(mockedCreateApiKey.mock.calls[0][1]).toMatchObject({
+        ...createApiKeyParams,
+        state: 'disabled',
+      })
+
+      expect(resopnse).toEqual({ apiKey: apiKeyObj })
+    })
+
+    it('rejects non string name', async () => {
+      await expect(
+        caller.createApiKey({
+          entityId: crypto.randomUUID(),
+          state: 'disabled',
+          // @ts-expect-error - testing invalid input
+          name: 123,
+        }),
+      ).rejects.toThrowError(/invalid_type/)
+    })
+
     it('rejects empty string key', async () => {
       await expect(
         caller.createApiKey({

--- a/apps/api-key-service/src/routes/keys/KeysRoute.ts
+++ b/apps/api-key-service/src/routes/keys/KeysRoute.ts
@@ -24,6 +24,7 @@ export class KeysRoute extends Route {
     .input(
       z.object({
         entityId: z.string(),
+        name: z.string().optional().nullable(),
         state: z
           .union([z.literal('enabled'), z.literal('disabled')])
           .optional()
@@ -37,7 +38,7 @@ export class KeysRoute extends Route {
       }),
     )
     .mutation(async ({ input }) => {
-      const { entityId, state, key } = input
+      const { entityId, name, state, key } = input
 
       let apiKey: ApiKey
       try {
@@ -45,6 +46,7 @@ export class KeysRoute extends Route {
           entityId,
           state,
           key,
+          name,
         })
         this.metrics.generatedApiKeysCount.inc()
       } catch (e) {

--- a/apps/api-key-service/src/testUtils/toApiKeyObj.ts
+++ b/apps/api-key-service/src/testUtils/toApiKeyObj.ts
@@ -8,6 +8,7 @@ export const toApiKeyObj = (partialApiKey: Partial<ApiKey>): ApiKey => {
     id: partialApiKey.id ?? crypto.randomUUID(),
     entityId: partialApiKey.entityId ?? crypto.randomUUID(),
     key: partialApiKey.key ?? crypto.randomUUID(),
+    name: partialApiKey.name ?? null,
     state: partialApiKey.state ?? 'disabled',
     createdAt: partialApiKey.createdAt ?? new Date(),
     updatedAt: partialApiKey.updatedAt ?? new Date(),


### PR DESCRIPTION
adds a column to `api-keys` table to support an optional name parameter. This can be used to save user defined metadata about apikeys