### PR TITLE
feat(dapp-console-api): fetch admin wallet balance for faucet

### DIFF
--- a/apps/dapp-console-api/src/monitoring/metrics.ts
+++ b/apps/dapp-console-api/src/monitoring/metrics.ts
@@ -198,6 +198,11 @@ export const metrics = {
     help: 'How many times the balance of a faucet failed to be fetched',
     labelNames: ['chainId'] as const,
   }),
+  faucetAdminWalletFetchBalanceFailures: new Counter({
+    name: 'faucet_admin_wallet_fetch_balance_failures',
+    help: 'How many times the balance of the faucet admin wallet failed to be fetched',
+    labelNames: ['chainId'] as const,
+  }),
   faucetFetchLastDripFailures: new Counter({
     name: 'faucet_fetch_last_drip_failures',
     help: 'How many times the last drip on a faucet failed to be fetched',

--- a/apps/dapp-console-api/src/routes/faucet/FaucetRoute.spec.ts
+++ b/apps/dapp-console-api/src/routes/faucet/FaucetRoute.spec.ts
@@ -194,6 +194,8 @@ describe(FaucetRoute.name, () => {
           isAvailable: true,
           onChainDripAmount: parseEther('1.0'),
           offChainDripAmount: parseEther('0.05'),
+          adminWalletBalance: 4200000000000000000000n,
+          faucetBalance: 4200000000000000000000n,
         },
       ])
     })

--- a/apps/dapp-console-api/src/utils/Faucet.ts
+++ b/apps/dapp-console-api/src/utils/Faucet.ts
@@ -12,7 +12,10 @@ import type {
 } from 'viem'
 import { encodeFunctionData, getContract, keccak256, numberToHex } from 'viem'
 
-import { getFaucetContractBalance } from './faucetBalances'
+import {
+  getFaucetAdminWalletBalance,
+  getFaucetContractBalance,
+} from './faucetBalances'
 import type { RedisCache } from './redis'
 
 export type FaucetConstructorArgs = {
@@ -116,6 +119,14 @@ export class Faucet {
       redisCache: this.redisCache,
       chainId: this.l1ChainId,
       address: this.faucetAddress,
+    })
+  }
+
+  public async getAdminWalletBalance() {
+    return getFaucetAdminWalletBalance({
+      redisCache: this.redisCache,
+      address: this.adminWalletClient.account.address,
+      chainId: this.l1ChainId,
     })
   }
 

--- a/apps/dapp-console-api/src/utils/faucetBalances.ts
+++ b/apps/dapp-console-api/src/utils/faucetBalances.ts
@@ -16,7 +16,7 @@ export const getFaucetContractBalance = async ({
 }) => redisCache.getItem<bigint>(getFaucetContractBalanceKey(address, chainId))
 
 const getFaucetAdminWalletBalanceKey = (address: Address, chainId: number) =>
-  `faucet_admin_wallet_balance_${chainId}_${address}`
+  `faucet_admin_wallet_balance_${chainId}_${address.toLowerCase()}`
 
 export const getFaucetAdminWalletBalance = async ({
   redisCache,


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem/issues/448

This PR enables the dev console backend to fetch the balance of the admin wallet. If the balance of the admin wallet is below .01 ETH, then the faucet will be marked as unavailable.