### PR TITLE
Wait for supersim to be ready

### DIFF
--- a/packages/viem/.gitignore
+++ b/packages/viem/.gitignore
@@ -1,1 +1,2 @@
 dist
+src/test/*.txt

--- a/packages/viem/src/test/globalSetup.ts
+++ b/packages/viem/src/test/globalSetup.ts
@@ -3,8 +3,14 @@ import { setupTicTacToe } from '@/test/setupTicTacToe.js'
 import { startSupersim } from './startSupersim.js'
 
 async function main() {
-  const shutdown = await startSupersim()
-  await setupTicTacToe()
+  let shutdown
+
+  try {
+    shutdown = await startSupersim()
+    await setupTicTacToe()
+  } catch (e) {
+    process.exit(1)
+  }
 
   return () => {
     shutdown()

--- a/packages/viem/src/test/startSupersim.ts
+++ b/packages/viem/src/test/startSupersim.ts
@@ -1,6 +1,6 @@
+import { spawn } from 'child_process'
 import fs from 'fs'
 import path from 'path'
-import { spawn } from 'child_process'
 
 export type SupersimParameters = {
   l1Port?: number

--- a/packages/viem/src/test/startSupersim.ts
+++ b/packages/viem/src/test/startSupersim.ts
@@ -1,3 +1,5 @@
+import fs from 'fs'
+import path from 'path'
 import { spawn } from 'child_process'
 
 export type SupersimParameters = {
@@ -6,6 +8,10 @@ export type SupersimParameters = {
 }
 
 export type SupersimReturnArg = Promise<() => void>
+
+const READY_TEXT = 'supersim is ready'
+const STD_OUT_PATH = path.resolve(__dirname, './stdout.txt')
+const STD_ERR_PATH = path.resolve(__dirname, './stderr.txt')
 
 export async function startSupersim(
   params?: SupersimParameters,
@@ -20,11 +26,32 @@ export async function startSupersim(
     args.push(` --l2.starting.port ${params.l2StartingPort}`)
   }
 
+  fs.writeFileSync(STD_OUT_PATH, '')
+  fs.writeFileSync(STD_ERR_PATH, '')
+
   const supersimProcess = spawn('supersim', args, { shell: true })
 
-  return () => {
+  const cleanup = () => {
     if (!supersimProcess.killed) {
       supersimProcess.kill()
     }
   }
+
+  return new Promise((resolve, reject) => {
+    supersimProcess.stdout.on('data', (data) => {
+      const blob: string = data.toString()
+
+      fs.appendFileSync(STD_OUT_PATH, blob.replace(/\\n/g, '\n'))
+
+      if (blob.includes(READY_TEXT)) {
+        resolve(cleanup)
+      }
+    })
+
+    supersimProcess.stderr.on('data', (data) => {
+      const blob: string = data.toString()
+      fs.appendFileSync(STD_ERR_PATH, blob.replace(/\\n/g, '\n'))
+      reject(blob)
+    })
+  })
 }


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Updates our supersim viem logic to wait for the blob of text that says it's ready, and adds utility helpers for local development so it generates two texts files `stdout.txt` and `stderr.txt`
