### PR TITLE
Adds Interop Predeploy Addresses & Abi

### DIFF
--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@eth-optimism/viem",
   "private": true,
+  "module": "",
   "version": "0.0.0",
   "main": "build/index.js",
   "types": "types/index.d.ts",

--- a/packages/viem/package.json
+++ b/packages/viem/package.json
@@ -1,25 +1,28 @@
 {
-    "name": "@eth-optimism/viem",
-    "private": true,
-    "version": "0.0.0",
-    "main": "build/index.js",
-    "types": "types/index.d.ts",
-    "scripts": {
-      "test": "vitest --passWithNoTests",
-      "clean": "rm -rf build types tsconfig.tsbuildinfo",
-      "typecheck": "tsc --noEmit --emitDeclarationOnly false",
-      "typecheck:ci": "tsc --noEmit --emitDeclarationOnly false",
-      "build": "tsup",
-      "build:types": "tsc && resolve-tspaths",
-      "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
-      "lint:ci": "eslint \"**/*.{ts,tsx}\" --quiet && pnpm prettier --check \"**/*.{ts,tsx}\"",
-      "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn"
-    },
-    "devDependencies": {
-      "resolve-tspaths": "^0.8.18",
-      "tsup": "^8.0.1",
-      "typescript": "^5.2.2",
-      "vitest": "^1.6.0"
-    }
+  "name": "@eth-optimism/viem",
+  "private": true,
+  "version": "0.0.0",
+  "main": "build/index.js",
+  "types": "types/index.d.ts",
+  "scripts": {
+    "test": "vitest --passWithNoTests",
+    "clean": "rm -rf build types tsconfig.tsbuildinfo",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck:ci": "tsc --noEmit --emitDeclarationOnly false",
+    "build": "tsup",
+    "build:types": "tsc && resolve-tspaths",
+    "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
+    "lint:ci": "eslint \"**/*.{ts,tsx}\" --quiet && pnpm prettier --check \"**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn"
+  },
+  "devDependencies": {
+    "resolve-tspaths": "^0.8.18",
+    "tsup": "^8.0.1",
+    "typescript": "^5.2.2",
+    "viem": "^2.17.9",
+    "vitest": "^1.6.0"
+  },
+  "peerDependencies": {
+    "viem": "^2.17.9"
+  }
 }
-  

--- a/packages/viem/src/abis.ts
+++ b/packages/viem/src/abis.ts
@@ -1,0 +1,854 @@
+/**
+ * ABI for the OP Stack [`L1BlockInterop` contract](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L1BlockInterop.sol).
+ */
+export const l1BlockInteropAbi = [
+  {
+    inputs: [],
+    name: 'DEPOSITOR_ACCOUNT',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'addr_',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'baseFeeScalar',
+    outputs: [
+      {
+        internalType: 'uint32',
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'basefee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'batcherHash',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'blobBaseFee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'blobBaseFeeScalar',
+    outputs: [
+      {
+        internalType: 'uint32',
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'dependencySetSize',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'gasPayingToken',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'addr_',
+        type: 'address',
+      },
+      {
+        internalType: 'uint8',
+        name: 'decimals_',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'gasPayingTokenName',
+    outputs: [
+      {
+        internalType: 'string',
+        name: 'name_',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'gasPayingTokenSymbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: 'symbol_',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'hash',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'isCustomGasToken',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_chainId',
+        type: 'uint256',
+      },
+    ],
+    name: 'isInDependencySet',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'l1FeeOverhead',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'l1FeeScalar',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'number',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'sequenceNumber',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'enum ConfigType',
+        name: '_type',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes',
+        name: '_value',
+        type: 'bytes',
+      },
+    ],
+    name: 'setConfig',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint8',
+        name: '_decimals',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_name',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_symbol',
+        type: 'bytes32',
+      },
+    ],
+    name: 'setGasPayingToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: '_number',
+        type: 'uint64',
+      },
+      {
+        internalType: 'uint64',
+        name: '_timestamp',
+        type: 'uint64',
+      },
+      {
+        internalType: 'uint256',
+        name: '_basefee',
+        type: 'uint256',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_hash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint64',
+        name: '_sequenceNumber',
+        type: 'uint64',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_batcherHash',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l1FeeOverhead',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_l1FeeScalar',
+        type: 'uint256',
+      },
+    ],
+    name: 'setL1BlockValues',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'setL1BlockValuesEcotone',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'timestamp',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'version',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+    ],
+    name: 'DependencyAdded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'chainId',
+        type: 'uint256',
+      },
+    ],
+    name: 'DependencyRemoved',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'uint8',
+        name: 'decimals',
+        type: 'uint8',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'name',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'symbol',
+        type: 'bytes32',
+      },
+    ],
+    name: 'GasPayingTokenSet',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'AlreadyDependency',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'CantRemovedDependency',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'DependencySetSizeTooLarge',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotDependency',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotDepositor',
+    type: 'error',
+  },
+] as const
+
+/**
+ * ABI for the OP Stack [`CrossL2Inbox` contract](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol).
+ */
+export const crossL2InboxABI = [
+  {
+    type: 'function',
+    name: 'blockNumber',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'chainId',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'executeMessage',
+    inputs: [
+      {
+        name: '_id',
+        type: 'tuple',
+        internalType: 'struct ICrossL2Inbox.Identifier',
+        components: [
+          {
+            name: 'origin',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'blockNumber',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'logIndex',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'timestamp',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'chainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
+      {
+        name: '_target',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_message',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'logIndex',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'origin',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'timestamp',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'version',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    name: 'ExecutingMessage',
+    inputs: [
+      {
+        name: 'encodedId',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+      {
+        name: 'message',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'error',
+    name: 'InvalidChainId',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InvalidTimestamp',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NotEntered',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'TargetCallFailed',
+    inputs: [],
+  },
+] as const
+
+/**
+ * ABI for the OP Stack [`L2ToL2CrossDomainMessenger` contract](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol).
+ */
+export const l2ToL2CrossDomainMessengerABI = [
+  {
+    type: 'function',
+    name: 'crossDomainMessageSender',
+    inputs: [],
+    outputs: [
+      {
+        name: '_sender',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'crossDomainMessageSource',
+    inputs: [],
+    outputs: [
+      {
+        name: '_source',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'messageNonce',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'messageVersion',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint16',
+        internalType: 'uint16',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'relayMessage',
+    inputs: [
+      {
+        name: '_destination',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_source',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_nonce',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_sender',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_target',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_message',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'sendMessage',
+    inputs: [
+      {
+        name: '_destination',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_target',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_message',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'successfulMessages',
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'version',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    name: 'FailedRelayedMessage',
+    inputs: [
+      {
+        name: 'messageHash',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'RelayedMessage',
+    inputs: [
+      {
+        name: 'messageHash',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'SentMessage',
+    inputs: [
+      {
+        name: 'data',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
+    anonymous: true,
+  },
+  {
+    type: 'error',
+    name: 'CrossL2InboxOriginNotL2ToL2CrossDomainMessenger',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'MessageAlreadyRelayed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'MessageDestinationNotRelayChain',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'MessageDestinationSameChain',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'MessageTargetCrossL2Inbox',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'MessageTargetL2ToL2CrossDomainMessenger',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NotEntered',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ReentrantCall',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'RelayMessageCallerNotCrossL2Inbox',
+    inputs: [],
+  },
+] as const

--- a/packages/viem/src/contracts.ts
+++ b/packages/viem/src/contracts.ts
@@ -1,0 +1,14 @@
+import { contracts as existingContracts } from 'viem/op-stack/contracts'
+
+export const contracts = {
+  ...existingContracts,
+  l1BlockInterop: {
+    address: '0x4200000000000000000000000000000000000015',
+  },
+  crossL2Inbox: {
+    address: '0x4200000000000000000000000000000000000022',
+  },
+  l2ToL2CrossDomainMessenger: {
+    address: '0x4200000000000000000000000000000000000023',
+  },
+}

--- a/packages/viem/src/contracts.ts
+++ b/packages/viem/src/contracts.ts
@@ -1,7 +1,7 @@
-import { contracts as existingContracts } from 'viem/op-stack/contracts'
+import { chainConfig } from 'viem/op-stack'
 
 export const contracts = {
-  ...existingContracts,
+  ...chainConfig.contracts,
   l1BlockInterop: {
     address: '0x4200000000000000000000000000000000000015',
   },

--- a/packages/viem/src/types/interop.ts
+++ b/packages/viem/src/types/interop.ts
@@ -1,0 +1,17 @@
+import type { Address } from 'viem'
+
+/**
+ * Spec for [`MessageIdentifier`](https://github.com/ethereum-optimism/specs/blob/main/specs/interop/messaging.md#message-identifier).
+ */
+export type MessageIdentifier = {
+  /** Account that emits the SendMessage log in L2ToL2CrossDomainMessenger. */
+  origin: Address
+  /** Block number in which the log was emitted */
+  blockNumber: bigint
+  /** The index of the log in the array of all logs emitted in the block */
+  logIndex: bigint
+  /** The timestamp that the log was emitted. Used to enforce the timestamp invariant */
+  timestamp: bigint
+  /** The chain id of the chain that emitted the log */
+  chainId: bigint
+}

--- a/packages/viem/tsconfig.json
+++ b/packages/viem/tsconfig.json
@@ -12,6 +12,8 @@
       "strict": true,
       "composite": true,
       "outDir": "types",
+      "moduleResolution": "NodeNext",
+      "module": "NodeNext",
       "emitDeclarationOnly": true
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1407,6 +1407,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.4.5
+      viem:
+        specifier: ^2.17.9
+        version: 2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.11)(jsdom@23.2.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))(terser@5.31.3)
@@ -18043,7 +18046,7 @@ snapshots:
       change-case: 4.1.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      viem: 2.9.21(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
+      viem: 2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
     optionalDependencies:
       '@wagmi/core': 2.12.2(@tanstack/query-core@5.29.0)(@types/react@18.2.79)(immer@10.0.4)(react@18.2.0)(typescript@5.4.5)(viem@2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))
       wagmi: 2.11.3(@react-native-async-storage/async-storage@1.23.1(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3)))(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.79)(bufferutil@4.0.8)(encoding@0.1.13)(esbuild@0.19.12)(immer@10.0.4)(ioredis@5.4.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3))(react@18.2.0)(rollup@4.14.3)(typescript@5.4.5)(utf-8-validate@6.0.3)(viem@2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))(zod@3.22.4)
@@ -18060,7 +18063,7 @@ snapshots:
       change-case: 4.1.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      viem: 2.9.21(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
+      viem: 2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
     optionalDependencies:
       '@wagmi/core': 2.12.2(@tanstack/query-core@5.29.0)(@types/react@18.2.79)(immer@10.0.4)(react@18.2.0)(typescript@5.4.5)(viem@2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))
       wagmi: 2.11.3(@react-native-async-storage/async-storage@1.23.1(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3)))(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.79)(bufferutil@4.0.8)(encoding@0.1.13)(immer@10.0.4)(ioredis@5.4.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3))(react@18.2.0)(rollup@4.14.3)(typescript@5.4.5)(utf-8-validate@6.0.3)(viem@2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))(zod@3.22.4)
@@ -18077,7 +18080,7 @@ snapshots:
       change-case: 4.1.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      viem: 2.9.21(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
+      viem: 2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4)
     optionalDependencies:
       '@wagmi/core': 2.12.2(@tanstack/query-core@5.29.0)(@types/react@18.3.1)(immer@10.0.4)(react@18.2.0)(typescript@5.4.5)(viem@2.9.21(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))
       wagmi: 2.11.3(@react-native-async-storage/async-storage@1.23.1(react-native@0.73.6(@babel/core@7.24.9)(@babel/preset-env@7.24.4(@babel/core@7.24.9))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3)))(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(esbuild@0.19.12)(immer@10.0.4)(ioredis@5.4.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.24.9)(@babel/preset-env@7.24.4(@babel/core@7.24.9))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3))(react@18.2.0)(rollup@4.14.3)(typescript@5.4.5)(utf-8-validate@6.0.3)(viem@2.9.21(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))(zod@3.22.4)
@@ -21610,7 +21613,7 @@ snapshots:
   '@scure/bip32@1.3.2':
     dependencies:
       '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.6
 
   '@scure/bip32@1.3.3':
@@ -21621,9 +21624,9 @@ snapshots:
 
   '@scure/bip32@1.4.0':
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
+      '@scure/base': 1.1.7
 
   '@scure/bip39@1.1.1':
     dependencies:
@@ -21632,7 +21635,7 @@ snapshots:
 
   '@scure/bip39@1.2.1':
     dependencies:
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.6
 
   '@scure/bip39@1.2.2':
@@ -21643,7 +21646,7 @@ snapshots:
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
+      '@scure/base': 1.1.7
 
   '@sentry-internal/feedback@7.110.1':
     dependencies:


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Directory structure is matching the exact same structure as `viem` so there is less work with upstreaming. Module resolution was also updated to match `viem` so it's easier to upstream

* Adds `viem` as a peer dep and dev dep to `@eth-optimism/viem`
* Adds interop predeploys
* Adds `MessageIdentifier` type