### PR TITLE
feat(dapp-console): require github auth for all auth methods

### DIFF
--- a/apps/dapp-console/app/faucet/components/FaucetHeader.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeader.tsx
@@ -1,17 +1,17 @@
 'use client'
 
-import { hasAuthentication } from '@/app/faucet/helpers'
 import { LogoChain } from '@/app/faucet/components/LogoChain'
 import { AuthenticatedHeader } from '@/app/faucet/components/AuthenticatedHeader'
 import { FaucetHeaderInner } from '@/app/faucet/components/FaucetHeaderInner'
 import { useFaucetVerifications } from '@/app/hooks/useFaucetVerifications'
 
 const FaucetHeader = () => {
-  const { faucetAuthentications } = useFaucetVerifications()
+  const { hasOnChainAuthentication, faucetAuthentications } =
+    useFaucetVerifications()
 
   return (
     <div>
-      {hasAuthentication(faucetAuthentications) ? (
+      {hasOnChainAuthentication ? (
         <AuthenticatedHeader authentications={faucetAuthentications} />
       ) : (
         <div className="flex justify-between flex-col-reverse md:flex-row items-start gap-4">

--- a/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
+++ b/apps/dapp-console/app/faucet/components/FaucetHeaderInner.tsx
@@ -27,7 +27,7 @@ const seeDetails = (
 
 const FaucetHeaderInner = () => {
   const { connectWallet, authenticated, linkGithub } = usePrivy()
-  const { userNeedsGithubAuth } = useAuth()
+  const { userHasGithubAuth } = useAuth()
   const { connectedWallet } = useConnectedWallet()
   const { login } = useAuth()
   const { refetchWorldId, isAuthenticationLoading } = useFaucetVerifications()
@@ -115,7 +115,7 @@ const FaucetHeaderInner = () => {
         <Button onClick={handleLogin}>Sign in</Button>
       </>
     )
-  } else if (userNeedsGithubAuth) {
+  } else if (!userHasGithubAuth) {
     // User is signed in, but no github is linked
     content = (
       <>

--- a/apps/dapp-console/app/hooks/useAuth.ts
+++ b/apps/dapp-console/app/hooks/useAuth.ts
@@ -44,8 +44,8 @@ const useAuth = () => {
   return {
     login: privyLogin,
     logout: privyLogout,
-    userNeedsGithubAuth:
-      githubAuthRequired && ready && authenticated && !user?.github,
+    userHasGithubAuth:
+      !githubAuthRequired || (ready && authenticated && !!user?.github),
   }
 }
 


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem/issues/449

Previously github auth was only required for users authing with privy and no on chain method of auth. This change makes it so that even users authenticated with an on chain method must also be authenticated with github.