### PR TITLE
feat(faucet): pad max priority fee on faucet drip tx

### DIFF
--- a/apps/dapp-console-api/src/utils/Faucet.ts
+++ b/apps/dapp-console-api/src/utils/Faucet.ts
@@ -163,8 +163,13 @@ export class Faucet {
       userId,
       domain,
     )
+    const { maxPriorityFeePerGas } =
+      await this.publicClient.estimateFeesPerGas()
     return this._faucetContract.write.drip([dripParams, authParams], {
       gas: BigInt(DRIP_MIN_GAS_LIMIT),
+      maxPriorityFeePerGas:
+        maxPriorityFeePerGas &&
+        (maxPriorityFeePerGas * BigInt(150)) / BigInt(100),
     })
   }
 


### PR DESCRIPTION
Drip transactions from the console have been getting stuck. This pads the `maxPriorityFee` on the drip transaction in order to see if this causes transactions to not get stuck.