### PR TITLE
feat(viem): add `crossChainSendETH` action

### DIFF
--- a/.changeset/few-clocks-argue.md
+++ b/.changeset/few-clocks-argue.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/viem": patch
+---
+
+add crossChainSendETH action

--- a/packages/viem/docs/README.md
+++ b/packages/viem/docs/README.md
@@ -14,6 +14,7 @@
 
 ## L2 Public Actions
 
+- [simulateCrossChainSendETH](functions/simulateCrossChainSendETH.md)
 - [simulateDepositSuperchainWETH](functions/simulateDepositSuperchainWETH.md)
 - [simulateRelayL2ToL2Message](functions/simulateRelayL2ToL2Message.md)
 - [simulateSendL2ToL2Message](functions/simulateSendL2ToL2Message.md)
@@ -23,7 +24,9 @@
 
 ## L2 Wallet Actions
 
+- [crossChainSendETH](functions/crossChainSendETH.md)
 - [depositSuperchainWETH](functions/depositSuperchainWETH.md)
+- [estimateCrossChainSendETHGas](functions/estimateCrossChainSendETHGas.md)
 - [estimateDepositSuperchainWETHGas](functions/estimateDepositSuperchainWETHGas.md)
 - [estimateRelayL2ToL2MessageGas](functions/estimateRelayL2ToL2MessageGas.md)
 - [estimateSendL2ToL2MessageGas](functions/estimateSendL2ToL2MessageGas.md)
@@ -61,6 +64,9 @@
 
 ## Types
 
+- [CrossChainSendETHContractReturnType](type-aliases/CrossChainSendETHContractReturnType.md)
+- [CrossChainSendETHErrorType](type-aliases/CrossChainSendETHErrorType.md)
+- [CrossChainSendETHParameters](type-aliases/CrossChainSendETHParameters.md)
 - [DepositSuperchainWETHContractReturnType](type-aliases/DepositSuperchainWETHContractReturnType.md)
 - [DepositSuperchainWETHErrorType](type-aliases/DepositSuperchainWETHErrorType.md)
 - [DepositSuperchainWETHParameters](type-aliases/DepositSuperchainWETHParameters.md)

--- a/packages/viem/docs/functions/createInteropMessage.md
+++ b/packages/viem/docs/functions/createInteropMessage.md
@@ -1375,4 +1375,4 @@ created interop message Message
 
 ## Defined in
 
-[packages/viem/src/utils/interop.ts:32](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/interop.ts#L32)
+[packages/viem/src/utils/interop.ts:32](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/interop.ts#L32)

--- a/packages/viem/docs/functions/createInteropSentL2ToL2Messages.md
+++ b/packages/viem/docs/functions/createInteropSentL2ToL2Messages.md
@@ -1375,4 +1375,4 @@ Decoded interop messages [CreateInteropSentL2ToL2MessagesReturnType](../type-ali
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:60](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L60)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:60](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L60)

--- a/packages/viem/docs/functions/crossChainSendETH.md
+++ b/packages/viem/docs/functions/crossChainSendETH.md
@@ -1,0 +1,39 @@
+[**@eth-optimism/viem**](../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../README.md) / crossChainSendETH
+
+# crossChainSendETH()
+
+> **crossChainSendETH**\<`chain`, `account`, `chainOverride`\>(`client`, `parameters`): `Promise`\<[`CrossChainSendETHContractReturnType`](../type-aliases/CrossChainSendETHContractReturnType.md)\>
+
+Sends ETH to the specified recipient on the destination chain
+
+## Type Parameters
+
+• **chain** *extends* `undefined` \| `Chain`
+
+• **account** *extends* `undefined` \| `Account`
+
+• **chainOverride** *extends* `undefined` \| `Chain` = `undefined`
+
+## Parameters
+
+• **client**: `Client`\<`Transport`, `chain`, `account`\>
+
+L2 Wallet Client
+
+• **parameters**: [`CrossChainSendETHParameters`](../type-aliases/CrossChainSendETHParameters.md)\<`chain`, `account`, `chainOverride`, `DeriveChain`\<`chain`, `chainOverride`\>\>
+
+[CrossChainSendETHParameters](../type-aliases/CrossChainSendETHParameters.md)
+
+## Returns
+
+`Promise`\<[`CrossChainSendETHContractReturnType`](../type-aliases/CrossChainSendETHContractReturnType.md)\>
+
+The crosschainSendETH transaction hash. [CrossChainSendETHContractReturnType](../type-aliases/CrossChainSendETHContractReturnType.md)
+
+## Defined in
+
+[packages/viem/src/actions/crosschainSendETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/crosschainSendETH.ts#L67)

--- a/packages/viem/docs/functions/decodeExecutingMessages.md
+++ b/packages/viem/docs/functions/decodeExecutingMessages.md
@@ -24,4 +24,4 @@ Decoded cross-chain calls [DecodeExecutingMessagesReturnType](../type-aliases/De
 
 ## Defined in
 
-[packages/viem/src/utils/interop.ts:66](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/interop.ts#L66)
+[packages/viem/src/utils/interop.ts:66](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/interop.ts#L66)

--- a/packages/viem/docs/functions/decodeRelayedL2ToL2Messages.md
+++ b/packages/viem/docs/functions/decodeRelayedL2ToL2Messages.md
@@ -24,4 +24,4 @@ Identified relayed messages [DecodeRelayedL2ToL2MessagesReturnType](../type-alia
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L106)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L106)

--- a/packages/viem/docs/functions/decodeSentL2ToL2Messages.md
+++ b/packages/viem/docs/functions/decodeSentL2ToL2Messages.md
@@ -24,4 +24,4 @@ Decoded cross-chain calls [DecodeSentL2ToL2MessagesReturnType](../type-aliases/D
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:85](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L85)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:85](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L85)

--- a/packages/viem/docs/functions/depositSuperchainWETH.md
+++ b/packages/viem/docs/functions/depositSuperchainWETH.md
@@ -36,4 +36,4 @@ The depositSuperchainWETH transaction hash. [DepositSuperchainWETHReturnType](..
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:64](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L64)
+[packages/viem/src/actions/depositSuperchainWETH.ts:64](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L64)

--- a/packages/viem/docs/functions/estimateCrossChainSendETHGas.md
+++ b/packages/viem/docs/functions/estimateCrossChainSendETHGas.md
@@ -1,0 +1,39 @@
+[**@eth-optimism/viem**](../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../README.md) / estimateCrossChainSendETHGas
+
+# estimateCrossChainSendETHGas()
+
+> **estimateCrossChainSendETHGas**\<`TChain`, `TAccount`, `TChainOverride`\>(`client`, `parameters`): `Promise`\<`bigint`\>
+
+Estimates gas for [crossChainSendETH](crossChainSendETH.md)
+
+## Type Parameters
+
+• **TChain** *extends* `undefined` \| `Chain`
+
+• **TAccount** *extends* `undefined` \| `Account`
+
+• **TChainOverride** *extends* `undefined` \| `Chain` = `undefined`
+
+## Parameters
+
+• **client**: `Client`\<`Transport`, `TChain`, `TAccount`\>
+
+L2 Wallet Client
+
+• **parameters**: [`CrossChainSendETHParameters`](../type-aliases/CrossChainSendETHParameters.md)\<`TChain`, `TAccount`, `TChainOverride`, `DeriveChain`\<`TChain`, `TChainOverride`\>\>
+
+[CrossChainSendETHParameters](../type-aliases/CrossChainSendETHParameters.md)
+
+## Returns
+
+`Promise`\<`bigint`\>
+
+The estimated gas value.
+
+## Defined in
+
+[packages/viem/src/actions/crosschainSendETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/crosschainSendETH.ts#L96)

--- a/packages/viem/docs/functions/estimateDepositSuperchainWETHGas.md
+++ b/packages/viem/docs/functions/estimateDepositSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:91](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L91)
+[packages/viem/src/actions/depositSuperchainWETH.ts:91](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L91)

--- a/packages/viem/docs/functions/estimateRelayL2ToL2MessageGas.md
+++ b/packages/viem/docs/functions/estimateRelayL2ToL2MessageGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:103](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L103)
+[packages/viem/src/actions/relayL2ToL2Message.ts:103](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L103)

--- a/packages/viem/docs/functions/estimateSendL2ToL2MessageGas.md
+++ b/packages/viem/docs/functions/estimateSendL2ToL2MessageGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:105](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L105)
+[packages/viem/src/actions/sendL2ToL2Message.ts:105](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L105)

--- a/packages/viem/docs/functions/estimateSendSupERC20Gas.md
+++ b/packages/viem/docs/functions/estimateSendSupERC20Gas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L106)
+[packages/viem/src/actions/sendSupERC20.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L106)

--- a/packages/viem/docs/functions/estimateSendSuperchainWETHGas.md
+++ b/packages/viem/docs/functions/estimateSendSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/sendSuperchainWETH.ts:74](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSuperchainWETH.ts#L74)
+[packages/viem/src/actions/sendSuperchainWETH.ts:74](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSuperchainWETH.ts#L74)

--- a/packages/viem/docs/functions/estimateWithdrawSuperchainWETHGas.md
+++ b/packages/viem/docs/functions/estimateWithdrawSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L96)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L96)

--- a/packages/viem/docs/functions/relayL2ToL2Message.md
+++ b/packages/viem/docs/functions/relayL2ToL2Message.md
@@ -36,4 +36,4 @@ The relayMessage transaction hash. [RelayL2ToL2MessageReturnType](../type-aliase
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:74](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L74)
+[packages/viem/src/actions/relayL2ToL2Message.ts:74](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L74)

--- a/packages/viem/docs/functions/sendL2ToL2Message.md
+++ b/packages/viem/docs/functions/sendL2ToL2Message.md
@@ -36,4 +36,4 @@ The sendL2ToL2Message transaction hash. [SendL2ToL2MessageReturnType](../type-al
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:76](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L76)
+[packages/viem/src/actions/sendL2ToL2Message.ts:76](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L76)

--- a/packages/viem/docs/functions/sendSupERC20.md
+++ b/packages/viem/docs/functions/sendSupERC20.md
@@ -36,4 +36,4 @@ The sendSupERC20 transaction hash. [SendSupERC20ReturnType](../type-aliases/Send
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L77)
+[packages/viem/src/actions/sendSupERC20.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L77)

--- a/packages/viem/docs/functions/sendSuperchainWETH.md
+++ b/packages/viem/docs/functions/sendSuperchainWETH.md
@@ -36,4 +36,4 @@ The sendSuperchainWETH transaction hash. [SendSupERC20ReturnType](../type-aliase
 
 ## Defined in
 
-[packages/viem/src/actions/sendSuperchainWETH.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSuperchainWETH.ts#L53)
+[packages/viem/src/actions/sendSuperchainWETH.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSuperchainWETH.ts#L53)

--- a/packages/viem/docs/functions/simulateCrossChainSendETH.md
+++ b/packages/viem/docs/functions/simulateCrossChainSendETH.md
@@ -1,0 +1,39 @@
+[**@eth-optimism/viem**](../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../README.md) / simulateCrossChainSendETH
+
+# simulateCrossChainSendETH()
+
+> **simulateCrossChainSendETH**\<`TChain`, `TAccount`, `TChainOverride`\>(`client`, `parameters`): `Promise`\<[`CrossChainSendETHContractReturnType`](../type-aliases/CrossChainSendETHContractReturnType.md)\>
+
+Simulate contract call for [crossChainSendETH](crossChainSendETH.md)
+
+## Type Parameters
+
+• **TChain** *extends* `undefined` \| `Chain`
+
+• **TAccount** *extends* `undefined` \| `Account`
+
+• **TChainOverride** *extends* `undefined` \| `Chain` = `undefined`
+
+## Parameters
+
+• **client**: `Client`\<`Transport`, `TChain`, `TAccount`\>
+
+L2 Public Client
+
+• **parameters**: [`CrossChainSendETHParameters`](../type-aliases/CrossChainSendETHParameters.md)\<`TChain`, `TAccount`, `TChainOverride`, `DeriveChain`\<`TChain`, `TChainOverride`\>\>
+
+[CrossChainSendETHParameters](../type-aliases/CrossChainSendETHParameters.md)
+
+## Returns
+
+`Promise`\<[`CrossChainSendETHContractReturnType`](../type-aliases/CrossChainSendETHContractReturnType.md)\>
+
+The contract functions return value. [CrossChainSendETHContractReturnType](../type-aliases/CrossChainSendETHContractReturnType.md)
+
+## Defined in
+
+[packages/viem/src/actions/crosschainSendETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/crosschainSendETH.ts#L122)

--- a/packages/viem/docs/functions/simulateDepositSuperchainWETH.md
+++ b/packages/viem/docs/functions/simulateDepositSuperchainWETH.md
@@ -36,4 +36,4 @@ The contract functions return value. depositSuperchainWETHContractReturnType
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:115](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L115)
+[packages/viem/src/actions/depositSuperchainWETH.ts:115](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L115)

--- a/packages/viem/docs/functions/simulateRelayL2ToL2Message.md
+++ b/packages/viem/docs/functions/simulateRelayL2ToL2Message.md
@@ -36,4 +36,4 @@ The contract functions return value. [RelayL2ToL2MessageContractReturnType](../t
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:129](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L129)
+[packages/viem/src/actions/relayL2ToL2Message.ts:129](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L129)

--- a/packages/viem/docs/functions/simulateSendL2ToL2Message.md
+++ b/packages/viem/docs/functions/simulateSendL2ToL2Message.md
@@ -36,4 +36,4 @@ The contract functions return value. [SendL2ToL2MessageContractReturnType](../ty
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L131)
+[packages/viem/src/actions/sendL2ToL2Message.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L131)

--- a/packages/viem/docs/functions/simulateSendSupERC20.md
+++ b/packages/viem/docs/functions/simulateSendSupERC20.md
@@ -36,4 +36,4 @@ The contract functions return value. [SendSupERC20ContractReturnType](../type-al
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:132](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L132)
+[packages/viem/src/actions/sendSupERC20.ts:132](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L132)

--- a/packages/viem/docs/functions/simulateSendSuperchainWETH.md
+++ b/packages/viem/docs/functions/simulateSendSuperchainWETH.md
@@ -36,4 +36,4 @@ The contract functions return value. [SendSupERC20ContractReturnType](../type-al
 
 ## Defined in
 
-[packages/viem/src/actions/sendSuperchainWETH.ts:95](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSuperchainWETH.ts#L95)
+[packages/viem/src/actions/sendSuperchainWETH.ts:95](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSuperchainWETH.ts#L95)

--- a/packages/viem/docs/functions/simulateWithdrawSuperchainWETH.md
+++ b/packages/viem/docs/functions/simulateWithdrawSuperchainWETH.md
@@ -36,4 +36,4 @@ The contract functions return value. withdrawSuperchainWETHContractReturnType
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:126](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L126)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:126](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L126)

--- a/packages/viem/docs/functions/withdrawSuperchainWETH.md
+++ b/packages/viem/docs/functions/withdrawSuperchainWETH.md
@@ -36,4 +36,4 @@ The withdrawSuperchainWETH transaction hash. [WithdrawSuperchainWETHReturnType](
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L67)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L67)

--- a/packages/viem/docs/type-aliases/CreateInteropMessageParameters.md
+++ b/packages/viem/docs/type-aliases/CreateInteropMessageParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/interop.ts:15](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/interop.ts#L15)
+[packages/viem/src/utils/interop.ts:15](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/interop.ts#L15)

--- a/packages/viem/docs/type-aliases/CreateInteropMessageReturnType.md
+++ b/packages/viem/docs/type-aliases/CreateInteropMessageReturnType.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/interop.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/interop.ts#L16)
+[packages/viem/src/utils/interop.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/interop.ts#L16)

--- a/packages/viem/docs/type-aliases/CreateInteropSentL2ToL2MessagesParameters.md
+++ b/packages/viem/docs/type-aliases/CreateInteropSentL2ToL2MessagesParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:24](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L24)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:24](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L24)

--- a/packages/viem/docs/type-aliases/CreateInteropSentL2ToL2MessagesReturnType.md
+++ b/packages/viem/docs/type-aliases/CreateInteropSentL2ToL2MessagesReturnType.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L27)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L27)

--- a/packages/viem/docs/type-aliases/CrossChainSendETHContractReturnType.md
+++ b/packages/viem/docs/type-aliases/CrossChainSendETHContractReturnType.md
@@ -1,0 +1,13 @@
+[**@eth-optimism/viem**](../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../README.md) / CrossChainSendETHContractReturnType
+
+# CrossChainSendETHContractReturnType
+
+> **CrossChainSendETHContractReturnType**: `ContractFunctionReturnType`\<*typeof* [`superchainWETHABI`](../variables/superchainWETHABI.md), `"payable"`, `"sendETH"`\>
+
+## Defined in
+
+[packages/viem/src/actions/crosschainSendETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/crosschainSendETH.ts#L46)

--- a/packages/viem/docs/type-aliases/CrossChainSendETHErrorType.md
+++ b/packages/viem/docs/type-aliases/CrossChainSendETHErrorType.md
@@ -1,0 +1,13 @@
+[**@eth-optimism/viem**](../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../README.md) / CrossChainSendETHErrorType
+
+# CrossChainSendETHErrorType
+
+> **CrossChainSendETHErrorType**: `EstimateContractGasErrorType` \| `WriteContractErrorType` \| `ErrorType`
+
+## Defined in
+
+[packages/viem/src/actions/crosschainSendETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/crosschainSendETH.ts#L55)

--- a/packages/viem/docs/type-aliases/CrossChainSendETHParameters.md
+++ b/packages/viem/docs/type-aliases/CrossChainSendETHParameters.md
@@ -1,0 +1,37 @@
+[**@eth-optimism/viem**](../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../README.md) / CrossChainSendETHParameters
+
+# CrossChainSendETHParameters\<TChain, TAccount, TChainOverride, TDerivedChain\>
+
+> **CrossChainSendETHParameters**\<`TChain`, `TAccount`, `TChainOverride`, `TDerivedChain`\>: `BaseWriteContractActionParameters`\<`TChain`, `TAccount`, `TChainOverride`, `TDerivedChain`\> & `object`
+
+## Type declaration
+
+### chainId
+
+> **chainId**: `number`
+
+Chain ID of the destination chain.
+
+### to
+
+> **to**: `Address`
+
+Address to send ETH to.
+
+## Type Parameters
+
+• **TChain** *extends* `Chain` \| `undefined` = `Chain` \| `undefined`
+
+• **TAccount** *extends* `Account` \| `undefined` = `Account` \| `undefined`
+
+• **TChainOverride** *extends* `Chain` \| `undefined` = `Chain` \| `undefined`
+
+• **TDerivedChain** *extends* `Chain` \| `undefined` = `DeriveChain`\<`TChain`, `TChainOverride`\>
+
+## Defined in
+
+[packages/viem/src/actions/crosschainSendETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/crosschainSendETH.ts#L26)

--- a/packages/viem/docs/type-aliases/DecodeExecutingMessagesParameters.md
+++ b/packages/viem/docs/type-aliases/DecodeExecutingMessagesParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/interop.ts:21](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/interop.ts#L21)
+[packages/viem/src/utils/interop.ts:21](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/interop.ts#L21)

--- a/packages/viem/docs/type-aliases/DecodeExecutingMessagesReturnType.md
+++ b/packages/viem/docs/type-aliases/DecodeExecutingMessagesReturnType.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/interop.ts:22](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/interop.ts#L22)
+[packages/viem/src/utils/interop.ts:22](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/interop.ts#L22)

--- a/packages/viem/docs/type-aliases/DecodeRelayedL2ToL2MessagesParameters.md
+++ b/packages/viem/docs/type-aliases/DecodeRelayedL2ToL2MessagesParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:43](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L43)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:43](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L43)

--- a/packages/viem/docs/type-aliases/DecodeRelayedL2ToL2MessagesReturnType.md
+++ b/packages/viem/docs/type-aliases/DecodeRelayedL2ToL2MessagesReturnType.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L46)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L46)

--- a/packages/viem/docs/type-aliases/DecodeSentL2ToL2MessagesParameters.md
+++ b/packages/viem/docs/type-aliases/DecodeSentL2ToL2MessagesParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:31](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L31)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:31](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L31)

--- a/packages/viem/docs/type-aliases/DecodeSentL2ToL2MessagesReturnType.md
+++ b/packages/viem/docs/type-aliases/DecodeSentL2ToL2MessagesReturnType.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:32](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L32)
+[packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts:32](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/utils/l2ToL2CrossDomainMessenger.ts#L32)

--- a/packages/viem/docs/type-aliases/DepositSuperchainWETHContractReturnType.md
+++ b/packages/viem/docs/type-aliases/DepositSuperchainWETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L46)
+[packages/viem/src/actions/depositSuperchainWETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L46)

--- a/packages/viem/docs/type-aliases/DepositSuperchainWETHErrorType.md
+++ b/packages/viem/docs/type-aliases/DepositSuperchainWETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:52](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L52)
+[packages/viem/src/actions/depositSuperchainWETH.ts:52](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L52)

--- a/packages/viem/docs/type-aliases/DepositSuperchainWETHParameters.md
+++ b/packages/viem/docs/type-aliases/DepositSuperchainWETHParameters.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L26)
+[packages/viem/src/actions/depositSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L26)

--- a/packages/viem/docs/type-aliases/DepositSuperchainWETHReturnType.md
+++ b/packages/viem/docs/type-aliases/DepositSuperchainWETHReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/depositSuperchainWETH.ts:41](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/depositSuperchainWETH.ts#L41)
+[packages/viem/src/actions/depositSuperchainWETH.ts:41](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/depositSuperchainWETH.ts#L41)

--- a/packages/viem/docs/type-aliases/MessageIdentifier.md
+++ b/packages/viem/docs/type-aliases/MessageIdentifier.md
@@ -44,4 +44,4 @@ The timestamp that the log was emitted. Used to enforce the timestamp invariant
 
 ## Defined in
 
-[packages/viem/src/types/interop.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/types/interop.ts#L7)
+[packages/viem/src/types/interop.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/types/interop.ts#L7)

--- a/packages/viem/docs/type-aliases/RelayL2ToL2MessageContractReturnType.md
+++ b/packages/viem/docs/type-aliases/RelayL2ToL2MessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L53)
+[packages/viem/src/actions/relayL2ToL2Message.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L53)

--- a/packages/viem/docs/type-aliases/RelayL2ToL2MessageErrorType.md
+++ b/packages/viem/docs/type-aliases/RelayL2ToL2MessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:62](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L62)
+[packages/viem/src/actions/relayL2ToL2Message.ts:62](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L62)

--- a/packages/viem/docs/type-aliases/RelayL2ToL2MessageParameters.md
+++ b/packages/viem/docs/type-aliases/RelayL2ToL2MessageParameters.md
@@ -34,4 +34,4 @@ MessagePayload of the SentMessage event *
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L28)
+[packages/viem/src/actions/relayL2ToL2Message.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L28)

--- a/packages/viem/docs/type-aliases/RelayL2ToL2MessageReturnType.md
+++ b/packages/viem/docs/type-aliases/RelayL2ToL2MessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/relayL2ToL2Message.ts:48](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/relayL2ToL2Message.ts#L48)
+[packages/viem/src/actions/relayL2ToL2Message.ts:48](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/relayL2ToL2Message.ts#L48)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageContractReturnType.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L55)
+[packages/viem/src/actions/sendL2ToL2Message.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L55)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageErrorType.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:64](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L64)
+[packages/viem/src/actions/sendL2ToL2Message.ts:64](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L64)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageParameters.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageParameters.md
@@ -40,4 +40,4 @@ Target contract or wallet address.
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L28)
+[packages/viem/src/actions/sendL2ToL2Message.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L28)

--- a/packages/viem/docs/type-aliases/SendL2ToL2MessageReturnType.md
+++ b/packages/viem/docs/type-aliases/SendL2ToL2MessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendL2ToL2Message.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendL2ToL2Message.ts#L50)
+[packages/viem/src/actions/sendL2ToL2Message.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendL2ToL2Message.ts#L50)

--- a/packages/viem/docs/type-aliases/SendSupERC20ContractReturnType.md
+++ b/packages/viem/docs/type-aliases/SendSupERC20ContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L56)
+[packages/viem/src/actions/sendSupERC20.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L56)

--- a/packages/viem/docs/type-aliases/SendSupERC20ErrorType.md
+++ b/packages/viem/docs/type-aliases/SendSupERC20ErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L65)
+[packages/viem/src/actions/sendSupERC20.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L65)

--- a/packages/viem/docs/type-aliases/SendSupERC20Parameters.md
+++ b/packages/viem/docs/type-aliases/SendSupERC20Parameters.md
@@ -46,4 +46,4 @@ Token to send.
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L27)
+[packages/viem/src/actions/sendSupERC20.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L27)

--- a/packages/viem/docs/type-aliases/SendSupERC20ReturnType.md
+++ b/packages/viem/docs/type-aliases/SendSupERC20ReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/sendSupERC20.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSupERC20.ts#L51)
+[packages/viem/src/actions/sendSupERC20.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSupERC20.ts#L51)

--- a/packages/viem/docs/type-aliases/SendSuperchainWETHParameters.md
+++ b/packages/viem/docs/type-aliases/SendSuperchainWETHParameters.md
@@ -40,4 +40,4 @@ Address to send tokens to.
 
 ## Defined in
 
-[packages/viem/src/actions/sendSuperchainWETH.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/sendSuperchainWETH.ts#L27)
+[packages/viem/src/actions/sendSuperchainWETH.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/sendSuperchainWETH.ts#L27)

--- a/packages/viem/docs/type-aliases/WithdrawSuperchainWETHContractReturnType.md
+++ b/packages/viem/docs/type-aliases/WithdrawSuperchainWETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:49](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L49)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:49](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L49)

--- a/packages/viem/docs/type-aliases/WithdrawSuperchainWETHErrorType.md
+++ b/packages/viem/docs/type-aliases/WithdrawSuperchainWETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L55)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L55)

--- a/packages/viem/docs/type-aliases/WithdrawSuperchainWETHParameters.md
+++ b/packages/viem/docs/type-aliases/WithdrawSuperchainWETHParameters.md
@@ -28,4 +28,4 @@ Amount of SuperchainWETH to withdraw.
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L26)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L26)

--- a/packages/viem/docs/type-aliases/WithdrawSuperchainWETHReturnType.md
+++ b/packages/viem/docs/type-aliases/WithdrawSuperchainWETHReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/withdrawSuperchainWETH.ts:44](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/actions/withdrawSuperchainWETH.ts#L44)
+[packages/viem/src/actions/withdrawSuperchainWETH.ts:44](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/actions/withdrawSuperchainWETH.ts#L44)

--- a/packages/viem/docs/variables/contracts.md
+++ b/packages/viem/docs/variables/contracts.md
@@ -94,4 +94,4 @@ OP Stack Predeploy Addresses
 
 ## Defined in
 
-[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/contracts.ts#L8)
+[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/contracts.ts#L8)

--- a/packages/viem/docs/variables/crossL2InboxABI.md
+++ b/packages/viem/docs/variables/crossL2InboxABI.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `CrossL2Inbox`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/abis.ts#L7)
+[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/abis.ts#L7)

--- a/packages/viem/docs/variables/l2ToL2CrossDomainMessengerABI.md
+++ b/packages/viem/docs/variables/l2ToL2CrossDomainMessengerABI.md
@@ -6,10 +6,10 @@
 
 # l2ToL2CrossDomainMessengerABI
 
-> `const` **l2ToL2CrossDomainMessengerABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **l2ToL2CrossDomainMessengerABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `L2ToL2CrossDomainMessenger`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:293](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/abis.ts#L293)
+[packages/viem/src/abis.ts:293](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/abis.ts#L293)

--- a/packages/viem/docs/variables/superchainERC20ABI.md
+++ b/packages/viem/docs/variables/superchainERC20ABI.md
@@ -6,10 +6,10 @@
 
 # superchainERC20ABI
 
-> `const` **superchainERC20ABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **superchainERC20ABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `SuperchainERC20`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:980](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/abis.ts#L980)
+[packages/viem/src/abis.ts:1135](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/abis.ts#L1135)

--- a/packages/viem/docs/variables/superchainTokenBridgeABI.md
+++ b/packages/viem/docs/variables/superchainTokenBridgeABI.md
@@ -6,10 +6,10 @@
 
 # superchainTokenBridgeABI
 
-> `const` **superchainTokenBridgeABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **superchainTokenBridgeABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `SuperchainTokenBridge`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:1411](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/abis.ts#L1411)
+[packages/viem/src/abis.ts:1602](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/abis.ts#L1602)

--- a/packages/viem/docs/variables/superchainWETHABI.md
+++ b/packages/viem/docs/variables/superchainWETHABI.md
@@ -6,10 +6,10 @@
 
 # superchainWETHABI
 
-> `const` **superchainWETHABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **superchainWETHABI**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `SuperchainWETH`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:588](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/abis.ts#L588)
+[packages/viem/src/abis.ts:593](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/abis.ts#L593)

--- a/packages/viem/docs/variables/supersimL1.md
+++ b/packages/viem/docs/variables/supersimL1.md
@@ -152,4 +152,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/chains/supersim.ts#L8)
+[packages/viem/src/chains/supersim.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/chains/supersim.ts#L8)

--- a/packages/viem/docs/variables/supersimL2A.md
+++ b/packages/viem/docs/variables/supersimL2A.md
@@ -504,4 +504,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:24](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/chains/supersim.ts#L24)
+[packages/viem/src/chains/supersim.ts:24](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/chains/supersim.ts#L24)

--- a/packages/viem/docs/variables/supersimL2B.md
+++ b/packages/viem/docs/variables/supersimL2B.md
@@ -504,4 +504,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:41](https://github.com/ethereum-optimism/ecosystem/blob/5b57c542e6f02774701a464de238b830e81b7ecb/packages/viem/src/chains/supersim.ts#L41)
+[packages/viem/src/chains/supersim.ts:41](https://github.com/ethereum-optimism/ecosystem/blob/1d855f26d1024617b154d28d909dbc33a421f5de/packages/viem/src/chains/supersim.ts#L41)

--- a/packages/viem/src/abis.ts
+++ b/packages/viem/src/abis.ts
@@ -38,7 +38,7 @@ export const crossL2InboxABI = [
       {
         name: '_id',
         type: 'tuple',
-        internalType: 'struct ICrossL2Inbox.Identifier',
+        internalType: 'struct Identifier',
         components: [
           {
             name: 'origin',
@@ -147,7 +147,7 @@ export const crossL2InboxABI = [
       {
         name: '_id',
         type: 'tuple',
-        internalType: 'struct ICrossL2Inbox.Identifier',
+        internalType: 'struct Identifier',
         components: [
           {
             name: 'origin',
@@ -212,7 +212,7 @@ export const crossL2InboxABI = [
         name: 'id',
         type: 'tuple',
         indexed: false,
-        internalType: 'struct ICrossL2Inbox.Identifier',
+        internalType: 'struct Identifier',
         components: [
           {
             name: 'origin',
@@ -368,7 +368,7 @@ export const l2ToL2CrossDomainMessengerABI = [
       {
         name: '_id',
         type: 'tuple',
-        internalType: 'struct ICrossL2Inbox.Identifier',
+        internalType: 'struct Identifier',
         components: [
           {
             name: 'origin',
@@ -541,6 +541,11 @@ export const l2ToL2CrossDomainMessengerABI = [
   },
   {
     type: 'error',
+    name: 'InvalidChainId',
+    inputs: [],
+  },
+  {
+    type: 'error',
     name: 'MessageAlreadyRelayed',
     inputs: [],
   },
@@ -599,12 +604,12 @@ export const superchainWETHABI = [
     name: 'allowance',
     inputs: [
       {
-        name: '',
+        name: 'owner',
         type: 'address',
         internalType: 'address',
       },
       {
-        name: '',
+        name: 'spender',
         type: 'address',
         internalType: 'address',
       },
@@ -647,7 +652,7 @@ export const superchainWETHABI = [
     name: 'balanceOf',
     inputs: [
       {
-        name: '',
+        name: 'src',
         type: 'address',
         internalType: 'address',
       },
@@ -726,6 +731,72 @@ export const superchainWETHABI = [
         name: '',
         type: 'string',
         internalType: 'string',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'relayETH',
+    inputs: [
+      {
+        name: '_from',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'sendETH',
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_chainId',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'msgHash_',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'supportsInterface',
+    inputs: [
+      {
+        name: '_interfaceId',
+        type: 'bytes4',
+        internalType: 'bytes4',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
       },
     ],
     stateMutability: 'view',
@@ -862,7 +933,7 @@ export const superchainWETHABI = [
   },
   {
     type: 'event',
-    name: 'CrosschainBurnt',
+    name: 'CrosschainBurn',
     inputs: [
       {
         name: 'from',
@@ -876,12 +947,18 @@ export const superchainWETHABI = [
         indexed: false,
         internalType: 'uint256',
       },
+      {
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
     anonymous: false,
   },
   {
     type: 'event',
-    name: 'CrosschainMinted',
+    name: 'CrosschainMint',
     inputs: [
       {
         name: 'to',
@@ -894,6 +971,12 @@ export const superchainWETHABI = [
         type: 'uint256',
         indexed: false,
         internalType: 'uint256',
+      },
+      {
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
     ],
     anonymous: false,
@@ -910,6 +993,68 @@ export const superchainWETHABI = [
       },
       {
         name: 'wad',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'RelayETH',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'source',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'SendETH',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
+        name: 'destination',
         type: 'uint256',
         indexed: false,
         internalType: 'uint256',
@@ -963,12 +1108,22 @@ export const superchainWETHABI = [
   },
   {
     type: 'error',
+    name: 'InvalidCrossDomainSender',
+    inputs: [],
+  },
+  {
+    type: 'error',
     name: 'NotCustomGasToken',
     inputs: [],
   },
   {
     type: 'error',
     name: 'Unauthorized',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ZeroAddress',
     inputs: [],
   },
 ] as const
@@ -1184,6 +1339,25 @@ export const superchainERC20ABI = [
   },
   {
     type: 'function',
+    name: 'supportsInterface',
+    inputs: [
+      {
+        name: '_interfaceId',
+        type: 'bytes4',
+        internalType: 'bytes4',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'symbol',
     inputs: [],
     outputs: [
@@ -1301,7 +1475,7 @@ export const superchainERC20ABI = [
   },
   {
     type: 'event',
-    name: 'CrosschainBurnt',
+    name: 'CrosschainBurn',
     inputs: [
       {
         name: 'from',
@@ -1315,12 +1489,18 @@ export const superchainERC20ABI = [
         indexed: false,
         internalType: 'uint256',
       },
+      {
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
     ],
     anonymous: false,
   },
   {
     type: 'event',
-    name: 'CrosschainMinted',
+    name: 'CrosschainMint',
     inputs: [
       {
         name: 'to',
@@ -1333,6 +1513,12 @@ export const superchainERC20ABI = [
         type: 'uint256',
         indexed: false,
         internalType: 'uint256',
+      },
+      {
+        name: 'sender',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
       },
     ],
     anonymous: false,
@@ -1385,6 +1571,11 @@ export const superchainERC20ABI = [
   {
     type: 'error',
     name: 'InvalidPermit',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Permit2AllowanceIsFixedAtInfinity',
     inputs: [],
   },
   {
@@ -1561,6 +1752,11 @@ export const superchainTokenBridgeABI = [
   {
     type: 'error',
     name: 'InvalidCrossDomainSender',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InvalidERC7802',
     inputs: [],
   },
   {

--- a/packages/viem/src/actions/crosschainSendETH.spec.ts
+++ b/packages/viem/src/actions/crosschainSendETH.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { supersimL2B } from '@/chains/supersim.js'
+import { publicClientA, testAccount, walletClientA } from '@/test/clients.js'
+import { createInteropSentL2ToL2Messages } from '@/utils/l2ToL2CrossDomainMessenger.js'
+
+const AMOUNT_TO_SEND = 10n
+
+describe('crossChainSendETH', () => {
+  describe('write contract', () => {
+    it('should return expected request', async () => {
+      const startingBalance = await publicClientA.getBalance({
+        address: testAccount.address,
+      })
+
+      const hash = await walletClientA.crossChainSendETH({
+        to: testAccount.address,
+        value: AMOUNT_TO_SEND,
+        chainId: supersimL2B.id,
+      })
+
+      const receipt = await publicClientA.waitForTransactionReceipt({ hash })
+
+      const { sentMessages } = await createInteropSentL2ToL2Messages(
+        publicClientA,
+        { receipt },
+      )
+      expect(sentMessages).toHaveLength(1)
+
+      const gasPaid = receipt.gasUsed * receipt.effectiveGasPrice
+      const endingBalance = await publicClientA.getBalance({
+        address: testAccount.address,
+      })
+
+      expect(endingBalance).toEqual(startingBalance - AMOUNT_TO_SEND - gasPaid)
+    })
+  })
+
+  describe('estimate gas', () => {
+    it('should estimate gas', async () => {
+      const gas = await publicClientA.estimateCrossChainSendETHGas({
+        account: testAccount.address,
+        to: testAccount.address,
+        value: AMOUNT_TO_SEND,
+        chainId: supersimL2B.id,
+      })
+
+      expect(gas).toBeDefined()
+    })
+  })
+
+  describe('simulate', () => {
+    it('should simulate', async () => {
+      expect(() =>
+        publicClientA.simulateCrossChainSendETH({
+          account: testAccount.address,
+          to: testAccount.address,
+          value: AMOUNT_TO_SEND,
+          chainId: supersimL2B.id,
+        }),
+      ).not.throw()
+    })
+  })
+})

--- a/packages/viem/src/actions/crosschainSendETH.ts
+++ b/packages/viem/src/actions/crosschainSendETH.ts
@@ -1,0 +1,143 @@
+/** @module crosschainSendETH */
+import type {
+  Account,
+  Address,
+  Chain,
+  Client,
+  ContractFunctionReturnType,
+  DeriveChain,
+  EstimateContractGasErrorType,
+  EstimateContractGasParameters,
+  SimulateContractParameters,
+  Transport,
+  WriteContractErrorType,
+} from 'viem'
+import { estimateContractGas, simulateContract } from 'viem/actions'
+
+import { superchainWETHABI } from '@/abis.js'
+import { contracts } from '@/contracts.js'
+import type { BaseWriteContractActionParameters } from '@/core/baseWriteAction.js'
+import { baseWriteAction } from '@/core/baseWriteAction.js'
+import type { ErrorType } from '@/types/utils.js'
+
+/**
+ * @category Types
+ */
+export type CrossChainSendETHParameters<
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends Account | undefined = Account | undefined,
+  TChainOverride extends Chain | undefined = Chain | undefined,
+  TDerivedChain extends Chain | undefined = DeriveChain<TChain, TChainOverride>,
+> = BaseWriteContractActionParameters<
+  TChain,
+  TAccount,
+  TChainOverride,
+  TDerivedChain
+> & {
+  /** Address to send ETH to. */
+  to: Address
+  /** Chain ID of the destination chain. */
+  chainId: number
+}
+
+/**
+ * @category Types
+ */
+export type CrossChainSendETHContractReturnType = ContractFunctionReturnType<
+  typeof superchainWETHABI,
+  'payable',
+  'sendETH'
+>
+
+/**
+ * @category Types
+ */
+export type CrossChainSendETHErrorType =
+  | EstimateContractGasErrorType
+  | WriteContractErrorType
+  | ErrorType
+
+/**
+ * Sends ETH to the specified recipient on the destination chain
+ * @category L2 Wallet Actions
+ * @param client - L2 Wallet Client
+ * @param parameters - {@link CrossChainSendETHParameters}
+ * @returns The crosschainSendETH transaction hash. {@link CrossChainSendETHContractReturnType}
+ */
+export async function crossChainSendETH<
+  chain extends Chain | undefined,
+  account extends Account | undefined,
+  chainOverride extends Chain | undefined = undefined,
+>(
+  client: Client<Transport, chain, account>,
+  parameters: CrossChainSendETHParameters<chain, account, chainOverride>,
+): Promise<CrossChainSendETHContractReturnType> {
+  const { to, chainId, ...txParameters } = parameters
+
+  return baseWriteAction(
+    client,
+    {
+      abi: superchainWETHABI,
+      contractAddress: contracts.superchainWETH.address,
+      contractFunctionName: 'sendETH',
+      contractArgs: [to, chainId],
+    },
+    txParameters as BaseWriteContractActionParameters,
+  )
+}
+
+/**
+ * Estimates gas for {@link crossChainSendETH}
+ * @category L2 Wallet Actions
+ * @param client - L2 Wallet Client
+ * @param parameters - {@link CrossChainSendETHParameters}
+ * @returns The estimated gas value.
+ */
+export async function estimateCrossChainSendETHGas<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+  TChainOverride extends Chain | undefined = undefined,
+>(
+  client: Client<Transport, TChain, TAccount>,
+  parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
+): Promise<bigint> {
+  const { to, chainId, ...txParameters } = parameters
+
+  return estimateContractGas(client, {
+    abi: superchainWETHABI,
+    address: contracts.superchainWETH.address,
+    functionName: 'sendETH',
+    args: [to, chainId],
+    ...txParameters,
+  } as EstimateContractGasParameters)
+}
+
+/**
+ * Simulate contract call for {@link crossChainSendETH}
+ * @category L2 Public Actions
+ * @param client - L2 Public Client
+ * @param parameters - {@link CrossChainSendETHParameters}
+ * @returns The contract functions return value. {@link CrossChainSendETHContractReturnType}
+ */
+export async function simulateCrossChainSendETH<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+  TChainOverride extends Chain | undefined = undefined,
+>(
+  client: Client<Transport, TChain, TAccount>,
+  parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
+): Promise<CrossChainSendETHContractReturnType> {
+  const { account, value, to, chainId } = parameters
+
+  const res = await simulateContract(client, {
+    account,
+    abi: superchainWETHABI,
+    address: contracts.superchainWETH.address,
+    chain: client.chain,
+    functionName: 'sendETH',
+    args: [to, chainId],
+    value,
+  } as SimulateContractParameters)
+
+  return res.result as CrossChainSendETHContractReturnType
+}

--- a/packages/viem/src/decorators/publicL2.ts
+++ b/packages/viem/src/decorators/publicL2.ts
@@ -3,6 +3,14 @@ import type { PublicActionsL2 as UpstreamPublicActionsL2 } from 'viem/op-stack'
 import { publicActionsL2 as upstreamPublicActionsL2 } from 'viem/op-stack'
 
 import type {
+  CrossChainSendETHContractReturnType,
+  CrossChainSendETHParameters,
+} from '@/actions/crosschainSendETH.js'
+import {
+  estimateCrossChainSendETHGas,
+  simulateCrossChainSendETH,
+} from '@/actions/crosschainSendETH.js'
+import type {
   DepositSuperchainWETHContractReturnType,
   DepositSuperchainWETHParameters,
 } from '@/actions/depositSuperchainWETH.js'
@@ -78,6 +86,12 @@ export type PublicActionsL2<
     >,
   ) => Promise<bigint>
 
+  estimateCrossChainSendETHGas: <
+    TChainOverride extends Chain | undefined = undefined,
+  >(
+    parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
+  ) => Promise<bigint>
+
   estimateWithdrawSuperchainWETHGas: <
     TChainOverride extends Chain | undefined = undefined,
   >(
@@ -120,6 +134,12 @@ export type PublicActionsL2<
     >,
   ) => Promise<DepositSuperchainWETHContractReturnType>
 
+  simulateCrossChainSendETH: <
+    TChainOverride extends Chain | undefined = undefined,
+  >(
+    parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
+  ) => Promise<CrossChainSendETHContractReturnType>
+
   simulateWithdrawSuperchainWETH: <
     TChainOverride extends Chain | undefined = undefined,
   >(
@@ -158,6 +178,8 @@ export function publicActionsL2() {
         estimateDepositSuperchainWETHGas(client, args),
       estimateWithdrawSuperchainWETHGas: (args) =>
         estimateWithdrawSuperchainWETHGas(client, args),
+      estimateCrossChainSendETHGas: (args) =>
+        estimateCrossChainSendETHGas(client, args),
       simulateSendL2ToL2Message: (args) =>
         simulateSendL2ToL2Message(client, args),
       simulateRelayL2ToL2Message: (args) =>
@@ -169,6 +191,8 @@ export function publicActionsL2() {
         simulateWithdrawSuperchainWETH(client, args),
       simulateSendSuperchainWETH: (args) =>
         simulateSendSuperchainWETH(client, args),
+      simulateCrossChainSendETH: (args) =>
+        simulateCrossChainSendETH(client, args),
     } as PublicActionsL2<TChain, TAccount>
   }
 }

--- a/packages/viem/src/decorators/walletL2.ts
+++ b/packages/viem/src/decorators/walletL2.ts
@@ -3,6 +3,11 @@ import type { WalletActionsL2 as UpstreamWalletActionsL2 } from 'viem/op-stack'
 import { walletActionsL2 as upstreamWalletActionsL2 } from 'viem/op-stack'
 
 import {
+  crossChainSendETH,
+  type CrossChainSendETHContractReturnType,
+  type CrossChainSendETHParameters,
+} from '@/actions/crosschainSendETH.js'
+import {
   depositSuperchainWETH,
   type DepositSuperchainWETHParameters,
   type DepositSuperchainWETHReturnType,
@@ -52,6 +57,9 @@ export type WalletActionsL2<
   withdrawSuperchainWETH: <chainOverride extends Chain | undefined = undefined>(
     parameters: WithdrawSuperchainWETHParameters<chain, account, chainOverride>,
   ) => Promise<WithdrawSuperchainWETHReturnType>
+  crossChainSendETH: <chainOverride extends Chain | undefined = undefined>(
+    parameters: CrossChainSendETHParameters<chain, account, chainOverride>,
+  ) => Promise<CrossChainSendETHContractReturnType>
 }
 
 export function walletActionsL2() {
@@ -70,6 +78,7 @@ export function walletActionsL2() {
       sendSuperchainWETH: (args) => sendSuperchainWETH(client, args),
       depositSuperchainWETH: (args) => depositSuperchainWETH(client, args),
       withdrawSuperchainWETH: (args) => withdrawSuperchainWETH(client, args),
+      crossChainSendETH: (args) => crossChainSendETH(client, args),
     } as WalletActionsL2<chain, account>
   }
 }

--- a/packages/viem/src/index.ts
+++ b/packages/viem/src/index.ts
@@ -12,6 +12,16 @@ export { contracts } from '@/contracts.js'
 
 // actions
 export type {
+  CrossChainSendETHContractReturnType,
+  CrossChainSendETHErrorType,
+  CrossChainSendETHParameters,
+} from '@/actions/crosschainSendETH.js'
+export {
+  crossChainSendETH,
+  estimateCrossChainSendETHGas,
+  simulateCrossChainSendETH,
+} from '@/actions/crosschainSendETH.js'
+export type {
   DepositSuperchainWETHContractReturnType,
   DepositSuperchainWETHErrorType,
   DepositSuperchainWETHParameters,


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem-private/issues/93

adds `crossChainSendETH` action, which performs native `ETH` transfers via the `SuperchainWETH` contract.