### PR TITLE
feat(faucet): Add failed state

### DIFF
--- a/apps/dapp-console/app/faucet/components/ClaimButton.tsx
+++ b/apps/dapp-console/app/faucet/components/ClaimButton.tsx
@@ -18,6 +18,7 @@ interface ClaimButtonProps {
   authentications: Authentications
   recipientAddress: string
   onSuccess: () => void
+  onFailed: () => void
   setBlockExplorerUrl: (url: string) => void
   children: React.ReactNode
 }
@@ -32,6 +33,7 @@ const ClaimButton = forwardRef<HTMLButtonElement, ClaimButtonProps>(
       authentications,
       recipientAddress,
       onSuccess,
+      onFailed,
       setBlockExplorerUrl,
       children,
     },
@@ -102,8 +104,6 @@ const ClaimButton = forwardRef<HTMLButtonElement, ClaimButtonProps>(
           response = await handleOffchainClaim()
         }
 
-        console.log(response)
-
         if (response && !response.error) {
           setBlockExplorerUrl(response.etherscanUrl || '')
           onSuccess()
@@ -116,6 +116,7 @@ const ClaimButton = forwardRef<HTMLButtonElement, ClaimButtonProps>(
         }
       } catch (e) {
         console.error('Claim failed', e)
+        onFailed()
       }
     }
 

--- a/apps/dapp-console/app/faucet/components/FaucetContent.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetContent.tsx
@@ -10,7 +10,7 @@ import { Confetti } from '@eth-optimism/ui-components/src/components/ui/confetti
 import { isAddress } from 'viem'
 import { useEffect, useState } from 'react'
 import { getFormattedCountdown } from '@/app/utils'
-import { Authentications, ClaimStatus } from '@/app/faucet/types'
+import { ClaimStatus } from '@/app/faucet/types'
 import {
   Dialog,
   DialogContent,

--- a/apps/dapp-console/app/faucet/components/FaucetContent.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetContent.tsx
@@ -10,6 +10,7 @@ import { Confetti } from '@eth-optimism/ui-components/src/components/ui/confetti
 import { isAddress } from 'viem'
 import { useEffect, useState } from 'react'
 import { getFormattedCountdown } from '@/app/utils'
+import { Authentications, ClaimStatus } from '@/app/faucet/types'
 import {
   Dialog,
   DialogContent,
@@ -38,9 +39,9 @@ const FaucetContent = () => {
   const [selectedNetwork, setSelectedNetwork] = useState(faucetNetworks[0])
   const [countdown, setCountdown] = useState(secondsUntilNextDrip || 0)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [isClaimSuccessful, setIsClaimSuccessful] = useState(false)
-  const [isClaimInProgress, setIsClaimInProgress] = useState(false)
   const [blockExplorerUrl, setBlockExplorerUrl] = useState('')
+
+  const [claimStatus, setClaimStatus] = useState<ClaimStatus>(null)
 
   useEffect(() => {
     if (secondsUntilNextDrip) {
@@ -83,22 +84,20 @@ const FaucetContent = () => {
     }
   }, [isDialogOpen])
 
-  // COME BACK TO THIS.
-  // Attempting to poll the nextDrips endpoint every 5 seconds while a claim is in progress to check if the claim has been processed.
+  // Poll for the transaction status once the claim has been initiated.
   useEffect(() => {
-    if (isClaimInProgress && secondsUntilNextDrip !== 0) {
-      setIsClaimSuccessful(true)
-      setIsClaimInProgress(false)
+    if (claimStatus === 'initiated' && secondsUntilNextDrip !== 0) {
+      setClaimStatus('successful')
     }
 
-    if (isClaimInProgress) {
+    if (claimStatus === 'initiated') {
       const interval = setInterval(() => {
         refetchNextDrips()
       }, 5000)
 
       return () => clearInterval(interval)
     }
-  }, [isClaimInProgress, secondsUntilNextDrip])
+  }, [claimStatus, secondsUntilNextDrip])
 
   const handleAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setAddress(e.target.value)
@@ -106,7 +105,7 @@ const FaucetContent = () => {
 
   const handleCloseDialog = () => {
     setIsDialogOpen(false)
-    setIsClaimSuccessful(false)
+    setClaimStatus(null)
   }
 
   return (
@@ -191,7 +190,10 @@ const FaucetContent = () => {
           authentications={faucetAuthentications}
           recipientAddress={address}
           onSuccess={() => {
-            setIsClaimInProgress(true)
+            setClaimStatus('initiated')
+          }}
+          onFailed={() => {
+            setClaimStatus('failed')
           }}
           setBlockExplorerUrl={setBlockExplorerUrl}
         >
@@ -202,13 +204,12 @@ const FaucetContent = () => {
             claimAmount={claimAmount}
             claimNetwork={selectedNetwork.label}
             closeDialog={handleCloseDialog}
-            isClaimSuccessful={isClaimSuccessful}
-            isClaimInProgress={isClaimInProgress}
+            claimStatus={claimStatus}
             blockExplorerUrl={blockExplorerUrl}
           />
         </DialogContent>
       </Dialog>
-      <Confetti runAnimation={isClaimSuccessful} zIndex={1000} />
+      <Confetti runAnimation={claimStatus === 'successful'} zIndex={1000} />
     </div>
   )
 }

--- a/apps/dapp-console/app/faucet/types.ts
+++ b/apps/dapp-console/app/faucet/types.ts
@@ -11,3 +11,5 @@ export type AuthMode =
   | 'GITCOIN_PASSPORT'
   | 'WORLD_ID'
   | 'PRIVY'
+
+export type ClaimStatus = 'successful' | 'initiated' | 'failed' | null


### PR DESCRIPTION
### Description
This PR introduces an `onFailed` callback for the `ClaimButton` component, improving error handling for the claiming process. Additionally, the claiming logic has been refactored to use a unified `claimStatus` state in the `FaucetContent` component, simplifying the state management and improving readability.

- Added `onFailed` callback to `ClaimButton` component.
- Refactored `FaucetContent` to use a single `claimStatus` state instead of separate boolean states.
- Updated `SuccessDialog` to handle and display different claim statuses based on the new `claimStatus` state.
- Removed unnecessary logging from `ClaimButton`.