### PR TITLE
Github action to publish snapshots to NPM

### DIFF
--- a/.changeset/flat-laws-cross.md
+++ b/.changeset/flat-laws-cross.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/op-app": patch
+---
+
+Test

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -2,7 +2,6 @@ name: Release snapshot
 
 # Releases a snapshot release when new commits merge to main
 # This ensures the release process is working as expected as well as always gives us a release
-# we should move to a single branch in near future
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,0 +1,43 @@
+name: Release snapshot
+
+# Releases a snapshot release when new commits merge to main
+# This ensures the release process is working as expected as well as always gives us a release
+# we should move to a single branch in near future
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  publish-snapshot:
+    name: Publish snapshot release to npm
+    if: github.repository == 'ethereum-optimism/ecosystem'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Set deployment token
+        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify NPM Token is valid
+        run: npm whoami
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish snapshots
+        uses: seek-oss/changesets-snapshot@v0
+        with:
+          pre-publish: pnpm nx run-many --target=build --skip-nx-cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -5,7 +5,7 @@ name: Release snapshot
 # we should move to a single branch in near future
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/apps/paymaster-proxy/package.json
+++ b/apps/paymaster-proxy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/paymaster-proxy",
   "version": "0.0.0",
+  "private": true,
   "scripts": {
     "test": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/apps/ui-component-storybook/package.json
+++ b/apps/ui-component-storybook/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/ui-component-storybook",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.0",
     "@nx/js": "17.1.3",
     "@nx/plugin": "17.1.3",
     "eslint-config-react-app": "^7.0.1",

--- a/packages/api-plugin/package.json
+++ b/packages/api-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/api-plugin",
   "version": "0.0.1",
+  "private": true,
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf dist",

--- a/packages/op-app/package.json
+++ b/packages/op-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@eth-optimism/op-app",
-  "private": true,
   "type": "module",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^2.27.1
         version: 2.27.1
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.0
+        version: 0.5.0(encoding@0.1.13)
       '@nx/js':
         specifier: 17.1.3
         version: 17.1.3(@babel/traverse@7.24.1)(@types/node@20.12.12)(nx@17.1.3)(typescript@5.4.5)
@@ -2146,6 +2149,9 @@ packages:
   '@changesets/changelog-git@0.2.0':
     resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
 
+  '@changesets/changelog-github@0.5.0':
+    resolution: {integrity: sha512-zoeq2LJJVcPJcIotHRJEEA2qCqX0AQIeFE+L21L8sRLPVqDhSXY8ZWAt2sohtBpFZkBwu+LUwMSKRr2lMy3LJA==}
+
   '@changesets/cli@2.27.1':
     resolution: {integrity: sha512-iJ91xlvRnnrJnELTp4eJJEOPjgpF3NOh4qeQehM6Ugiz9gJPRZ2t+TsXun6E3AMN4hScZKjqVXl0TX+C7AB3ZQ==}
     hasBin: true
@@ -2158,6 +2164,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.0.0':
     resolution: {integrity: sha512-cafUXponivK4vBgZ3yLu944mTvam06XEn2IZGjjKc0antpenkYANXiiE6GExV/yKdsCnE8dXVZ25yGqLYZmScA==}
+
+  '@changesets/get-github-info@0.6.0':
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
 
   '@changesets/get-release-plan@4.0.0':
     resolution: {integrity: sha512-9L9xCUeD/Tb6L/oKmpm8nyzsOzhdNBBbt/ZNcjynbHC07WW4E1eX8NMGC5g5SbM5z/V+MOrYsJ4lRW41GCbg3w==}
@@ -7434,6 +7443,9 @@ packages:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   dataloader@2.2.2:
     resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
 
@@ -7717,6 +7729,10 @@ packages:
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   dreamopt@0.8.0:
     resolution: {integrity: sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==}
@@ -15042,6 +15058,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.0.0
 
+  '@changesets/changelog-github@0.5.0(encoding@0.1.13)':
+    dependencies:
+      '@changesets/get-github-info': 0.6.0(encoding@0.1.13)
+      '@changesets/types': 6.0.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.27.1':
     dependencies:
       '@babel/runtime': 7.24.4
@@ -15098,6 +15122,13 @@ snapshots:
       chalk: 2.4.2
       fs-extra: 7.0.1
       semver: 7.6.0
+
+  '@changesets/get-github-info@0.6.0(encoding@0.1.13)':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.0':
     dependencies:
@@ -23139,6 +23170,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.1
 
+  dataloader@1.4.0: {}
+
   dataloader@2.2.2: {}
 
   date-fns@2.30.0:
@@ -23389,6 +23422,8 @@ snapshots:
   dotenv@16.3.2: {}
 
   dotenv@16.4.5: {}
+
+  dotenv@8.6.0: {}
 
   dreamopt@0.8.0:
     dependencies:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a new workflow called `release-snaphot` this will publish a snapshot of a **public** package to NPM. This is important to note that if your NPM package is marked as **private** publishing will be skipped even if a changeset exists for it. Now back to the conditions for getting snapshots published when we merge to our `main` branch.

* If a public package has never been published to NPM it will automatically create an entry
* If a changeset exists it will publish the package to NPM (Run `pnpm changeset` this will prompt you with the interactive cli)

This PR also adds/updates the following
* Adds `@changesets/changelog-github` as a root dev dep
* Marks all packages that we dont' want to publish as private. This is everything besides `op-app` and `sdk`

Example (tested this from a PR): https://www.npmjs.com/package/@eth-optimism/op-app