### PR TITLE
feat(dapp-console-api): require github auth for faucet claims using privy auth

### DIFF
--- a/apps/dapp-console-api/package.json
+++ b/apps/dapp-console-api/package.json
@@ -33,6 +33,7 @@
     "@types/body-parser": "^1.19.5",
     "@types/cookie-parser": "^1.4.7",
     "@types/cors": "^2.8.5",
+    "@types/eventsource": "^1.1.11",
     "@types/express": "^4.17.21",
     "@types/express-serve-static-core": "4.17.41",
     "@types/isomorphic-fetch": "^0.0.39",
@@ -54,10 +55,11 @@
     "vitest": "^1.1.3"
   },
   "dependencies": {
-    "@eth-optimism/contracts-ts": "^0.17.0",
     "@eth-optimism/contracts-ecosystem": "workspace:*",
+    "@eth-optimism/contracts-ts": "^0.17.0",
     "@eth-optimism/message-queue": "workspace:*",
     "@eth-optimism/screening": "workspace:*",
+    "@growthbook/growthbook": "^0.27.0",
     "@privy-io/server-auth": "^1.7.2",
     "@trpc/server": "^10.45.2",
     "abitype": "^1.0.0",
@@ -67,6 +69,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
     "drizzle-orm": "^0.30.1",
+    "eventsource": "^2.0.2",
     "express": "^4.19.2",
     "express-prom-bundle": "^7.0.0",
     "express-rate-limit": "^7.1.5",

--- a/apps/dapp-console-api/src/Service.ts
+++ b/apps/dapp-console-api/src/Service.ts
@@ -29,6 +29,7 @@ import { AdminApi } from './api/AdminApi'
 import { ensureAdmin } from './auth'
 import { corsAllowlist, envVars } from './constants'
 import { connectToDatabase, runMigrations } from './db'
+import { GrowthbookStore } from './growthbook/GrowthbookStore'
 import { getRateLimiter } from './middleware/getRateLimiter'
 import { metrics } from './monitoring/metrics'
 import { AppsRoute } from './routes/apps'
@@ -131,6 +132,7 @@ export class Service {
       envVars.PRIVY_APP_ID,
       envVars.PRIVY_APP_SECRET,
     )
+    const growthbookStore = await GrowthbookStore.create()
 
     const logger = pino().child({
       namespace: 'dapp-console-api-server',
@@ -174,6 +176,7 @@ export class Service {
     )
     const faucetRoute = new FaucetRoute(
       trpc,
+      growthbookStore,
       getSupportedFaucets(gatewayRedisCache),
     )
 

--- a/apps/dapp-console-api/src/constants/envVars.ts
+++ b/apps/dapp-console-api/src/constants/envVars.ts
@@ -89,6 +89,7 @@ const envVarSchema = z.object({
   WORLDID_APP_ID: z.string(),
   WORLDID_APP_ACTION_NAME: z.string(),
   API_QUEUE_REDIS_URL: z.string(),
+  GROWTHBOOK_CLIENT_KEY: z.string(),
 })
 
 const isTest = process.env.NODE_ENV === 'test'
@@ -167,6 +168,7 @@ export const envVars = envVarSchema.parse(
         WORLDID_APP_ID: 'test worldid app id',
         WORLDID_APP_ACTION_NAME: 'test worldid app action name',
         API_QUEUE_REDIS_URL: 'redis://localhost:6379',
+        GROWTHBOOK_CLIENT_KEY: 'GROWTHBOOK_CLIENT_KEY',
       }
     : {
         PORT: process.env.PORT
@@ -255,5 +257,6 @@ export const envVars = envVarSchema.parse(
         WORLDID_APP_ID: process.env.WORLDID_APP_ID,
         WORLDID_APP_ACTION_NAME: process.env.WORLDID_APP_ACTION_NAME,
         API_QUEUE_REDIS_URL: process.env.API_QUEUE_REDIS_URL,
+        GROWTHBOOK_CLIENT_KEY: process.env.GROWTHBOOK_CLIENT_KEY,
       },
 )

--- a/apps/dapp-console-api/src/growthbook/GrowthbookStore.ts
+++ b/apps/dapp-console-api/src/growthbook/GrowthbookStore.ts
@@ -1,0 +1,59 @@
+import { GrowthBook, setPolyfills } from '@growthbook/growthbook'
+import { webcrypto } from 'crypto'
+import eventsource from 'eventsource'
+import isomorphicFetch from 'isomorphic-fetch'
+import z from 'zod'
+
+import { envVars } from '../constants'
+
+// Growthbook SDK requires some polyfills
+setPolyfills({
+  fetch: isomorphicFetch,
+  EventSource: eventsource,
+  SubtleCrypto: webcrypto.subtle,
+})
+
+const bool = z.boolean().catch(false)
+
+// there's more than this in our growthbook but we're only concerned with flags we use in the backend
+// If you have a new feature flag, add it here
+const flags = z.object({
+  enable_github_auth: bool,
+})
+
+type FeatureFlag = keyof typeof flags.shape
+
+// The SDK recommends instantiating this as a middleware
+// Instantiating it as a middleware allows you to save context per request,
+// ie. for running UX A/B testing.
+//
+// But we're not using it for that purpose, and we're okay with feature flags that get shared
+// across all requests which is why we're instantiating it as a singleton.
+// Benefit of this is that we can easily use it in non-express handler code
+// & plays well with our dependency injection pattern
+
+export class GrowthbookStore {
+  constructor(
+    private readonly _growthbook: GrowthBook<z.infer<typeof flags>>,
+  ) {}
+
+  static async create() {
+    const growthbook = new GrowthBook({
+      apiHost: 'https://cdn.growthbook.io',
+      clientKey: envVars.GROWTHBOOK_CLIENT_KEY,
+    })
+    // Growthbook in general does not throw, instead just returning default values if fetch fails
+    await growthbook.loadFeatures({ autoRefresh: true })
+    return new GrowthbookStore(growthbook)
+  }
+
+  // returns typesafe feature flag value
+  get = <T extends FeatureFlag>(key: T): z.infer<(typeof flags.shape)[T]> => {
+    const parser = flags.shape[key]
+    return parser.parse(
+      // returns default value if feature flag is not found
+      // parser.parse(null) triggers the catch(false) in the zod schema
+      this._growthbook.getFeatureValue(key, parser.parse(null)),
+    )
+  }
+}

--- a/apps/dapp-console-api/src/growthbook/index.ts
+++ b/apps/dapp-console-api/src/growthbook/index.ts
@@ -1,0 +1,1 @@
+export * from './GrowthbookStore'

--- a/apps/dapp-console-api/src/testhelpers/MockGrowtbookStore.ts
+++ b/apps/dapp-console-api/src/testhelpers/MockGrowtbookStore.ts
@@ -1,0 +1,8 @@
+import type { MockedFunction } from 'vitest'
+import { vi } from 'vitest'
+
+import type { GrowthbookStore } from '../growthbook'
+
+export const mockGrowthbookStore = {
+  get: vi.fn() as MockedFunction<GrowthbookStore['get']>,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       '@eth-optimism/screening':
         specifier: workspace:*
         version: link:../../packages/screening
+      '@growthbook/growthbook':
+        specifier: ^0.27.0
+        version: 0.27.0
       '@privy-io/server-auth':
         specifier: ^1.7.2
         version: 1.7.3
@@ -411,6 +414,9 @@ importers:
       drizzle-orm:
         specifier: ^0.30.1
         version: 0.30.8(@opentelemetry/api@1.8.0)(@types/pg@8.11.5)(@types/react@18.3.1)(better-sqlite3@9.5.0)(kysely@0.26.3)(pg@8.11.5)(react@18.2.0)
+      eventsource:
+        specifier: ^2.0.2
+        version: 2.0.2
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -472,6 +478,9 @@ importers:
       '@types/cors':
         specifier: ^2.8.5
         version: 2.8.17
+      '@types/eventsource':
+        specifier: ^1.1.11
+        version: 1.1.15
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -3536,6 +3545,10 @@ packages:
     peerDependencies:
       react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
 
+  '@growthbook/growthbook@0.27.0':
+    resolution: {integrity: sha512-gt/DWXfgyudY3gXAUjzKm9kMjVfCzfRc8d0nQQiXCP523ow23jThrmBzkRKCN+zxYVxUKcHjP9yjU9EKJqP4Fw==}
+    engines: {node: '>=10'}
+
   '@growthbook/growthbook@0.34.0':
     resolution: {integrity: sha512-3K5JL8QftX7y77EpieYg9anXVYb6+ZafTsrNCWp0HOdmtf4lxHOzCUYwuYDaS3bvmaeIUWJ5hYcOTc6WhNbfJw==}
     engines: {node: '>=10'}
@@ -6101,6 +6114,9 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  '@types/eventsource@1.1.15':
+    resolution: {integrity: sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==}
+
   '@types/express-serve-static-core@4.17.41':
     resolution: {integrity: sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==}
 
@@ -8516,6 +8532,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-mutator@0.5.0:
+    resolution: {integrity: sha512-bbeX8HWE8JGzraFgbVBX4ws2g3heZFuTtrleQBuN7huy+7n2n7etSuVnot3/1z3jdY2MiwuvoS4Ep1UT2rrGBw==}
+    engines: {node: '>=10'}
+
   dom-mutator@0.6.0:
     resolution: {integrity: sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==}
     engines: {node: '>=10'}
@@ -9196,6 +9216,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
@@ -17618,7 +17642,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       keccak: 3.0.4
-      preact: 10.20.2
+      preact: 10.22.1
       sha.js: 2.4.11
 
   '@colors/colors@1.5.0':
@@ -18274,7 +18298,7 @@ snapshots:
       '@ethereumjs/block': 3.6.3
       '@ethereumjs/blockchain': 5.5.3
       '@ethereumjs/common': 2.6.0
-      '@ethereumjs/tx': 3.4.0
+      '@ethereumjs/tx': 3.5.2
       async-eventemitter: 0.2.4
       core-js-pure: 3.37.1
       debug: 2.6.9
@@ -18618,6 +18642,10 @@ snapshots:
     dependencies:
       '@growthbook/growthbook': 0.34.0
       react: 18.2.0
+
+  '@growthbook/growthbook@0.27.0':
+    dependencies:
+      dom-mutator: 0.5.0
 
   '@growthbook/growthbook@0.34.0':
     dependencies:
@@ -22955,6 +22983,8 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
+  '@types/eventsource@1.1.15': {}
+
   '@types/express-serve-static-core@4.17.41':
     dependencies:
       '@types/node': 20.12.7
@@ -25604,7 +25634,7 @@ snapshots:
 
   async-mutex@0.2.6:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   async-mutex@0.4.1:
     dependencies:
@@ -27014,6 +27044,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-mutator@0.5.0: {}
+
   dom-mutator@0.6.0: {}
 
   dot-case@3.0.4:
@@ -27406,7 +27438,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.20.2):
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.20.2
     transitivePeerDependencies:
       - supports-color
@@ -28151,6 +28183,8 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
+
+  eventsource@2.0.2: {}
 
   evp_bytestokey@1.0.3:
     dependencies:


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem/issues/449

Updates the dapp-console-api to require that claims using `PRIVY` auth must also have a github account associated with their privy user when the `enable_github_auth` feature flag is enabled.