### PR TITLE
Semver NPM Publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,8 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "privatePackages": { "version": true, "tag": true },
-  "ignore": []
+  "ignore": [
+    "@eth-optimism/bridge-app",
+    "@eth-optimism/dapp-console"
+  ]
 }

--- a/.changeset/honest-fireants-relate.md
+++ b/.changeset/honest-fireants-relate.md
@@ -1,5 +1,0 @@
----
-"@eth-optimism/sdk": patch
----
-
-Fix SDK build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release and version
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+# Always wait for previous release to finish before releasing again
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish-release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: github.repository == 'ethereum-optimism/ecosystem'
+    # Permissions necessary for Changesets to push a new branch and open PRs
+    # (for automated Version Packages PRs), and request the JWT for provenance.
+    # More info: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+          ref: "main"
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Check if NPM_TOKEN is set
+        id: check_token
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "NPM_TOKEN is not set. Is it set it in your repository secrets?"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Set deployment token
+        run: npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify NPM Token is valid
+        run: npm whoami
+
+      # Makes a pr to publish the changesets that when
+      # merged will publish to npm
+      # see https://github.com/changesets/action
+      - name: Publish To NPM or Create Release Pull Request
+        uses: changesets/action@v1
+        id: changesets
+        with:
+          createGithubReleases: false
+          publish: pnpm release:publish
+          version: pnpm release:version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "clean": "pnpm recursive run clean",
     "create:app": "cd apps && pnpm create vite --template=react-ts ",
-    "create:react:library": "cd packages && pnpm create vite --template=react-ts "
+    "create:react:library": "cd packages && pnpm create vite --template=react-ts ",
+    "release:publish": "pnpm install --frozen-lockfile && pnpm nx run-many --target=build && changeset publish",
+    "release:version": "changeset version && pnpm install --lockfile-only"
   },
   "private": true,
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eth-optimism/sdk",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "[Optimism] Tools for working with Optimism",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
* Adds support for publishing semvar versions of changesets.
* Ignores apps that pull in those public packages. The reason is changeset right now will attempt to [bump the version](https://github.com/changesets/changesets/blob/761b2d3d26b996a91ddfaa91c6887e50145dcbd7/packages/assemble-release-plan/src/determine-dependents.ts#L194-L205) of those apps  
* Bumps `sdk` to latest versions that we published in monorepo

Flow for publishing packages
* When something gets merged into `main` the release github action will check to see what changesets exist. If there are changesets it will automatically open up a versions PR that increments the package versions, . Once this PR gets approved and merged the same release action will then publish this version to npm. 

