### PR TITLE
Bump supersim to pull 0.1.0-alpha.31

### DIFF
--- a/.changeset/bright-beans-tell.md
+++ b/.changeset/bright-beans-tell.md
@@ -1,0 +1,5 @@
+---
+"supersim": patch
+---
+
+Bump supersim package to use 0.1.0-alpha.31

--- a/packages/supersim/install.js
+++ b/packages/supersim/install.js
@@ -7,7 +7,7 @@ const { exec } = require('child_process')
 const PLATFORM = os.platform()
 const ARCH = os.arch()
 const BIN_PATH = path.join(__dirname, 'bin')
-const SUPERSIM_VERSION = '0.1.0-alpha.26'
+const SUPERSIM_VERSION = '0.1.0-alpha.31'
 
 const archiveFilename = {
   darwin: {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Bumps supersim package to fetch version `0.1.0-alpha.31`