### PR TITLE
Move the /faq route to the root of the FAQ site

### DIFF
--- a/apps/kyc-faq/src/App.tsx
+++ b/apps/kyc-faq/src/App.tsx
@@ -19,10 +19,7 @@ const router = createBrowserRouter([
   {
     path: '/',
     element: <AppRoot />,
-    children: [
-      { path: '/', element: null },
-      { path: '/faq', element: <FaqPage /> },
-    ],
+    children: [{ path: '/', element: <FaqPage /> }],
   },
 ])
 


### PR DESCRIPTION
This pull request simplifies the routing configuration for the KYC FAQ application. The nested routes under the root path have been removed, leaving only the FAQ page. This change ensures that '/' route directly leads to the FaqPage component. Previously, the root path had multiple children routes, which became redundant and unnecessary.