### PR TITLE
feat(dapp-console): frontend support for requiring github auth when claiming from faucet through privy auth

### DIFF
--- a/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
@@ -26,7 +26,8 @@ const seeDetails = (
 )
 
 const FaucetHeaderInner = () => {
-  const { connectWallet, authenticated } = usePrivy()
+  const { connectWallet, authenticated, linkGithub } = usePrivy()
+  const { userNeedsGithubAuth } = useAuth()
   const { connectedWallet } = useConnectedWallet()
   const { login } = useAuth()
   const { refetchWorldId, isAuthenticationLoading } = useFaucetVerifications()
@@ -112,6 +113,20 @@ const FaucetHeaderInner = () => {
           your onchain identity for more tokens. {seeDetails}
         </Text>
         <Button onClick={handleLogin}>Sign in</Button>
+      </>
+    )
+  } else if (userNeedsGithubAuth) {
+    // User is signed in, but no github is linked
+    content = (
+      <>
+        <Text as="h3" className="text-base font-semibold mb-1">
+          Link Github to use the faucet
+        </Text>
+        <Text as="p" className="text-base text-secondary-foreground mb-4">
+          Anyone can claim 0.05 test ETH on 1 network every 24 hours, or verify
+          your onchain identity for more tokens. {seeDetails}
+        </Text>
+        <Button onClick={linkGithub}>Link Github</Button>
       </>
     )
   } else if (!connectedWallet) {

--- a/apps/dapp-console/app/hooks/useAuth.ts
+++ b/apps/dapp-console/app/hooks/useAuth.ts
@@ -1,12 +1,15 @@
-import { useLogin, useLogout } from '@privy-io/react-auth'
+import { useLogin, useLogout, usePrivy } from '@privy-io/react-auth'
 import { apiClient } from '@/app/helpers/apiClient'
 import { toast } from '@eth-optimism/ui-components'
 import { LONG_DURATION } from '@/app/constants/toast'
 import { captureError } from '@/app/helpers/errorReporting'
+import { useFeatureFlag } from '@/app/hooks/useFeatureFlag'
 
 const useAuth = () => {
   const { mutateAsync: loginUser } = apiClient.auth.loginUser.useMutation()
   const { mutateAsync: logoutUser } = apiClient.auth.logoutUser.useMutation()
+  const { ready, authenticated, user } = usePrivy()
+  const githubAuthRequired = useFeatureFlag('enable_github_auth')
 
   const { login: privyLogin } = useLogin({
     onComplete: async () => {
@@ -38,7 +41,12 @@ const useAuth = () => {
     },
   })
 
-  return { login: privyLogin, logout: privyLogout }
+  return {
+    login: privyLogin,
+    logout: privyLogout,
+    userNeedsGithubAuth:
+      githubAuthRequired && ready && authenticated && !user?.github,
+  }
 }
 
 export { useAuth }

--- a/apps/dapp-console/app/hooks/useFaucetVerifications.ts
+++ b/apps/dapp-console/app/hooks/useFaucetVerifications.ts
@@ -3,9 +3,11 @@ import { useConnectedWallet } from '@/app/hooks/useConnectedWallet'
 import { Authentications } from '@/app/faucet/types'
 import { getOnchainAuthentication } from '@/app/faucet/helpers'
 import { usePrivy } from '@privy-io/react-auth'
+import { useAuth } from '@/app/hooks/useAuth'
 
 const useFaucetVerifications = () => {
   const { authenticated, ready } = usePrivy()
+  const { userNeedsGithubAuth } = useAuth()
   const { connectedWallet } = useConnectedWallet()
   const walletAddress = connectedWallet?.address ?? ''
 
@@ -85,7 +87,7 @@ const useFaucetVerifications = () => {
       {
         authMode: 'PRIVY',
       },
-      { enabled: !!authenticated },
+      { enabled: !!authenticated && !userNeedsGithubAuth },
     )
 
   const isAuthenticationLoading =

--- a/apps/dapp-console/app/hooks/useFeatureFlag.ts
+++ b/apps/dapp-console/app/hooks/useFeatureFlag.ts
@@ -16,6 +16,7 @@ const flags = {
   enable_deployment_rebate: flag.bool,
   enable_console_faucet: flag.bool,
   enable_new_brand: flag.bool,
+  enable_github_auth: flag.bool,
 }
 
 export type FeatureFlag = keyof typeof flags


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem/issues/449

Updates faucet dev console to require a user to link their github account in order to perform an offchain claim from the faucet.