### PR TITLE
feat(dapp-console): improve error handling on faucet claim flow

### DIFF
--- a/apps/dapp-console/app/faucet/components/ClaimButton.tsx
+++ b/apps/dapp-console/app/faucet/components/ClaimButton.tsx
@@ -17,7 +17,7 @@ interface ClaimButtonProps {
   chainId: number
   authentications: Authentications
   recipientAddress: string
-  onSuccess: () => void
+  onClaimStarted: () => void
   onFailed: () => void
   setBlockExplorerUrl: (url: string) => void
   children: React.ReactNode
@@ -32,7 +32,7 @@ const ClaimButton = forwardRef<HTMLButtonElement, ClaimButtonProps>(
       chainId,
       authentications,
       recipientAddress,
-      onSuccess,
+      onClaimStarted,
       onFailed,
       setBlockExplorerUrl,
       children,
@@ -97,6 +97,7 @@ const ClaimButton = forwardRef<HTMLButtonElement, ClaimButtonProps>(
       if (!authenticated) return
       onClick()
       try {
+        onClaimStarted()
         let response
         if (isOnchainClaim) {
           response = await handleOnchainClaim()
@@ -104,9 +105,14 @@ const ClaimButton = forwardRef<HTMLButtonElement, ClaimButtonProps>(
           response = await handleOffchainClaim()
         }
 
+        if (response && response.error) {
+          console.error('Claim failed', response.error)
+          onFailed()
+          return
+        }
+
         if (response && !response.error) {
           setBlockExplorerUrl(response.etherscanUrl || '')
-          onSuccess()
           trackFaucetClaim({
             chainId,
             authMode: response.authMode,

--- a/apps/dapp-console/app/faucet/components/FaucetContent.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetContent.tsx
@@ -102,7 +102,7 @@ const FaucetContent = () => {
 
       return () => clearInterval(interval)
     }
-  }, [claimStatus, secondsUntilNextDrip])
+  }, [claimStatus, secondsUntilNextDrip, refetchNextDrips])
 
   const handleAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setAddress(e.target.value)
@@ -194,7 +194,7 @@ const FaucetContent = () => {
           chainId={selectedNetwork.chainID}
           authentications={faucetAuthentications}
           recipientAddress={address}
-          onSuccess={() => {
+          onClaimStarted={() => {
             setClaimStatus('initiated')
           }}
           onFailed={() => {

--- a/apps/dapp-console/app/hooks/useFaucetVerifications.ts
+++ b/apps/dapp-console/app/hooks/useFaucetVerifications.ts
@@ -17,7 +17,10 @@ const useFaucetVerifications = () => {
       {
         address: walletAddress,
       },
-      { enabled: !!walletAddress && !!authenticated },
+      {
+        enabled: !!walletAddress && !!authenticated,
+        refetchOnWindowFocus: false,
+      },
     )
 
   const { data: coinbaseNextDrips, refetch: refetchCoinbaseDrips } =
@@ -35,7 +38,10 @@ const useFaucetVerifications = () => {
       {
         address: walletAddress,
       },
-      { enabled: !!walletAddress && !!authenticated },
+      {
+        enabled: !!walletAddress && !!authenticated,
+        refetchOnWindowFocus: false,
+      },
     )
 
   const { data: easNextDrips, refetch: refetchEasNextDrips } =
@@ -53,7 +59,10 @@ const useFaucetVerifications = () => {
       {
         address: walletAddress,
       },
-      { enabled: !!walletAddress && !!authenticated },
+      {
+        enabled: !!walletAddress && !!authenticated,
+        refetchOnWindowFocus: false,
+      },
     )
 
   const { data: gitcoinNextDrips, refetch: refetchGitcoinNextDrips } =
@@ -72,6 +81,7 @@ const useFaucetVerifications = () => {
     isFetching: isWorldIDUserLoading,
   } = apiClient.auth.isWorldIdUser.useQuery(undefined, {
     enabled: !!authenticated,
+    refetchOnWindowFocus: false,
   })
 
   const { data: worldIdNextDrips, refetch: refetchWorldIdNextDrips } =


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem/issues/456

Improves the faucet claim dialog to properly display the claim failed state if the claim tx fails. This will prevent the claim spinner from endlessly spinning when claim txs fail.