### PR TITLE
Adds walletL2 & publicL2 decorators

### DIFF
--- a/packages/viem/src/actions/buildExecuteL2ToL2Message.spec.ts
+++ b/packages/viem/src/actions/buildExecuteL2ToL2Message.spec.ts
@@ -2,7 +2,6 @@ import { encodeFunctionData } from 'viem'
 import { base, optimism } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
-import { buildExecuteL2ToL2Message } from '@/actions/buildExecuteL2ToL2Message.js'
 import { publicClient, testAccount } from '@/test/clients.js'
 import { ticTacToeABI, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 import type { MessageIdentifier } from '@/types/interop.js'
@@ -24,7 +23,7 @@ describe('buildExecuteL2ToL2Message', () => {
   })
 
   it('should return expected request', async () => {
-    const res = await buildExecuteL2ToL2Message(publicClient, {
+    const res = await publicClient.buildExecuteL2ToL2Message({
       id: expectedId,
       target: expectedTarget,
       message: expectedMessage,

--- a/packages/viem/src/actions/buildSendL2ToL2Message.spec.ts
+++ b/packages/viem/src/actions/buildSendL2ToL2Message.spec.ts
@@ -2,7 +2,6 @@ import { encodeFunctionData } from 'viem'
 import { base, optimism } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
-import { buildSendL2ToL2Message } from '@/actions/buildSendL2ToL2Message.js'
 import { publicClient, testAccount } from '@/test/clients.js'
 import { ticTacToeABI, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 
@@ -16,7 +15,7 @@ describe('buildSendL2ToL2Message', () => {
   })
 
   it('should return expected request', async () => {
-    const res = await buildSendL2ToL2Message(publicClient, {
+    const res = await publicClient.buildSendL2ToL2Message({
       destinationChainId: expectedChainId,
       target: expectedTarget,
       message: expectedMessage,

--- a/packages/viem/src/actions/estimateExecuteL2ToL2MessageGas.spec.ts
+++ b/packages/viem/src/actions/estimateExecuteL2ToL2MessageGas.spec.ts
@@ -2,7 +2,6 @@ import { encodeFunctionData } from 'viem'
 import { base } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
-import { estimateExecuteL2ToL2MessageGas } from '@/actions/estimateExecuteL2ToL2MessageGas.js'
 import { publicClient, testAccount, walletClient } from '@/test/clients.js'
 import { ticTacToeABI, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 import type { MessageIdentifier } from '@/types/interop.js'
@@ -23,7 +22,7 @@ describe('estimateExecuteL2ToL2Message', () => {
       args: [testAccount.address],
     })
 
-    const gas = await estimateExecuteL2ToL2MessageGas(publicClient, {
+    const gas = await publicClient.estimateExecuteL2ToL2MessageGas({
       account: testAccount.address,
       id: expectedId,
       target: ticTacToeAddress,

--- a/packages/viem/src/actions/estimateSendL2ToL2MessageGas.spec.ts
+++ b/packages/viem/src/actions/estimateSendL2ToL2MessageGas.spec.ts
@@ -2,7 +2,6 @@ import { encodeFunctionData } from 'viem'
 import { base } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
-import { estimateSendL2ToL2MessageGas } from '@/actions/estimateSendL2ToL2MessageGas.js'
 import { publicClient, testAccount } from '@/test/clients.js'
 import { ticTacToeABI, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 
@@ -14,7 +13,7 @@ describe('estimateSendL2ToL2Message', () => {
       args: [testAccount.address],
     })
 
-    const gas = await estimateSendL2ToL2MessageGas(publicClient, {
+    const gas = await publicClient.estimateSendL2ToL2MessageGas({
       account: testAccount.address,
       target: ticTacToeAddress,
       destinationChainId: base.id,

--- a/packages/viem/src/actions/executeL2ToL2Message.spec.ts
+++ b/packages/viem/src/actions/executeL2ToL2Message.spec.ts
@@ -3,8 +3,6 @@ import { base } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
 import { crossL2InboxABI } from '@/abis.js'
-import { buildExecuteL2ToL2Message } from '@/actions/buildExecuteL2ToL2Message.js'
-import { executeL2ToL2Message } from '@/actions/executeL2ToL2Message.js'
 import { publicClient, testAccount, walletClient } from '@/test/clients.js'
 import { ticTacToeABI, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 import type { MessageIdentifier } from '@/types/interop.js'
@@ -19,7 +17,7 @@ describe('executeL2ToL2Message', () => {
       chainId: BigInt(base.id),
     } as MessageIdentifier
 
-    const args = await buildExecuteL2ToL2Message(publicClient, {
+    const args = await publicClient.buildExecuteL2ToL2Message({
       id: expectedId,
       account: testAccount.address,
       target: ticTacToeAddress,
@@ -30,7 +28,7 @@ describe('executeL2ToL2Message', () => {
       }),
     })
 
-    const hash = await executeL2ToL2Message(walletClient, args)
+    const hash = await walletClient.executeL2ToL2Message(args)
 
     expect(hash).toBeDefined()
 

--- a/packages/viem/src/actions/sendL2ToL2Message.spec.ts
+++ b/packages/viem/src/actions/sendL2ToL2Message.spec.ts
@@ -3,7 +3,6 @@ import { base, optimism } from 'viem/chains'
 import { describe, expect, it } from 'vitest'
 
 import { buildSendL2ToL2Message } from '@/actions/buildSendL2ToL2Message.js'
-import { sendL2ToL2Message } from '@/actions/sendL2ToL2Message.js'
 import { publicClient, testAccount, walletClient } from '@/test/clients.js'
 import { ticTacToeABI, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 import { extractMessageIdentifierFromLogs } from '@/utils/extractMessageIdentifierFromLogs.js'
@@ -21,7 +20,7 @@ describe('sendL2ToL2Message', () => {
       }),
     })
 
-    const hash = await sendL2ToL2Message(walletClient, args)
+    const hash = await walletClient.sendL2ToL2Message(args)
     expect(hash).toBeDefined()
 
     const receipt = await publicClient.waitForTransactionReceipt({ hash })

--- a/packages/viem/src/decorators/publicL2.ts
+++ b/packages/viem/src/decorators/publicL2.ts
@@ -1,0 +1,91 @@
+import type { Account, Address, Chain, Client, Transport } from 'viem'
+import type { PublicActionsL2 as UpstreamPublicActionsL2 } from 'viem/op-stack'
+import { publicActionsL2 as upstreamPublicActionsL2 } from 'viem/op-stack'
+
+import type {
+  BuildExecuteL2ToL2MessageParameters,
+  BuildExecuteL2ToL2MessageReturnType,
+} from '@/actions/buildExecuteL2ToL2Message.js'
+import { buildExecuteL2ToL2Message } from '@/actions/buildExecuteL2ToL2Message.js'
+import type {
+  BuildSendL2ToL2MessageParameters,
+  BuildSendL2ToL2MessageReturnType,
+} from '@/actions/buildSendL2ToL2Message.js'
+import { buildSendL2ToL2Message } from '@/actions/buildSendL2ToL2Message.js'
+import type {
+  EstimateExecuteL2ToL2MessageGasParameters,
+  EstimateExecuteL2ToL2MessageGasReturnType,
+} from '@/actions/estimateExecuteL2ToL2MessageGas.js'
+import { estimateExecuteL2ToL2MessageGas } from '@/actions/estimateExecuteL2ToL2MessageGas.js'
+import type {
+  EstimateSendL2ToL2MessageGasParameters,
+  EstimateSendL2ToL2MessageGasReturnType,
+} from '@/actions/estimateSendL2ToL2MessageGas.js'
+import { estimateSendL2ToL2MessageGas } from '@/actions/estimateSendL2ToL2MessageGas.js'
+
+export type PublicActionsL2<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+> = UpstreamPublicActionsL2 & {
+  buildSendL2ToL2Message: <
+    chainOverride extends Chain | undefined = undefined,
+    accountOverride extends Account | Address | undefined = undefined,
+  >(
+    parameters: BuildSendL2ToL2MessageParameters<
+      chain,
+      account,
+      chainOverride,
+      accountOverride
+    >,
+  ) => Promise<BuildSendL2ToL2MessageReturnType>
+  buildExecuteL2ToL2Message: <
+    chainOverride extends Chain | undefined = undefined,
+    accountOverride extends Account | Address | undefined = undefined,
+  >(
+    parameters: BuildExecuteL2ToL2MessageParameters<
+      chain,
+      account,
+      chainOverride,
+      accountOverride
+    >,
+  ) => Promise<BuildExecuteL2ToL2MessageReturnType>
+  estimateSendL2ToL2MessageGas: <
+    chainOverride extends Chain | undefined = undefined,
+  >(
+    parameters: EstimateSendL2ToL2MessageGasParameters<
+      chain,
+      account,
+      chainOverride
+    >,
+  ) => Promise<EstimateSendL2ToL2MessageGasReturnType>
+  estimateExecuteL2ToL2MessageGas: <
+    chainOverride extends Chain | undefined = undefined,
+  >(
+    parameters: EstimateExecuteL2ToL2MessageGasParameters<
+      chain,
+      account,
+      chainOverride
+    >,
+  ) => Promise<EstimateExecuteL2ToL2MessageGasReturnType>
+}
+
+export function publicActionsL2() {
+  return <
+    transport extends Transport,
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  >(
+    client: Client<transport, chain, account>,
+  ): PublicActionsL2<chain, account> => {
+    return {
+      ...upstreamPublicActionsL2(),
+      buildSendL2ToL2Message: (args) => buildSendL2ToL2Message(client, args),
+      buildExecuteL2ToL2Message: (args) =>
+        buildExecuteL2ToL2Message(client, args),
+      estimateSendL2ToL2MessageGas: (args) =>
+        estimateSendL2ToL2MessageGas(client, args),
+      estimateExecuteL2ToL2MessageGas: (args) =>
+        estimateExecuteL2ToL2MessageGas(client, args),
+    } as PublicActionsL2<chain, account>
+  }
+}

--- a/packages/viem/src/decorators/walletL2.ts
+++ b/packages/viem/src/decorators/walletL2.ts
@@ -1,0 +1,42 @@
+import type { Account, Chain, Client, Transport } from 'viem'
+import type { WalletActionsL2 as UpstreamWalletActionsL2 } from 'viem/op-stack'
+import { walletActionsL2 as upstreamWalletActionsL2 } from 'viem/op-stack'
+
+import type {
+  ExecuteL2ToL2MessageParameters,
+  ExecuteL2ToL2MessageReturnType,
+} from '@/actions/executeL2ToL2Message.js'
+import { executeL2ToL2Message } from '@/actions/executeL2ToL2Message.js'
+import type {
+  SendL2ToL2MessageParameters,
+  SendL2ToL2MessageReturnType,
+} from '@/actions/sendL2ToL2Message.js'
+import { sendL2ToL2Message } from '@/actions/sendL2ToL2Message.js'
+
+export type WalletActionsL2<
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+> = UpstreamWalletActionsL2<chain, account> & {
+  sendL2ToL2Message: <chainOverride extends Chain | undefined = undefined>(
+    parameters: SendL2ToL2MessageParameters<chain, account, chainOverride>,
+  ) => Promise<SendL2ToL2MessageReturnType>
+  executeL2ToL2Message: <chainOverride extends Chain | undefined = undefined>(
+    parameters: ExecuteL2ToL2MessageParameters<chain, account, chainOverride>,
+  ) => Promise<ExecuteL2ToL2MessageReturnType>
+}
+
+export function walletActionsL2() {
+  return <
+    transport extends Transport,
+    chain extends Chain | undefined = Chain | undefined,
+    account extends Account | undefined = Account | undefined,
+  >(
+    client: Client<transport, chain, account>,
+  ): WalletActionsL2<chain, account> => {
+    return {
+      ...upstreamWalletActionsL2(),
+      sendL2ToL2Message: (args) => sendL2ToL2Message(client, args),
+      executeL2ToL2Message: (args) => executeL2ToL2Message(client, args),
+    } as WalletActionsL2<chain, account>
+  }
+}

--- a/packages/viem/src/test/clients.ts
+++ b/packages/viem/src/test/clients.ts
@@ -7,6 +7,9 @@ import {
 import { privateKeyToAccount } from 'viem/accounts'
 import { optimism } from 'viem/chains'
 
+import { publicActionsL2 } from '@/decorators/publicL2.js'
+import { walletActionsL2 } from '@/decorators/walletL2.js'
+
 const RPC_URL = `http://localhost:8545/${Number(process.env.VITEST_vitestPool_ID ?? 1)}`
 
 // anvil account: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
@@ -17,13 +20,13 @@ export const testAccount = privateKeyToAccount(
 export const publicClient = createPublicClient({
   chain: optimism,
   transport: http(RPC_URL),
-})
+}).extend(publicActionsL2())
 
 export const walletClient = createWalletClient({
   account: testAccount,
   chain: optimism,
   transport: http(RPC_URL),
-})
+}).extend(walletActionsL2())
 
 export const testClient = createTestClient({
   chain: optimism,


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds `walletL2` & `publicL2` decorators that allow end users to extend public & wallet clients
* Update tests to use decorators

```
import { publicActionsL2, walletActionsL2 } from '@eth-optimism/viem'

export const publicClient = createPublicClient({
  chain: optimism,
  transport: http(RPC_URL),
}).extend(publicActionsL2())

export const walletClient = createWalletClient({
  account,
  chain: optimism,
  transport: http(RPC_URL),
}).extend(walletActionsL2())

# example
const args = publicClient.buildSendL2ToL2Message({ ... }) 
await walletClient.sendL2ToL2Message(args)
```

Tracker: https://github.com/ethereum-optimism/ecosystem/issues/416