### PR TITLE
Add supersim support to bridge app

### DIFF
--- a/apps/bridge-app/package.json
+++ b/apps/bridge-app/package.json
@@ -17,6 +17,8 @@
     "@eth-optimism/op-app": "workspace:*",
     "@eth-optimism/tokenlist": "^9.0.12",
     "@eth-optimism/ui-components": "workspace:*",
+    "@eth-optimism/viem": "workspace:*",
+    "@eth-optimism/wagmi": "workspace:*",
     "@rainbow-me/rainbowkit": "2.1.3",
     "@remixicon/react": "^4.1.1",
     "@tanstack/react-query": "^5.29.2",

--- a/apps/bridge-app/src/App.tsx
+++ b/apps/bridge-app/src/App.tsx
@@ -20,8 +20,8 @@ import { NETWORK_TYPE } from '@/constants/networkType'
 import { TicTacToe } from '@/routes/TicTacToe'
 import { Home } from '@/routes/Home'
 import { Playground } from '@/routes/Playground'
-import { foundry } from 'viem/chains'
 import { Toaster } from '@eth-optimism/ui-components'
+import { supersimL1, supersimL2A, supersimL2B } from '@eth-optimism/viem'
 
 const classNames = {
   app: 'app w-full min-h-screen flex flex-col',
@@ -38,8 +38,10 @@ const opChains = configureOpChains({ type: NETWORK_TYPE }) as [
   ...[Chain],
 ]
 
-if (import.meta.env.VITE_DEPLOYMENT_ENV === 'local') {
-  opChains.push(foundry)
+if (import.meta.env.VITE_SUPERSIM_ENABLED === 'true') {
+  opChains.push(supersimL1)
+  opChains.push(supersimL2A)
+  opChains.push(supersimL2B)
 }
 
 const wagmiConfig = getDefaultConfig({

--- a/apps/bridge-app/src/components/NetworkSelector.tsx
+++ b/apps/bridge-app/src/components/NetworkSelector.tsx
@@ -30,7 +30,6 @@ const NetworkSelectorItem = ({
   logo,
   onSelect,
 }: NetworkSelectorItemProps) => {
-  console.log(chain)
   return (
     <div
       className="flex flex-row p-3 cursor-pointer max-h-12 hover:bg-accent rounded-md"

--- a/apps/bridge-app/src/components/NetworkSelector.tsx
+++ b/apps/bridge-app/src/components/NetworkSelector.tsx
@@ -30,6 +30,7 @@ const NetworkSelectorItem = ({
   logo,
   onSelect,
 }: NetworkSelectorItemProps) => {
+  console.log(chain)
   return (
     <div
       className="flex flex-row p-3 cursor-pointer max-h-12 hover:bg-accent rounded-md"
@@ -82,7 +83,7 @@ export const NetworkSelector = () => {
             <NetworkSelectorItem
               key={mainnet.id}
               chain={mainnet}
-              logo={networkPairsByID[mainnet.id] ? l2AssetLogo : l1AssetLogo}
+              logo={mainnet.sourceId ? l2AssetLogo : l1AssetLogo}
               isActive={chain?.id === mainnet.id}
               onSelect={onSwitchNetwork}
             />
@@ -95,7 +96,7 @@ export const NetworkSelector = () => {
             <NetworkSelectorItem
               key={testnet.id}
               chain={testnet}
-              logo={networkPairsByID[testnet.id] ? l2AssetLogo : l1AssetLogo}
+              logo={testnet.sourceId ? l2AssetLogo : l1AssetLogo}
               isActive={chain?.id === testnet.id}
               onSelect={onSwitchNetwork}
             />

--- a/apps/bridge-app/src/routes/TicTacToe.tsx
+++ b/apps/bridge-app/src/routes/TicTacToe.tsx
@@ -3,13 +3,16 @@ import { Game } from '@/components/tictactoe/Game'
 import { JoinGameDialog } from '@/components/tictactoe/JoinGameDialog'
 import { SupportedNetworks } from '@/providers/SupportedNetworks'
 import { Text } from '@eth-optimism/ui-components'
+import { supersimL1, supersimL2A, supersimL2B } from '@eth-optimism/viem'
 import { useParams } from 'react-router'
-import { optimismSepolia, foundry, Chain } from 'viem/chains'
+import { optimismSepolia, Chain } from 'viem/chains'
 
 const supportedChains: Chain[] = [optimismSepolia]
 
-if (import.meta.env.VITE_DEPLOYMENT_ENV === 'local') {
-  supportedChains.push(foundry)
+if (import.meta.env.VITE_SUPERSIM_ENABLED === 'true') {
+  supportedChains.push(supersimL1)
+  supportedChains.push(supersimL2A)
+  supportedChains.push(supersimL2B)
 }
 
 export const TicTacToe = () => {

--- a/packages/viem/src/chains/supersim.ts
+++ b/packages/viem/src/chains/supersim.ts
@@ -1,0 +1,40 @@
+import { defineChain } from 'viem'
+import { mainnet, optimism } from 'viem/chains'
+
+export const supersimL1 = defineChain({
+  ...mainnet,
+  id: 900,
+  name: 'Supersim L1',
+  rpcUrls: {
+    default: {
+      http: ['http://127.0.0.1:8545'],
+    },
+  },
+  testnet: true,
+})
+
+export const supersimL2A = defineChain({
+  ...optimism,
+  id: 901,
+  name: 'Supersim L2 A',
+  rpcUrls: {
+    default: {
+      http: ['http://127.0.0.1:9545'],
+    },
+  },
+  testnet: true,
+  sourceId: 900,
+})
+
+export const supersimL2B = defineChain({
+  ...optimism,
+  id: 902,
+  name: 'Supersim L2 B',
+  rpcUrls: {
+    default: {
+      http: ['http://127.0.0.1:9546'],
+    },
+  },
+  testnet: true,
+  sourceId: 900,
+})

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -8,6 +8,9 @@ export {
   l2ToL2CrossDomainMessengerABI,
 } from '@/abis.js'
 
+// supersim
+export { supersimL1, supersimL2A, supersimL2B } from '@/chains/supersim.js'
+
 // contracts
 export { contracts } from '@/contracts.js'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,12 @@ importers:
       '@eth-optimism/ui-components':
         specifier: workspace:*
         version: link:../../packages/ui-components
+      '@eth-optimism/viem':
+        specifier: workspace:*
+        version: link:../../packages/viem
+      '@eth-optimism/wagmi':
+        specifier: workspace:*
+        version: link:../../packages/wagmi
       '@rainbow-me/rainbowkit':
         specifier: 2.1.3
         version: 2.1.3(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(viem@2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))(wagmi@2.11.3(@react-native-async-storage/async-storage@1.23.1(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3)))(@tanstack/query-core@5.29.0)(@tanstack/react-query@5.29.2(react@18.2.0))(@types/react@18.2.79)(bufferutil@4.0.8)(encoding@0.1.13)(immer@10.0.4)(ioredis@5.4.1)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.24.4)(@babel/preset-env@7.24.4(@babel/core@7.24.4))(bufferutil@4.0.8)(encoding@0.1.13)(react@18.2.0)(utf-8-validate@6.0.3))(react@18.2.0)(rollup@4.14.3)(typescript@5.4.5)(utf-8-validate@6.0.3)(viem@2.17.9(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.22.4))(zod@3.22.4))


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Adds chain defs for supersim in non fork mode to `@eth-optimism/viem`
* updates bridge app to bring in `@eth-optimism/viem` & `@eth-optimisim/wagmi`
* Adds support for configuring wagmi, and the network switcher to support supersim when `VITE_SUPERSIM_ENABLED` is set to `true`
* Adds supersim chains to the supported tic tac toe list

Tracker: https://github.com/ethereum-optimism/ecosystem/issues/416