### PR TITLE
feat(dapp-console-api): use gelato transaction sender for faucet drip

### DIFF
--- a/apps/dapp-console-api/src/Service.ts
+++ b/apps/dapp-console-api/src/Service.ts
@@ -23,6 +23,8 @@ import { optimism, optimismSepolia } from 'viem/chains'
 
 import type { ApiQueue } from '@/api-queue/apiQueueConfig'
 import { createApiQueue } from '@/api-queue/createApiQueue'
+import { createGelatoTransactionSender } from '@/transaction-sender/gelato/createGelatoTransactionSender'
+import { GelatoRelay } from '@/transaction-sender/gelato/GelatoRelay'
 
 import { ApiV0, Middleware } from './api'
 import { AdminApi } from './api/AdminApi'
@@ -161,6 +163,10 @@ export class Service {
       ),
     })
 
+    const sepoliaGelatoTransactionSender = createGelatoTransactionSender(
+      new GelatoRelay(envVars.GELATO_RELAY_API_KEY),
+    )
+
     const authRoute = new AuthRoute(trpc)
     const walletsRoute = new WalletsRoute(trpc)
     const appsRoute = new AppsRoute(trpc)
@@ -174,7 +180,7 @@ export class Service {
     )
     const faucetRoute = new FaucetRoute(
       trpc,
-      getSupportedFaucets(gatewayRedisCache),
+      getSupportedFaucets(gatewayRedisCache, sepoliaGelatoTransactionSender),
     )
 
     /**

--- a/apps/dapp-console-api/src/constants/envVars.ts
+++ b/apps/dapp-console-api/src/constants/envVars.ts
@@ -89,6 +89,7 @@ const envVarSchema = z.object({
   WORLDID_APP_ID: z.string(),
   WORLDID_APP_ACTION_NAME: z.string(),
   API_QUEUE_REDIS_URL: z.string(),
+  GELATO_RELAY_API_KEY: z.string(),
 })
 
 const isTest = process.env.NODE_ENV === 'test'
@@ -167,6 +168,7 @@ export const envVars = envVarSchema.parse(
         WORLDID_APP_ID: 'test worldid app id',
         WORLDID_APP_ACTION_NAME: 'test worldid app action name',
         API_QUEUE_REDIS_URL: 'redis://localhost:6379',
+        GELATO_RELAY_API_KEY: 'MOCK_GELATO_RELAY_API_KEY',
       }
     : {
         PORT: process.env.PORT
@@ -255,5 +257,6 @@ export const envVars = envVarSchema.parse(
         WORLDID_APP_ID: process.env.WORLDID_APP_ID,
         WORLDID_APP_ACTION_NAME: process.env.WORLDID_APP_ACTION_NAME,
         API_QUEUE_REDIS_URL: process.env.API_QUEUE_REDIS_URL,
+        GELATO_RELAY_API_KEY: process.env.GELATO_RELAY_API_KEY,
       },
 )

--- a/apps/dapp-console-api/src/constants/faucetConfigs.ts
+++ b/apps/dapp-console-api/src/constants/faucetConfigs.ts
@@ -161,10 +161,12 @@ export const sepoliaPublicClient = createPublicClient({
   transport: fallback(envVars.JSON_RPC_URLS_L1_SEPOLIA.map((url) => http(url))),
 })
 
+export const adminWalletAccount = privateKeyToAccount(
+  envVars.FAUCET_AUTH_ADMIN_WALLET_PRIVATE_KEY as Hex,
+)
+
 export const sepoliaAdminWalletClient = createWalletClient({
-  account: privateKeyToAccount(
-    envVars.FAUCET_AUTH_ADMIN_WALLET_PRIVATE_KEY as Hex,
-  ),
+  account: adminWalletAccount,
   chain: getSepoliaConfig().chain,
   transport: fallback(envVars.JSON_RPC_URLS_L1_SEPOLIA.map((url) => http(url))),
 })

--- a/apps/dapp-console-api/src/routes/faucet/FaucetRoute.ts
+++ b/apps/dapp-console-api/src/routes/faucet/FaucetRoute.ts
@@ -248,8 +248,6 @@ export class FaucetRoute extends Route {
           })
       }
 
-      console.log('got here')
-
       const faucet = this.faucets.find((f) => f.chainId === chainId)
 
       if (!faucet) {

--- a/apps/dapp-console-api/src/testUtils/anvil.ts
+++ b/apps/dapp-console-api/src/testUtils/anvil.ts
@@ -1,5 +1,5 @@
 import { startProxy } from '@viem/anvil'
-import type { Address, Chain, Hash, Hex } from 'viem'
+import type { Address, Chain, Hex } from 'viem'
 import {
   createPublicClient,
   createTestClient,
@@ -21,7 +21,7 @@ export type startAnvilL2InstanceArgs = {
 }
 
 // all accounts have a starting balance of 10000 ETH
-export const anvilAccounts = [
+export const anvilAccountAddresses = [
   '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
   '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
@@ -32,7 +32,7 @@ export const anvilAccounts = [
   '0x14dC79964da2C08b23698B3D3cc7Ca32193d9955',
   '0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f',
   '0xa0Ee7A142d267C1f36714E4a8F75612F20a79720',
-] as readonly Address[]
+] as const satisfies Address[]
 
 export const anvilAccountPrivateKeys = [
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
@@ -45,7 +45,9 @@ export const anvilAccountPrivateKeys = [
   '0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356',
   '0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97',
   '0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6',
-] as Hash[]
+] as const satisfies Hex[]
+
+export const anvilAccounts = anvilAccountPrivateKeys.map(privateKeyToAccount)
 
 export async function startAnvilL2Instance() {
   return await startProxy({
@@ -57,16 +59,11 @@ export async function startAnvilL2Instance() {
   })
 }
 
-export function anvilAccount(index?: number) {
-  const idx = index ?? 0
-  return privateKeyToAccount(anvilAccountPrivateKeys[idx])
-}
-
-export function createL2WalletClient(accountIndex?: number) {
+export function createL2WalletClient(accountIndex: number = 0) {
   return createWalletClient({
     chain: l2,
     pollingInterval: 0,
-    account: anvilAccount(accountIndex),
+    account: anvilAccounts[accountIndex],
     transport: http(),
   })
 }

--- a/apps/dapp-console-api/src/transaction-sender/TransactionSender.ts
+++ b/apps/dapp-console-api/src/transaction-sender/TransactionSender.ts
@@ -1,0 +1,32 @@
+import type { Address, Hex } from 'viem'
+
+export type TransactionSenderTrackerId = string
+
+export type TransactionSenderTxParams = {
+  chainId: number
+  to: Address
+  data: Hex
+}
+
+export type TransactionSenderTxStatus =
+  | {
+      status: 'pending'
+    }
+  | {
+      status: 'sent'
+      hash: Hex
+    }
+  | {
+      status: 'error'
+      error: string
+    }
+
+export type TransactionSender = {
+  sendTransaction: (params: TransactionSenderTxParams) => Promise<{
+    trackerId: TransactionSenderTrackerId
+    txStatus: TransactionSenderTxStatus
+  }>
+  getTransactionSendStatus: (
+    trackerId: TransactionSenderTrackerId,
+  ) => Promise<TransactionSenderTxStatus>
+}

--- a/apps/dapp-console-api/src/transaction-sender/gelato/GelatoRelay.ts
+++ b/apps/dapp-console-api/src/transaction-sender/gelato/GelatoRelay.ts
@@ -1,0 +1,127 @@
+import type { Address, Hex } from 'viem'
+import { z } from 'zod'
+
+export class GelatoRelay {
+  constructor(private readonly apiKey: string) {}
+
+  async sendSponsoredCall({
+    chainId,
+    to,
+    data,
+  }: {
+    chainId: number
+    to: Address
+    data: Hex
+  }) {
+    return gelatoRelayPostSponsoredCall({
+      apiKey: this.apiKey,
+      chainId,
+      to,
+      data,
+    })
+  }
+
+  async getTaskStatus({ taskId }: { taskId: string }) {
+    return gelatoRelayGetTaskStatus({ taskId })
+  }
+}
+
+// Example response
+// {
+//   "taskId": "text"
+// }
+
+const gelatoRelayPostSponsoredCallApiResponseSchema = z.object({
+  taskId: z.string(),
+})
+
+const gelatoRelayPostSponsoredCall = async ({
+  apiKey,
+  chainId,
+  to,
+  data,
+}: {
+  apiKey: string
+  chainId: number
+  to: Address
+  data: Hex
+}) => {
+  const response = await fetch('/relays/v2/sponsored-call', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      chainId: chainId,
+      target: to,
+      data: data,
+      sponsorApiKey: apiKey,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to send sponsored call: ${response.statusText}`)
+  }
+
+  const json = await response.json()
+
+  const result = gelatoRelayPostSponsoredCallApiResponseSchema.safeParse(json)
+
+  if (!result.success) {
+    throw new Error(`Invalid response from gelato relay: ${data}`, result.error)
+  }
+
+  return result.data
+}
+
+// Example response:
+// {
+//   "task": {
+//     "chainId": 0,
+//     "taskId": "text",
+//     "taskState": "CheckPending",
+//     "creationDate": "text",
+//     "lastCheckDate": "text",
+//     "lastCheckMessage": "text",
+//     "transactionHash": "text",
+//     "executionDate": "text",
+//     "blockNumber": 0
+//   }
+// }
+
+const gelatoRelayGetTaskStatusApiResponseSchema = z.object({
+  task: z.object({
+    chainId: z.number(),
+    taskId: z.string(),
+    taskState: z.enum([
+      'CheckPending',
+      'ExecPending',
+      'ExecSuccess',
+      'ExecReverted',
+      'WaitingForConfirmation',
+      'Blacklisted',
+      'Cancelled',
+    ]),
+    creationDate: z.coerce.date(),
+    lastCheckDate: z.coerce.date().optional(),
+    lastCheckMessage: z.string().nullable().optional(),
+    transactionHash: z.string().nullable().optional(),
+    executionDate: z.coerce.date().nullable().optional(),
+    blockNumber: z.number().nullable().optional(),
+  }),
+})
+const gelatoRelayGetTaskStatus = async ({ taskId }: { taskId: string }) => {
+  const response = await fetch(`/tasks/status/${taskId}`, {
+    method: 'GET',
+    headers: {},
+  })
+  const data = await response.json()
+
+  const result = gelatoRelayGetTaskStatusApiResponseSchema.safeParse(data)
+
+  if (!result.success) {
+    throw new Error(`Invalid response from gelato relay: ${data}`, result.error)
+  }
+
+  return result.data
+}

--- a/apps/dapp-console-api/src/transaction-sender/gelato/createGelatoTransactionSender.ts
+++ b/apps/dapp-console-api/src/transaction-sender/gelato/createGelatoTransactionSender.ts
@@ -1,0 +1,75 @@
+import { sepolia } from 'viem/chains'
+import { z } from 'zod'
+
+import type { GelatoRelay } from '@/transaction-sender/gelato/GelatoRelay'
+import type {
+  TransactionSender,
+  TransactionSenderTrackerId,
+  TransactionSenderTxParams,
+} from '@/transaction-sender/TransactionSender'
+
+const DOMAIN = 'GELATO_RELAY_SPONSOR_CALL'
+
+const getTrackerId = (taskId: string) => {
+  return [DOMAIN, taskId].join(':')
+}
+
+const trackerIdSchema = z
+  .string()
+  .transform((val) => {
+    const [domain, taskId] = val.split(':')
+    return {
+      domain,
+      taskId,
+    }
+  })
+  .pipe(
+    z.object({
+      domain: z.literal(DOMAIN),
+      taskId: z.string(),
+    }),
+  )
+
+export const createGelatoTransactionSender = (
+  gelatoRelay: GelatoRelay,
+): TransactionSender => {
+  return {
+    sendTransaction: async (txParams: TransactionSenderTxParams) => {
+      if (txParams.chainId !== sepolia.id) {
+        throw new Error('Invalid chainId')
+      }
+
+      const result = await gelatoRelay.sendSponsoredCall(txParams)
+
+      return {
+        trackerId: getTrackerId(result.taskId),
+        txStatus: {
+          status: 'pending',
+        },
+      }
+    },
+    getTransactionSendStatus: async (trackerId: TransactionSenderTrackerId) => {
+      const parseResult = trackerIdSchema.safeParse(trackerId)
+      if (!parseResult.success) {
+        throw new Error('Invalid trackerId')
+      }
+
+      const taskId = parseResult.data.taskId
+
+      const result = await gelatoRelay.getTaskStatus({ taskId })
+
+      const task = result.task
+
+      if (!task.transactionHash) {
+        return {
+          status: 'pending',
+        }
+      }
+
+      return {
+        status: 'pending',
+        hash: task.transactionHash,
+      }
+    },
+  }
+}

--- a/apps/dapp-console-api/src/transaction-sender/wallet/createWalletTransactionSender.ts
+++ b/apps/dapp-console-api/src/transaction-sender/wallet/createWalletTransactionSender.ts
@@ -1,0 +1,67 @@
+import type { Account, Chain, Hex, Transport, WalletClient } from 'viem'
+import { z } from 'zod'
+
+import type {
+  TransactionSender,
+  TransactionSenderTrackerId,
+  TransactionSenderTxParams,
+} from '@/transaction-sender/TransactionSender'
+import { hexSchema } from '@/utils/hexSchema'
+
+const DOMAIN = 'WALLET_TX'
+
+const getTrackerId = (txHash: Hex) => {
+  return [DOMAIN, txHash].join(':')
+}
+
+const trackerIdSchema = z
+  .string()
+  .transform((val) => {
+    const [domain, txHash] = val.split(':')
+    return {
+      domain,
+      txHash,
+    }
+  })
+  .pipe(
+    z.object({
+      domain: z.literal(DOMAIN),
+      txHash: hexSchema,
+    }),
+  )
+
+export const createWalletTransactionSender = (
+  adminWalletClient: WalletClient<Transport, Chain, Account>,
+): TransactionSender => {
+  return {
+    sendTransaction: async (txParams: TransactionSenderTxParams) => {
+      if (txParams.chainId !== adminWalletClient.chain.id) {
+        throw new Error('Invalid chainId')
+      }
+
+      const hash = await adminWalletClient.sendTransaction({
+        to: txParams.to,
+        data: txParams.data,
+        value: 0n,
+      })
+
+      return {
+        trackerId: getTrackerId(hash),
+        txStatus: {
+          status: 'sent',
+          hash,
+        },
+      }
+    },
+    getTransactionSendStatus: async (trackerId: TransactionSenderTrackerId) => {
+      const parseResult = trackerIdSchema.safeParse(trackerId)
+      if (!parseResult.success) {
+        throw new Error('Invalid trackerId')
+      }
+      return {
+        status: 'sent',
+        hash: parseResult.data.txHash,
+      }
+    },
+  }
+}

--- a/apps/dapp-console-api/src/utils/getRandomNonceHex.ts
+++ b/apps/dapp-console-api/src/utils/getRandomNonceHex.ts
@@ -1,0 +1,6 @@
+import crypto from 'crypto'
+import { bytesToHex } from 'viem'
+
+export const getRandomNonceHex = () => {
+  return bytesToHex(new Uint8Array(crypto.randomBytes(32).buffer))
+}

--- a/apps/dapp-console-api/src/utils/getSupportedFaucets.ts
+++ b/apps/dapp-console-api/src/utils/getSupportedFaucets.ts
@@ -1,8 +1,10 @@
 import { sepolia } from 'viem/chains'
 
+import type { TransactionSender } from '@/transaction-sender/TransactionSender'
+
 import {
+  adminWalletAccount,
   ONCE_UPON_BASE_URL,
-  sepoliaAdminWalletClient,
   sepoliaPublicClient,
   supportedFaucetConfigs,
 } from '../constants'
@@ -10,7 +12,10 @@ import { envVars } from '../constants/envVars'
 import { Faucet } from '../utils'
 import type { RedisCache } from './redis'
 
-export const getSupportedFaucets = (redisCache: RedisCache) =>
+export const getSupportedFaucets = (
+  redisCache: RedisCache,
+  transactionSender: TransactionSender,
+) =>
   supportedFaucetConfigs.map(
     ({
       chain,
@@ -33,7 +38,8 @@ export const getSupportedFaucets = (redisCache: RedisCache) =>
         l1BridgeAddress,
         isL1Faucet,
         publicClient: sepoliaPublicClient,
-        adminWalletClient: sepoliaAdminWalletClient,
+        adminAccount: adminWalletAccount,
+        transactionSender,
         l1ChainId: sepolia.id,
       })
     },

--- a/apps/dapp-console-api/src/utils/hexSchema.ts
+++ b/apps/dapp-console-api/src/utils/hexSchema.ts
@@ -1,0 +1,8 @@
+import type { Hex } from 'viem'
+import { isHex } from 'viem'
+import { z } from 'zod'
+
+export const hexSchema = z.custom<Hex>(
+  (val) => typeof val === 'string' && isHex(val),
+  'invalid hex string',
+)


### PR DESCRIPTION
- creates TransactionSender interface 
- create a gelato relay based tx sender
- use pseudorandom nonce rather than one based on account nonce
- TODO: update faucet route

Notes on faucet route API:
- this will cause a breaking change for the FaucetRoute API, since the async nature of TransactionSender means the endpoint will not be be able to synchronously return a tx hash
- instead of a breaking change, we should
    1. return an empty tx hash for the existing route `/offchainClaims` `/onChainClaims`, and etherscanUrl can just be to the etherscan website. Alternatively, we can use the createWalletTransactionSender so we can immediately return hash temporarily.
    2. create new routes `/triggerOffchainClaim` `/getOffchainClaimStatus`, `/triggerOnChainClaim` `/getOnChainClaimStatus`
    3. update front end to use new routes
    4. a week later, deprecate `/offchainClaims` `/onChainClaims` - the only consumer of the API is the web app so it shouldn't be too problematic 