### PR TITLE
Adds script to fetch the latest forge artifact bundle

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+forge-artifacts

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "create:app": "cd apps && pnpm create vite --template=react-ts ",
     "create:react:library": "cd packages && pnpm create vite --template=react-ts ",
     "release:publish": "pnpm install --frozen-lockfile && pnpm nx run-many --target=build && changeset publish",
-    "release:version": "changeset version && pnpm install --lockfile-only"
+    "release:version": "changeset version && pnpm install --lockfile-only",
+    "fetch:artifacts": "bash ./scripts/pull-contract-artifacts.sh"
   },
   "private": true,
   "devDependencies": {

--- a/scripts/pull-contract-artifacts.sh
+++ b/scripts/pull-contract-artifacts.sh
@@ -29,4 +29,6 @@ rm $archive_name
 rm -rf artifacts
 rm -rf cache
 
+gcloud config unset project
+
 echo "Done"

--- a/scripts/pull-contract-artifacts.sh
+++ b/scripts/pull-contract-artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+lib_dir=./lib
+artifact_project="oplabs-tools-artifacts"
+artifact_bucket="oplabs-contract-artifacts"
+artifact_prefix="artifacts-v1-"
+
+gcloud auth login
+gcloud config set project $artifact_project
+
+# Pulls latest v1 artifact bundle
+latest_archive=$(gsutil ls -l gs://$artifact_bucket/$artifact_prefix* | sort -k 2 | tail -2 | head -1 | awk '{print $3}')
+archive_name=$(basename $latest_archive)
+
+cd $lib_dir
+
+# Cleanup any existing artifacts
+rm -rf forge-artifacts
+
+# Download and extract the archive
+echo "Attempting to download $latest_archive"
+gsutil cp $latest_archive .
+tar -xzvf $archive_name
+
+# Cleanup
+rm $archive_name
+rm -rf artifacts
+rm -rf cache
+
+echo "Done"


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Adds a new command `pnpm fetch:artifacts`. This command expects `gcloud` and `gsutil` to be setup on your box which the ecopod team should already have setup ahead of time.

This script will do the following
* Prompt you to login through your browser and go thru Google OAuth and hit your yubikey
* Once it validates you have access to the artifact it will fetch the latest v1 artifact bundle
* It will then extract the `forge-artifacts` and place them under `lib`

Eventually each package can implement a `generate` command and the scripts to autogenerate our abi, predeploys, viem & wagmi code can all be configured to look at this directory for the latest forge artifacts