### PR TITLE
feat(faucet): Wire up privy login to backend

### DIFF
--- a/apps/dapp-console-api/src/routes/faucet/FaucetRoute.ts
+++ b/apps/dapp-console-api/src/routes/faucet/FaucetRoute.ts
@@ -143,7 +143,7 @@ export class FaucetRoute extends Route {
     )
     .mutation<FaucetClaim>(async ({ ctx, input }) => {
       const ownerAddress = input.ownerAddress as Address
-      const recipientAddrss = input.recipientAddress as Address
+      const recipientAddress = input.recipientAddress as Address
       const signature = input.signature as Hex
       const { chainId, authMode } = input
 

--- a/apps/dapp-console-api/src/routes/faucet/FaucetRoute.ts
+++ b/apps/dapp-console-api/src/routes/faucet/FaucetRoute.ts
@@ -143,7 +143,7 @@ export class FaucetRoute extends Route {
     )
     .mutation<FaucetClaim>(async ({ ctx, input }) => {
       const ownerAddress = input.ownerAddress as Address
-      const recipientAddress = input.recipientAddress as Address
+      const recipientAddrss = input.recipientAddress as Address
       const signature = input.signature as Hex
       const { chainId, authMode } = input
 

--- a/apps/dapp-console/app/faucet/components/FaucetHeader.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeader.tsx
@@ -3,7 +3,6 @@ import { hasAuthentication } from '@/app/faucet/helpers'
 import { LogoChain } from '@/app/faucet/components/LogoChain'
 import { AuthenticatedHeader } from '@/app/faucet/components/AuthenticatedHeader'
 import { FaucetHeaderInner } from '@/app/faucet/components/FaucetHeaderInner'
-import { usePrivy } from '@privy-io/react-auth'
 
 type FaucetHeaderProps = {
   authentications: Authentications

--- a/apps/dapp-console/app/faucet/components/FaucetHeader.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeader.tsx
@@ -10,15 +10,13 @@ type FaucetHeaderProps = {
 }
 
 const FaucetHeader = ({ authentications }: FaucetHeaderProps) => {
-  const { authenticated } = usePrivy()
-
   return (
     <div>
       {hasAuthentication(authentications) ? (
         <AuthenticatedHeader authentications={authentications} />
       ) : (
         <div className="flex justify-between flex-col-reverse md:flex-row items-start gap-4">
-          <FaucetHeaderInner signedIn={authenticated} />
+          <FaucetHeaderInner />
           <LogoChain />
         </div>
       )}

--- a/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
@@ -6,8 +6,9 @@ import {
   DialogContent,
 } from '@eth-optimism/ui-components/src/components/ui/dialog/dialog'
 import { LearnMoreDialogContent } from '@/app/faucet/components/LearnMoreDialogContent'
-import { usePrivy, useWallets } from '@privy-io/react-auth'
+import { usePrivy } from '@privy-io/react-auth'
 import { useAuth } from '@/app/hooks/useAuth'
+import { useConnectedWallet } from '@/app/hooks/useConnectedWallet'
 
 const seeDetails = (
   <DialogTrigger>
@@ -18,11 +19,8 @@ const seeDetails = (
 )
 
 const FaucetHeaderInner = () => {
-  const { connectWallet } = usePrivy()
-  const { wallets } = useWallets()
-  const connectedWallet = wallets.find((w) => w.walletClientType !== 'privy') // Exclude Privy wallet
-
-  const { authenticated } = usePrivy()
+  const { connectWallet, authenticated } = usePrivy()
+  const { connectedWallet } = useConnectedWallet()
   const { login } = useAuth()
 
   const handleLogin = () => {

--- a/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
@@ -7,10 +7,7 @@ import {
 } from '@eth-optimism/ui-components/src/components/ui/dialog/dialog'
 import { LearnMoreDialogContent } from '@/app/faucet/components/LearnMoreDialogContent'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
-
-type Props = {
-  signedIn: boolean
-}
+import { useAuth } from '@/app/hooks/useAuth'
 
 const seeDetails = (
   <DialogTrigger>
@@ -20,13 +17,20 @@ const seeDetails = (
   </DialogTrigger>
 )
 
-const FaucetHeaderInner = ({ signedIn }: Props) => {
-  const { connectWallet, login } = usePrivy()
+const FaucetHeaderInner = () => {
+  const { connectWallet } = usePrivy()
   const { wallets } = useWallets()
   const connectedWallet = wallets.find((w) => w.walletClientType !== 'privy') // Exclude Privy wallet
 
+  const { authenticated } = usePrivy()
+  const { login } = useAuth()
+
+  const handleLogin = () => {
+    login()
+  }
+
   let content = null
-  if (!signedIn) {
+  if (!authenticated) {
     // User is not signed in
     content = (
       <>
@@ -37,7 +41,7 @@ const FaucetHeaderInner = ({ signedIn }: Props) => {
           Anyone can claim 0.05 test ETH on 1 network every 24 hours, or verify
           your onchain identity for more tokens. {seeDetails}
         </Text>
-        <Button onClick={login}>Sign in</Button>
+        <Button onClick={handleLogin}>Sign in</Button>
       </>
     )
   } else if (!connectedWallet) {

--- a/apps/dapp-console/app/faucet/page.tsx
+++ b/apps/dapp-console/app/faucet/page.tsx
@@ -11,7 +11,7 @@ import { FaucetContent } from '@/app/faucet/components/FaucetContent'
 import { Faqs } from '@/app/faucet/components/Faqs'
 
 const authentications = {
-  coinbase: true,
+  coinbase: false,
   worldId: false,
   gitcoin: false,
   eas: false,

--- a/apps/dapp-console/app/faucet/page.tsx
+++ b/apps/dapp-console/app/faucet/page.tsx
@@ -4,9 +4,7 @@ import { CardContent, CardHeader } from '@eth-optimism/ui-components'
 import { Card } from '@eth-optimism/ui-components/src/components/ui/card/card'
 import { Text } from '@eth-optimism/ui-components/src/components/ui/text/text'
 import { FaucetHeader } from '@/app/faucet/components/FaucetHeader'
-import { useEffect } from 'react'
 import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
-import { useRouter } from 'next/navigation'
 import { FaucetContent } from '@/app/faucet/components/FaucetContent'
 import { Faqs } from '@/app/faucet/components/Faqs'
 
@@ -19,14 +17,10 @@ const authentications = {
 
 export default function Faucet() {
   const isConsoleFaucetEnabled = useFeatureFlag('enable_console_faucet')
-  const router = useRouter()
 
-  // Redirect to the home page if the faucet is disabled
-  useEffect(() => {
-    if (!isConsoleFaucetEnabled) {
-      router.push('/')
-    }
-  }, [isConsoleFaucetEnabled, router])
+  if (!isConsoleFaucetEnabled) {
+    return null
+  }
 
   return (
     <div className="flex flex-col w-full items-center py-10 px-2 pb-20 sm:px-6 bg-secondary">

--- a/apps/dapp-console/app/hooks/useAuth.ts
+++ b/apps/dapp-console/app/hooks/useAuth.ts
@@ -1,0 +1,44 @@
+import { useLogin, useLogout } from '@privy-io/react-auth'
+import { apiClient } from '@/app/helpers/apiClient'
+import { toast } from '@eth-optimism/ui-components'
+import { LONG_DURATION } from '@/app/constants/toast'
+import { captureError } from '@/app/helpers/errorReporting'
+
+const useAuth = () => {
+  const { mutateAsync: loginUser } = apiClient.auth.loginUser.useMutation()
+  const { mutateAsync: logoutUser } = apiClient.auth.logoutUser.useMutation()
+
+  const { login: privyLogin } = useLogin({
+    onComplete: async () => {
+      try {
+        await loginUser()
+      } catch (e) {
+        toast({
+          description: 'Sign in failed.',
+          duration: LONG_DURATION,
+        })
+        captureError(e, 'loginUser')
+        privyLogout()
+      }
+    },
+    onError: (privyError) => {
+      if (privyError !== 'exited_auth_flow') {
+        captureError(privyError, 'privyLogin')
+      }
+    },
+  })
+
+  const { logout: privyLogout } = useLogout({
+    onSuccess: async () => {
+      try {
+        await logoutUser()
+      } catch (e) {
+        captureError(e, 'logoutUser')
+      }
+    },
+  })
+
+  return { login: privyLogin, logout: privyLogout }
+}
+
+export { useAuth }

--- a/apps/dapp-console/app/hooks/useConnectedWallet.ts
+++ b/apps/dapp-console/app/hooks/useConnectedWallet.ts
@@ -1,0 +1,10 @@
+import { useWallets } from '@privy-io/react-auth'
+
+const useConnectedWallet = () => {
+  const { wallets } = useWallets()
+  const connectedWallet = wallets.find((w) => w.walletClientType !== 'privy') // Exclude Privy wallet
+
+  return { connectedWallet }
+}
+
+export { useConnectedWallet }


### PR DESCRIPTION
### Description
Refactored the authentication flow in `FaucetHeader` and `FaucetHeaderInner` components to decouple authentication logic from the components and use a new custom `useAuth` hook.

- Removed `usePrivy` authentication logic from `FaucetHeader` and `FaucetHeaderInner` components.
- Introduced a new `useAuth` hook to handle login and logout functionality.
- Modified the `FaucetHeaderInner` to use the new `useAuth` hook for login operations.
- Updated authentication state handling to ensure secure and efficient login/logout operations.