### PR TITLE
feat(dapp-console-api): check that faucet user has github account linked

### DIFF
--- a/apps/dapp-console-api/src/constants/session.ts
+++ b/apps/dapp-console-api/src/constants/session.ts
@@ -25,6 +25,7 @@ export type SessionData = {
     privyAccessTokenExpiration: number
     privyDid: string
     entityId: string
+    githubSubject?: string
   }
   worldIdUser?: {
     nullifierHash: string

--- a/apps/dapp-console-api/src/middleware/index.ts
+++ b/apps/dapp-console-api/src/middleware/index.ts
@@ -1,1 +1,2 @@
+export * from './isGithubAuthed'
 export * from './isPrivyAuthed'

--- a/apps/dapp-console-api/src/middleware/isGithubAuthed.spec.ts
+++ b/apps/dapp-console-api/src/middleware/isGithubAuthed.spec.ts
@@ -1,0 +1,160 @@
+import type { PrivyClient } from '@privy-io/server-auth'
+import { type RouterCaller, TRPCError } from '@trpc/server'
+import type { Mock } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Route } from '@/routes'
+import {
+  createSignedInCaller,
+  createSignedOutCaller,
+  mockDB,
+  mockLogger,
+  mockPrivyAccessToken,
+  mockUserSession,
+} from '@/testhelpers'
+import { mockGrowthbookStore } from '@/testhelpers/MockGrowtbookStore'
+import { mockPrivyClient } from '@/testhelpers/MockPrivyClient'
+import { Trpc } from '@/Trpc'
+
+import { isGithubAuthed } from './isGithubAuthed'
+
+describe('isPrivyAuthed', () => {
+  let privyClient: PrivyClient
+  let trpc: Trpc
+  let handler: TestRoute['handler']
+  let signedOutCaller: ReturnType<RouterCaller<TestRoute['handler']['_def']>>
+  let signedInCaller: ReturnType<RouterCaller<TestRoute['handler']['_def']>>
+  let getUser: Mock
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    privyClient = mockPrivyClient()
+    trpc = new Trpc(privyClient, mockLogger, mockDB)
+    handler = new TestRoute(trpc).handler
+    getUser = (privyClient.getUser as Mock).mockImplementation(async () => ({}))
+    signedInCaller = createSignedInCaller(
+      handler,
+      mockUserSession({
+        privyAccessToken: '0xhdfhdfh',
+        privyAccessTokenExpiration: Date.now() + 1000,
+        entityId: '1',
+        privyDid: 'privy:did',
+      }),
+    )
+    signedOutCaller = createSignedOutCaller(handler)
+    mockGrowthbookStore.get.mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('should pass if enable_github_auth flag is set to false', async () => {
+    mockGrowthbookStore.get.mockImplementation((key) =>
+      key === 'enable_github_auth' ? false : true,
+    )
+
+    await expect(signedInCaller.test()).resolves.not.toThrow()
+  })
+
+  it('should handle error when privy user is not logged in', async () => {
+    await expect(signedOutCaller.test()).rejects.toEqual(
+      new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'User is not logged into privy',
+      }),
+    )
+  })
+
+  it('should pass if user is already signed into privy with github account linked', async () => {
+    signedInCaller = createSignedInCaller(
+      handler,
+      mockUserSession({
+        privyAccessToken: '0xhdfhdfh',
+        privyAccessTokenExpiration: Date.now() + 1000,
+        entityId: '1',
+        privyDid: 'privy:did',
+        githubSubject: 'subject',
+      }),
+      `${mockPrivyAccessToken}-new`,
+    )
+
+    await expect(signedInCaller.test()).resolves.not.toThrow()
+    expect(getUser).not.toBeCalled()
+  })
+
+  it('should throw error if privy user has not linked github account', async () => {
+    getUser.mockImplementation(async () => ({
+      github: undefined,
+    }))
+
+    await expect(signedInCaller.test()).rejects.toEqual(
+      new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'User has not linked their github',
+      }),
+    )
+    expect(getUser).toBeCalled()
+  })
+
+  it('should throw error if session save fails', async () => {
+    const session = mockUserSession({
+      privyAccessToken: '0xhdfhdfh',
+      privyAccessTokenExpiration: Date.now() + 1000,
+      entityId: '1',
+      privyDid: 'privy:did',
+    })
+    const caller = createSignedInCaller(handler, session)
+    const expectedGithubSubject = '0x123'
+    getUser.mockImplementation(async () => ({
+      github: { subject: expectedGithubSubject },
+    }))
+    vi.spyOn(session, 'save').mockImplementation(async () => {
+      throw new Error('failed to save session')
+    })
+
+    await expect(caller.test()).rejects.toEqual(Trpc.handleStatus(500))
+  })
+
+  it('should update the session with the github subject', async () => {
+    const session = mockUserSession({
+      privyAccessToken: '0xhdfhdfh',
+      privyAccessTokenExpiration: Date.now() + 1000,
+      entityId: '1',
+      privyDid: 'privy:did',
+    })
+    const caller = createSignedInCaller(handler, session)
+    const expectedGithubSubject = '0x123'
+    getUser.mockImplementation(async () => ({
+      github: { subject: expectedGithubSubject },
+    }))
+
+    expect(session.user?.githubSubject).not.toBeDefined()
+    await caller.test()
+
+    expect(session.user).toEqual({
+      entityId: '1',
+      privyAccessToken: '0xhdfhdfh',
+      privyAccessTokenExpiration: Date.now() + 1000,
+      privyDid: 'privy:did',
+      githubSubject: expectedGithubSubject,
+    })
+    expect(session.save).toBeCalled()
+  })
+})
+
+class TestRoute extends Route {
+  public readonly name = 'testroute' as const
+
+  public readonly test = 'test' as const
+  public readonly testController = this.trpc.procedure
+    .use(isGithubAuthed(this.trpc, mockGrowthbookStore as any))
+    .query(async () => {
+      return 'test'
+    })
+
+  public readonly handler = this.trpc.router({
+    [this.test]: this.testController,
+  })
+}

--- a/apps/dapp-console-api/src/middleware/isGithubAuthed.ts
+++ b/apps/dapp-console-api/src/middleware/isGithubAuthed.ts
@@ -1,0 +1,64 @@
+import { TRPCError } from '@trpc/server'
+
+import type { GrowthbookStore } from '@/growthbook'
+import { metrics } from '@/monitoring/metrics'
+import { Trpc } from '@/Trpc'
+
+/** Middleware used for checking if the request is from a privy user with a github account linked. */
+export const isGithubAuthed = (
+  trpc: Trpc,
+  growthBookStore: GrowthbookStore,
+) => {
+  return trpc.middleware(async ({ ctx, next }) => {
+    const { session } = ctx
+
+    if (!growthBookStore.get('enable_github_auth')) {
+      return next()
+    }
+
+    if (!session.user || !session.user.privyDid) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'User is not logged into privy',
+      })
+    }
+
+    if (!!session.user.githubSubject) {
+      return next()
+    }
+
+    const user = await trpc.privy
+      .getUser(session.user.privyDid)
+      .catch((err) => {
+        metrics.fetchPrivyUserErrorCount.inc()
+        trpc.logger?.error(
+          {
+            error: err,
+            entityId: session.user?.entityId,
+            privyDid: session.user?.privyDid,
+          },
+          'error fetching privy user',
+        )
+        throw Trpc.handleStatus(500, 'error fetching privy user')
+      })
+
+    if (!user.github) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'User has not linked their github',
+      })
+    }
+
+    session.user.githubSubject = user.github.subject
+    await session.save().catch((err) => {
+      metrics.failedToSaveUserIronSessionErrorCount.inc()
+      trpc.logger.error(
+        { err, entityId: session.user?.entityId },
+        'failed to save github subject to user iron session',
+      )
+      throw Trpc.handleStatus(500, 'unable to verify github auth')
+    })
+
+    return next()
+  })
+}

--- a/apps/dapp-console-api/src/routes/auth/AuthRoute.ts
+++ b/apps/dapp-console-api/src/routes/auth/AuthRoute.ts
@@ -71,6 +71,7 @@ export class AuthRoute extends Route {
       const { session } = ctx
 
       delete session.user
+      delete session.worldIdUser
 
       await session.save().catch((err) => {
         metrics.logoutUserErrorCount.inc()

--- a/apps/dapp-console-api/src/routes/faucet/FaucetRoute.spec.ts
+++ b/apps/dapp-console-api/src/routes/faucet/FaucetRoute.spec.ts
@@ -363,7 +363,7 @@ describe(FaucetRoute.name, () => {
         ).rejects.toEqual(
           new TRPCError({
             code: 'UNAUTHORIZED',
-            message: 'User is not logged into github',
+            message: 'User has not linked their github',
           }),
         )
       })


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem/issues/449

Server side changes to enforce that users of the faucet have a github account linked to their privy account. This also updates the github account information to be stored in the session instead of fetching it from privy on each request.