### PR TITLE
Implements protcol updates for SentMessage

### DIFF
--- a/.changeset/ten-pugs-sort.md
+++ b/.changeset/ten-pugs-sort.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/viem": patch
+---
+
+Adds support for protocol changes related to SentMessage events

--- a/packages/viem/docs/functions/decodeExecutingMessage.md
+++ b/packages/viem/docs/functions/decodeExecutingMessage.md
@@ -24,4 +24,4 @@ Decoded message arugments [DecodeExecutingMessageReturnType](../type-aliases/Dec
 
 ## Defined in
 
-[packages/viem/src/utils/decodeExecutingMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/decodeExecutingMessage.ts#L28)
+[packages/viem/src/utils/decodeExecutingMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/decodeExecutingMessage.ts#L28)

--- a/packages/viem/docs/functions/decodeSentMessage.md
+++ b/packages/viem/docs/functions/decodeSentMessage.md
@@ -24,4 +24,4 @@ Decoded message arugments [DecodeSentMessageReturnType](../type-aliases/DecodeSe
 
 ## Defined in
 
-[packages/viem/src/utils/decodeSentMessage.ts:31](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/decodeSentMessage.ts#L31)
+[packages/viem/src/utils/decodeSentMessage.ts:31](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/decodeSentMessage.ts#L31)

--- a/packages/viem/docs/functions/estimateExecuteL2ToL2MessageGas.md
+++ b/packages/viem/docs/functions/estimateExecuteL2ToL2MessageGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:107](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L107)
+[packages/viem/src/actions/executeL2ToL2Message.ts:107](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L107)

--- a/packages/viem/docs/functions/estimateSendL2ToL2MessageGas.md
+++ b/packages/viem/docs/functions/estimateSendL2ToL2MessageGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:105](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L105)
+[packages/viem/src/actions/sendL2ToL2Message.ts:105](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L105)

--- a/packages/viem/docs/functions/executeL2ToL2Message.md
+++ b/packages/viem/docs/functions/executeL2ToL2Message.md
@@ -36,4 +36,4 @@ The executeL2ToL2Message transaction hash. [ExecuteL2ToL2MessageReturnType](../t
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:78](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L78)
+[packages/viem/src/actions/executeL2ToL2Message.ts:78](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L78)

--- a/packages/viem/docs/functions/extractMessageIdentifierFromLogs.md
+++ b/packages/viem/docs/functions/extractMessageIdentifierFromLogs.md
@@ -1377,4 +1377,4 @@ A valid message identifier. GetGameReturnType
 
 ## Defined in
 
-[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L55)
+[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:58](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L58)

--- a/packages/viem/docs/functions/sendL2ToL2Message.md
+++ b/packages/viem/docs/functions/sendL2ToL2Message.md
@@ -36,4 +36,4 @@ The sendL2ToL2Message transaction hash. [SendL2ToL2MessageReturnType](../type-al
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:76](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L76)
+[packages/viem/src/actions/sendL2ToL2Message.ts:76](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L76)

--- a/packages/viem/docs/functions/simulateExecuteL2ToL2Message.md
+++ b/packages/viem/docs/functions/simulateExecuteL2ToL2Message.md
@@ -36,4 +36,4 @@ The contract functions return value. [ExecuteL2ToL2MessageContractReturnType](..
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:133](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L133)
+[packages/viem/src/actions/executeL2ToL2Message.ts:133](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L133)

--- a/packages/viem/docs/functions/simulateSendL2ToL2Message.md
+++ b/packages/viem/docs/functions/simulateSendL2ToL2Message.md
@@ -36,4 +36,4 @@ The contract functions return value. [SendL2ToL2MessageContractReturnType](../ty
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L131)
+[packages/viem/src/actions/sendL2ToL2Message.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L131)

--- a/packages/viem/docs/type-aliases/DecodeExecutingMessageParameters.md
+++ b/packages/viem/docs/type-aliases/DecodeExecutingMessageParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/decodeExecutingMessage.ts:10](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/decodeExecutingMessage.ts#L10)
+[packages/viem/src/utils/decodeExecutingMessage.ts:10](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/decodeExecutingMessage.ts#L10)

--- a/packages/viem/docs/type-aliases/DecodeExecutingMessageReturnType.md
+++ b/packages/viem/docs/type-aliases/DecodeExecutingMessageReturnType.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/decodeExecutingMessage.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/decodeExecutingMessage.ts#L17)
+[packages/viem/src/utils/decodeExecutingMessage.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/decodeExecutingMessage.ts#L17)

--- a/packages/viem/docs/type-aliases/DecodeSentMessageParameters.md
+++ b/packages/viem/docs/type-aliases/DecodeSentMessageParameters.md
@@ -10,10 +10,10 @@
 
 ## Type declaration
 
-### payload
+### logs
 
-> **payload**: `Hex`
+> **logs**: `Log`[]
 
 ## Defined in
 
-[packages/viem/src/utils/decodeSentMessage.ts:9](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/decodeSentMessage.ts#L9)
+[packages/viem/src/utils/decodeSentMessage.ts:9](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/decodeSentMessage.ts#L9)

--- a/packages/viem/docs/type-aliases/DecodeSentMessageReturnType.md
+++ b/packages/viem/docs/type-aliases/DecodeSentMessageReturnType.md
@@ -14,6 +14,10 @@
 
 > **destination**: `bigint`
 
+### log
+
+> **log**: `Log`
+
 ### message
 
 > **message**: `Hex`
@@ -21,10 +25,6 @@
 ### messageNonce
 
 > **messageNonce**: `bigint`
-
-### origin
-
-> **origin**: `bigint`
 
 ### sender
 
@@ -36,4 +36,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/decodeSentMessage.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/decodeSentMessage.ts#L16)
+[packages/viem/src/utils/decodeSentMessage.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/decodeSentMessage.ts#L16)

--- a/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageContractReturnType.md
+++ b/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:57](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L57)
+[packages/viem/src/actions/executeL2ToL2Message.ts:57](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L57)

--- a/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageErrorType.md
+++ b/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:66](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L66)
+[packages/viem/src/actions/executeL2ToL2Message.ts:66](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L66)

--- a/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageParameters.md
+++ b/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageParameters.md
@@ -40,4 +40,4 @@ Target contract or wallet address.
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:30](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L30)
+[packages/viem/src/actions/executeL2ToL2Message.ts:30](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L30)

--- a/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageReturnType.md
+++ b/packages/viem/docs/type-aliases/ExecuteL2ToL2MessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/executeL2ToL2Message.ts:52](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/executeL2ToL2Message.ts#L52)
+[packages/viem/src/actions/executeL2ToL2Message.ts:52](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/executeL2ToL2Message.ts#L52)

--- a/packages/viem/docs/type-aliases/ExtractMessageIdentifierFromLogsErrorType.md
+++ b/packages/viem/docs/type-aliases/ExtractMessageIdentifierFromLogsErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:35](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L35)
+[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:38](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L38)

--- a/packages/viem/docs/type-aliases/ExtractMessageIdentifierFromLogsParameters.md
+++ b/packages/viem/docs/type-aliases/ExtractMessageIdentifierFromLogsParameters.md
@@ -18,4 +18,4 @@ The receipt for the sendL2ToL2Message transaction.
 
 ## Defined in
 
-[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L17)
+[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:20](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L20)

--- a/packages/viem/docs/type-aliases/ExtractMessageIdentifierFromLogsReturnType.md
+++ b/packages/viem/docs/type-aliases/ExtractMessageIdentifierFromLogsReturnType.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L27)
+[packages/viem/src/utils/extractMessageIdentifierFromLogs.ts:30](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/utils/extractMessageIdentifierFromLogs.ts#L30)

--- a/packages/viem/docs/type-aliases/MessageIdentifier.md
+++ b/packages/viem/docs/type-aliases/MessageIdentifier.md
@@ -44,4 +44,4 @@ The timestamp that the log was emitted. Used to enforce the timestamp invariant
 
 ## Defined in
 
-[packages/viem/src/types/interop.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/types/interop.ts#L7)
+[packages/viem/src/types/interop.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/types/interop.ts#L7)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageContractReturnType.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L55)
+[packages/viem/src/actions/sendL2ToL2Message.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L55)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageErrorType.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:64](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L64)
+[packages/viem/src/actions/sendL2ToL2Message.ts:64](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L64)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageParameters.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageParameters.md
@@ -40,4 +40,4 @@ Target contract or wallet address.
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L28)
+[packages/viem/src/actions/sendL2ToL2Message.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L28)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageReturnType.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/actions/sendL2ToL2Message.ts#L50)
+[packages/viem/src/actions/sendL2ToL2Message.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/actions/sendL2ToL2Message.ts#L50)

--- a/packages/viem/docs/variables/contracts.md
+++ b/packages/viem/docs/variables/contracts.md
@@ -86,4 +86,4 @@ OP Stack Predeploy Addresses
 
 ## Defined in
 
-[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/contracts.ts#L8)
+[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/contracts.ts#L8)

--- a/packages/viem/docs/variables/crossL2InboxABI.md
+++ b/packages/viem/docs/variables/crossL2InboxABI.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `CrossL2Inbox`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:588](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/abis.ts#L588)
+[packages/viem/src/abis.ts:689](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/abis.ts#L689)

--- a/packages/viem/docs/variables/l1BlockABI.md
+++ b/packages/viem/docs/variables/l1BlockABI.md
@@ -6,10 +6,10 @@
 
 # l1BlockABI
 
-> `const` **l1BlockABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **l1BlockABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `L1Block`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/abis.ts#L7)
+[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/abis.ts#L7)

--- a/packages/viem/docs/variables/l2ToL2CrossDomainMessengerABI.md
+++ b/packages/viem/docs/variables/l2ToL2CrossDomainMessengerABI.md
@@ -6,10 +6,10 @@
 
 # l2ToL2CrossDomainMessengerABI
 
-> `const` **l2ToL2CrossDomainMessengerABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **l2ToL2CrossDomainMessengerABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `L2ToL2CrossDomainMessenger`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:359](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/abis.ts#L359)
+[packages/viem/src/abis.ts:392](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/abis.ts#L392)

--- a/packages/viem/docs/variables/superchainWETHABI.md
+++ b/packages/viem/docs/variables/superchainWETHABI.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `SuperchainWETH`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:874](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/abis.ts#L874)
+[packages/viem/src/abis.ts:975](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/abis.ts#L975)

--- a/packages/viem/docs/variables/supersimL1.md
+++ b/packages/viem/docs/variables/supersimL1.md
@@ -152,4 +152,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/chains/supersim.ts#L8)
+[packages/viem/src/chains/supersim.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/chains/supersim.ts#L8)

--- a/packages/viem/docs/variables/supersimL2A.md
+++ b/packages/viem/docs/variables/supersimL2A.md
@@ -504,4 +504,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:24](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/chains/supersim.ts#L24)
+[packages/viem/src/chains/supersim.ts:24](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/chains/supersim.ts#L24)

--- a/packages/viem/docs/variables/supersimL2B.md
+++ b/packages/viem/docs/variables/supersimL2B.md
@@ -504,4 +504,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:41](https://github.com/ethereum-optimism/ecosystem/blob/c363acafc2b5c0db021f95b4e5fefe43bbcaf322/packages/viem/src/chains/supersim.ts#L41)
+[packages/viem/src/chains/supersim.ts:41](https://github.com/ethereum-optimism/ecosystem/blob/a6a591d88cd41aa48aa7325dbb668dbe8084e5ee/packages/viem/src/chains/supersim.ts#L41)

--- a/packages/viem/src/abis.ts
+++ b/packages/viem/src/abis.ts
@@ -85,6 +85,32 @@ export const l1BlockABI = [
   },
   {
     type: 'function',
+    name: 'eip1559Denominator',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'eip1559Elasticity',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'gasPayingToken',
     inputs: [],
     outputs: [
@@ -290,6 +316,13 @@ export const l1BlockABI = [
   },
   {
     type: 'function',
+    name: 'setL1BlockValuesHolocene',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
     name: 'timestamp',
     inputs: [],
     outputs: [
@@ -414,32 +447,39 @@ export const l2ToL2CrossDomainMessengerABI = [
     name: 'relayMessage',
     inputs: [
       {
-        name: '_destination',
-        type: 'uint256',
-        internalType: 'uint256',
+        name: '_id',
+        type: 'tuple',
+        internalType: 'struct ICrossL2Inbox.Identifier',
+        components: [
+          {
+            name: 'origin',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'blockNumber',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'logIndex',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'timestamp',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'chainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
       },
       {
-        name: '_source',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: '_nonce',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: '_sender',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: '_target',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
-        name: '_message',
+        name: '_sentMessage',
         type: 'bytes',
         internalType: 'bytes',
       },
@@ -469,7 +509,7 @@ export const l2ToL2CrossDomainMessengerABI = [
     ],
     outputs: [
       {
-        name: 'msgHash_',
+        name: '',
         type: 'bytes32',
         internalType: 'bytes32',
       },
@@ -513,6 +553,18 @@ export const l2ToL2CrossDomainMessengerABI = [
     name: 'FailedRelayedMessage',
     inputs: [
       {
+        name: 'source',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'messageNonce',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
         name: 'messageHash',
         type: 'bytes32',
         indexed: true,
@@ -526,6 +578,18 @@ export const l2ToL2CrossDomainMessengerABI = [
     name: 'RelayedMessage',
     inputs: [
       {
+        name: 'source',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'messageNonce',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
         name: 'messageHash',
         type: 'bytes32',
         indexed: true,
@@ -535,8 +599,50 @@ export const l2ToL2CrossDomainMessengerABI = [
     anonymous: false,
   },
   {
+    type: 'event',
+    name: 'SentMessage',
+    inputs: [
+      {
+        name: 'destination',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'target',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'messageNonce',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'sender',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+      {
+        name: 'message',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
+    anonymous: false,
+  },
+  {
     type: 'error',
-    name: 'CrossL2InboxOriginNotL2ToL2CrossDomainMessenger',
+    name: 'EventPayloadNotSentMessage',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'IdOriginNotL2ToL2CrossDomainMessenger',
     inputs: [],
   },
   {
@@ -572,11 +678,6 @@ export const l2ToL2CrossDomainMessengerABI = [
   {
     type: 'error',
     name: 'ReentrantCall',
-    inputs: [],
-  },
-  {
-    type: 'error',
-    name: 'RelayMessageCallerNotCrossL2Inbox',
     inputs: [],
   },
 ] as const

--- a/packages/viem/src/actions/sendL2ToL2Message.spec.ts
+++ b/packages/viem/src/actions/sendL2ToL2Message.spec.ts
@@ -40,12 +40,11 @@ describe('sendL2ToL2Message', () => {
       expect(id.blockNumber).toEqual(receipt.blockNumber)
       expect(id.logIndex).toEqual(BigInt(receipt.logs[0].logIndex))
 
-      const decodedPayload = decodeSentMessage({ payload })
-      expect(decodedPayload.origin).toEqual(BigInt(supersimL2A.id))
+      const decodedPayload = decodeSentMessage({ logs: receipt.logs })
       expect(decodedPayload.destination).toEqual(BigInt(supersimL2B.id))
       expect(decodedPayload.sender).toEqual(testAccount.address)
       expect(decodedPayload.target).toEqual(ticTacToeAddress)
-      expect(decodedPayload.message).toEqual(encodedMessage)
+      expect(decodedPayload.message).toEqual(payload)
     })
   })
 

--- a/packages/viem/src/utils/decodeSentMessage.ts
+++ b/packages/viem/src/utils/decodeSentMessage.ts
@@ -1,5 +1,5 @@
-import type { Address, Hex } from 'viem'
-import { decodeFunctionData } from 'viem'
+import type { Address, Hex, Log } from 'viem'
+import { parseEventLogs } from 'viem'
 
 import { l2ToL2CrossDomainMessengerABI } from '@/abis.js'
 
@@ -7,19 +7,19 @@ import { l2ToL2CrossDomainMessengerABI } from '@/abis.js'
  * @category Types
  */
 export type DecodeSentMessageParameters = {
-  payload: Hex
+  logs: Log[]
 }
 
 /**
  * @category Types
  */
 export type DecodeSentMessageReturnType = {
-  origin: bigint
   destination: bigint
   messageNonce: bigint
   sender: Address
   target: Address
   message: Hex
+  log: Log
 }
 
 /**
@@ -31,20 +31,21 @@ export type DecodeSentMessageReturnType = {
 export function decodeSentMessage(
   params: DecodeSentMessageParameters,
 ): DecodeSentMessageReturnType {
-  const decodedPayload = decodeFunctionData({
+  const parsedLogs = parseEventLogs({
     abi: l2ToL2CrossDomainMessengerABI,
-    data: params.payload,
+    eventName: 'SentMessage',
+    logs: params.logs,
   })
 
-  const [destination, origin, messageNonce, sender, target, message] =
-    decodedPayload.args
+  const { destination, target, messageNonce, sender, message } =
+    parsedLogs[0].args
 
   return {
-    origin,
     destination,
     messageNonce,
     sender,
     target,
     message,
+    log: parsedLogs[0],
   } as DecodeSentMessageReturnType
 }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The protocol recently updated how it handled `SentMessage` events notable it's just no longer an anonymous event

* Updates `decodeSentMessage` to accept an array of logs instead of the raw hex payload
* `decodeSentMessage` will now return the parsed log so we can generate the message id
* Updates `extractMessageIdentifierFromLog` to call `decodeSentMessage` now internally