### PR TITLE
Optimism.io refresh

### DIFF
--- a/apps/bridge-app/.eslintrc.cjs
+++ b/apps/bridge-app/.eslintrc.cjs
@@ -21,6 +21,6 @@ module.exports = {
       'error',
       { "varsIgnorePattern": "_", "argsIgnorePattern": "_" } 
     ],
-    'react-refresh/only-export-components': ['off']
+    'react-refresh/only-export-components': ['warn']
   },
 }

--- a/apps/bridge-app/README.md
+++ b/apps/bridge-app/README.md
@@ -2,8 +2,6 @@
 
 This is an example bridge application demonstrating how to bridge ETH & ERC20 tokens to any OP stack chain. We currently deploy this on every merge to the `main` branch. You can see what it looks like [here](https://main--magnificent-licorice-5d2277.netlify.app/).
 
-This is still a WIP as we are waiting for more libraries to support Wagmi v2
-
 ### Setup
 
 Create an `.env` and add `VITE_WALLET_CONNECT_PROJECT_ID` to it. You can find it [here](https://cloud.walletconnect.com/app/project).

--- a/apps/bridge-app/package.json
+++ b/apps/bridge-app/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "refresh": "vite build && vite preview"
   },
   "dependencies": {
     "@eth-optimism/contracts-ts": "^0.17.0",

--- a/packages/op-app/package.json
+++ b/packages/op-app/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\" --log-level=warn",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix --quiet && pnpm prettier \"**/*.{ts,tsx}\" --write --log-level=warn",
-    "codegen": "ts-node --esm -T ./scripts/codegen"
+    "codegen": "ts-node --esm -T ./scripts/codegen",
+    "refresh": "vite build && vite preview"
   },
   "dependencies": {
     "@eth-optimism/contracts-ts": "^0.17.0",
@@ -20,7 +21,8 @@
     "prettier": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tsup": "^8.0.1"
+    "tsup": "^8.0.1",
+    "vite-plugin-react-refresh": "^0.3.0"
   },
   "devDependencies": {
     "@eth-optimism/superchain-registry": "github:ethereum-optimism/superchain-registry#0496fcd6ee4e36f2bedd3e4fbffa9146b10219af",

--- a/packages/op-app/package.json
+++ b/packages/op-app/package.json
@@ -42,7 +42,7 @@
     "js-yaml": "^4.1.0",
     "jsdom": "^23.2.0",
     "node-fetch": "^3.3.2",
-    "op-viem": "1.1.0",
+    "op-viem": "1.3.1-alpha",
     "op-wagmi": "^0.2.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.29.2",
-    "op-viem": "1.1.0",
+    "op-viem": "1.3.1-alpha",
     "op-wagmi": "^0.2.2",
     "viem": "^2.17.9",
     "wagmi": "^2.11.3"


### PR DESCRIPTION
Fixes #609

Update the bridge application status and configurations to reflect the completion of the Optimism.io refresh.

* **README.md**: Remove the note about the bridge application being a work in progress and waiting for more libraries to support Wagmi v2.
* **.eslintrc.cjs**: Turn on the rule 'react-refresh/only-export-components' and set it to 'warn'.
* **package.json**: Update dependencies and scripts to reflect the completion of the refresh, including adding 'vite-plugin-react-refresh' and a new 'refresh' script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ethereum-optimism/ecosystem/pull/611?shareId=4bf9a90e-342f-42b0-91e8-d3fe9bdfe69d).