### PR TITLE
feat: remove L2ToL2 naming for interop actions

### DIFF
--- a/packages/viem/src/actions/interop/index.ts
+++ b/packages/viem/src/actions/interop/index.ts
@@ -1,14 +1,4 @@
 export type {
-  CrossChainSendETHContractReturnType,
-  CrossChainSendETHErrorType,
-  CrossChainSendETHParameters,
-} from '@/actions/interop/crosschainSendETH.js'
-export {
-  crossChainSendETH,
-  estimateCrossChainSendETHGas,
-  simulateCrossChainSendETH,
-} from '@/actions/interop/crosschainSendETH.js'
-export type {
   DepositSuperchainWETHContractReturnType,
   DepositSuperchainWETHErrorType,
   DepositSuperchainWETHParameters,
@@ -20,27 +10,37 @@ export {
   simulateDepositSuperchainWETH,
 } from '@/actions/interop/depositSuperchainWETH.js'
 export type {
-  RelayL2ToL2MessageContractReturnType,
-  RelayL2ToL2MessageErrorType,
-  RelayL2ToL2MessageParameters,
-  RelayL2ToL2MessageReturnType,
-} from '@/actions/interop/relayL2ToL2Message.js'
+  RelayMessageContractReturnType,
+  RelayMessageErrorType,
+  RelayMessageParameters,
+  RelayMessageReturnType,
+} from '@/actions/interop/relayMessage.js'
 export {
-  estimateRelayL2ToL2MessageGas,
-  relayL2ToL2Message,
-  simulateRelayL2ToL2Message,
-} from '@/actions/interop/relayL2ToL2Message.js'
+  estimateRelayMessageGas,
+  relayMessage,
+  simulateRelayMessage,
+} from '@/actions/interop/relayMessage.js'
 export type {
-  SendL2ToL2MessageContractReturnType,
-  SendL2ToL2MessageErrorType,
-  SendL2ToL2MessageParameters,
-  SendL2ToL2MessageReturnType,
-} from '@/actions/interop/sendL2ToL2Message.js'
+  SendETHContractReturnType,
+  SendETHErrorType,
+  SendETHParameters,
+} from '@/actions/interop/sendETH.js'
 export {
-  estimateSendL2ToL2MessageGas,
-  sendL2ToL2Message,
-  simulateSendL2ToL2Message,
-} from '@/actions/interop/sendL2ToL2Message.js'
+  estimateSendETHGas,
+  sendETH,
+  simulateSendETH,
+} from '@/actions/interop/sendETH.js'
+export type {
+  SendMessageContractReturnType,
+  SendMessageErrorType,
+  SendMessageParameters,
+  SendMessageReturnType,
+} from '@/actions/interop/sendMessage.js'
+export {
+  estimateSendMessageGas,
+  sendMessage,
+  simulateSendMessage,
+} from '@/actions/interop/sendMessage.js'
 export type {
   SendSuperchainERC20ContractReturnType,
   SendSuperchainERC20ErrorType,

--- a/packages/viem/src/actions/interop/relayMessage.spec.ts
+++ b/packages/viem/src/actions/interop/relayMessage.spec.ts
@@ -17,7 +17,7 @@ import {
   hashL2ToL2Message,
 } from '@/utils/l2ToL2CrossDomainMessenger.js'
 
-describe('relayL2ToL2Message', () => {
+describe('relayMessage', () => {
   const calldata = encodeFunctionData({
     abi: ticTacToeAbi,
     functionName: 'createGame',
@@ -26,7 +26,7 @@ describe('relayL2ToL2Message', () => {
 
   describe('estimate gas', () => {
     it('should estimate gas', async () => {
-      const hash = await walletClientA.interop.sendL2ToL2Message({
+      const hash = await walletClientA.interop.sendMessage({
         account: testAccount.address,
         destinationChainId: supersimL2B.id,
         target: ticTacToeAddress,
@@ -36,11 +36,13 @@ describe('relayL2ToL2Message', () => {
       const receipt = await publicClientA.waitForTransactionReceipt({ hash })
       const { sentMessages } = await createInteropSentL2ToL2Messages(
         publicClientA,
-        { receipt },
+        {
+          receipt,
+        },
       )
       expect(sentMessages).length(1)
 
-      const gas = await publicClientB.interop.estimateRelayL2ToL2MessageGas({
+      const gas = await publicClientB.interop.estimateRelayMessageGas({
         account: testAccount.address,
         sentMessageId: sentMessages[0].id,
         sentMessagePayload: sentMessages[0].payload,
@@ -52,7 +54,7 @@ describe('relayL2ToL2Message', () => {
 
   describe('simulate', () => {
     it('should simulate', async () => {
-      const hash = await walletClientA.interop.sendL2ToL2Message({
+      const hash = await walletClientA.interop.sendMessage({
         account: testAccount.address,
         destinationChainId: supersimL2B.id,
         target: ticTacToeAddress,
@@ -62,12 +64,14 @@ describe('relayL2ToL2Message', () => {
       const receipt = await publicClientA.waitForTransactionReceipt({ hash })
       const { sentMessages } = await createInteropSentL2ToL2Messages(
         publicClientA,
-        { receipt },
+        {
+          receipt,
+        },
       )
       expect(sentMessages).length(1)
 
       expect(() =>
-        publicClientB.interop.simulateRelayL2ToL2Message({
+        publicClientB.interop.simulateRelayMessage({
           account: testAccount,
           sentMessageId: sentMessages[0].id,
           sentMessagePayload: sentMessages[0].payload,
@@ -78,7 +82,7 @@ describe('relayL2ToL2Message', () => {
 
   describe('write contract', () => {
     it('should return expected request', async () => {
-      const sendTxHash = await walletClientA.interop.sendL2ToL2Message({
+      const sendTxHash = await walletClientA.interop.sendMessage({
         account: testAccount.address,
         destinationChainId: supersimL2B.id,
         target: ticTacToeAddress,
@@ -90,11 +94,13 @@ describe('relayL2ToL2Message', () => {
       })
       const { sentMessages } = await createInteropSentL2ToL2Messages(
         publicClientA,
-        { receipt: sendReceipt },
+        {
+          receipt: sendReceipt,
+        },
       )
       expect(sentMessages).length(1)
 
-      const relayTxHash = await walletClientB.interop.relayL2ToL2Message({
+      const relayTxHash = await walletClientB.interop.relayMessage({
         sentMessageId: sentMessages[0].id,
         sentMessagePayload: sentMessages[0].payload,
       })
@@ -110,7 +116,7 @@ describe('relayL2ToL2Message', () => {
       })
       expect(successfulMessages).length(1)
 
-      // L2ToL2CDM messageHash check
+      // CDM messageHash check
       const { messages } = decodeSentL2ToL2Messages({ receipt: sendReceipt })
       expect(messages).length(1)
 

--- a/packages/viem/src/actions/interop/relayMessage.ts
+++ b/packages/viem/src/actions/interop/relayMessage.ts
@@ -25,7 +25,7 @@ import type { ErrorType } from '@/types/utils.js'
 /**
  * @category Types
  */
-export type RelayL2ToL2MessageParameters<
+export type RelayMessageParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
@@ -45,12 +45,12 @@ export type RelayL2ToL2MessageParameters<
 /**
  * @category Types
  */
-export type RelayL2ToL2MessageReturnType = Hash
+export type RelayMessageReturnType = Hash
 
 /**
  * @category Types
  */
-export type RelayL2ToL2MessageContractReturnType = ContractFunctionReturnType<
+export type RelayMessageContractReturnType = ContractFunctionReturnType<
   typeof l2ToL2CrossDomainMessengerAbi,
   'payable',
   'relayMessage'
@@ -59,26 +59,26 @@ export type RelayL2ToL2MessageContractReturnType = ContractFunctionReturnType<
 /**
  * @category Types
  */
-export type RelayL2ToL2MessageErrorType =
+export type RelayMessageErrorType =
   | EstimateContractGasErrorType
   | WriteContractErrorType
   | ErrorType
 
 /**
- * Relays a message emitted by the L2ToL2CrossDomainMessenger
+ * Relays a message emitted by the CrossDomainMessenger
  * @category L2 Wallet Actions
  * @param client - Client to use
- * @param parameters - {@link RelayL2ToL2MessageParameters}
- * @returns The relayMessage transaction hash. {@link RelayL2ToL2MessageReturnType}
+ * @param parameters - {@link RelayMessageParameters}
+ * @returns The relayMessage transaction hash. {@link RelayMessageReturnType}
  */
-export async function relayL2ToL2Message<
+export async function relayMessage<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: RelayL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
-): Promise<RelayL2ToL2MessageReturnType> {
+  parameters: RelayMessageParameters<TChain, TAccount, TChainOverride>,
+): Promise<RelayMessageReturnType> {
   const { sentMessageId, sentMessagePayload, ...txParameters } = parameters
 
   return baseWriteAction(
@@ -94,19 +94,19 @@ export async function relayL2ToL2Message<
 }
 
 /**
- * Estimates gas for {@link relayL2ToL2Message}
+ * Estimates gas for {@link relayMessage}
  * @category L2 Wallet Actions
  * @param client - Client to use
- * @param parameters - {@link RelayL2ToL2MessageParameters}
+ * @param parameters - {@link RelayMessageParameters}
  * @returns The estimated gas value.
  */
-export async function estimateRelayL2ToL2MessageGas<
+export async function estimateRelayMessageGas<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: RelayL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
+  parameters: RelayMessageParameters<TChain, TAccount, TChainOverride>,
 ): Promise<bigint> {
   const { sentMessageId, sentMessagePayload, ...txParameters } = parameters
 
@@ -120,20 +120,20 @@ export async function estimateRelayL2ToL2MessageGas<
 }
 
 /**
- * Simulate contract call for {@link relayL2ToL2Message}
+ * Simulate contract call for {@link relayMessage}
  * @category L2 Public Actions
  * @param client - L2 Public Client
  * @param parameters - {@link Relay2ToL2MessageParameters}
- * @returns The contract functions return value. {@link RelayL2ToL2MessageContractReturnType}
+ * @returns The contract functions return value. {@link RelayMessageContractReturnType}
  */
-export async function simulateRelayL2ToL2Message<
+export async function simulateRelayMessage<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: RelayL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
-): Promise<RelayL2ToL2MessageContractReturnType> {
+  parameters: RelayMessageParameters<TChain, TAccount, TChainOverride>,
+): Promise<RelayMessageContractReturnType> {
   const { account, sentMessageId, sentMessagePayload } = parameters
 
   const res = await simulateContract(client, {
@@ -145,5 +145,5 @@ export async function simulateRelayL2ToL2Message<
     args: [sentMessageId, sentMessagePayload],
   } as SimulateContractParameters)
 
-  return res.result as RelayL2ToL2MessageContractReturnType
+  return res.result as RelayMessageContractReturnType
 }

--- a/packages/viem/src/actions/interop/sendETH.spec.ts
+++ b/packages/viem/src/actions/interop/sendETH.spec.ts
@@ -13,7 +13,7 @@ describe('crossChainSendETH', () => {
         address: testAccount.address,
       })
 
-      const hash = await walletClientA.interop.crossChainSendETH({
+      const hash = await walletClientA.interop.sendETH({
         to: testAccount.address,
         value: AMOUNT_TO_SEND,
         chainId: supersimL2B.id,
@@ -38,7 +38,7 @@ describe('crossChainSendETH', () => {
 
   describe('estimate gas', () => {
     it('should estimate gas', async () => {
-      const gas = await publicClientA.interop.estimateCrossChainSendETHGas({
+      const gas = await publicClientA.interop.estimateSendETHGas({
         account: testAccount.address,
         to: testAccount.address,
         value: AMOUNT_TO_SEND,
@@ -52,7 +52,7 @@ describe('crossChainSendETH', () => {
   describe('simulate', () => {
     it('should simulate', async () => {
       expect(() =>
-        publicClientA.interop.simulateCrossChainSendETH({
+        publicClientA.interop.simulateSendETH({
           account: testAccount.address,
           to: testAccount.address,
           value: AMOUNT_TO_SEND,

--- a/packages/viem/src/actions/interop/sendETH.ts
+++ b/packages/viem/src/actions/interop/sendETH.ts
@@ -23,7 +23,7 @@ import type { ErrorType } from '@/types/utils.js'
 /**
  * @category Types
  */
-export type CrossChainSendETHParameters<
+export type SendETHParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
@@ -43,7 +43,7 @@ export type CrossChainSendETHParameters<
 /**
  * @category Types
  */
-export type CrossChainSendETHContractReturnType = ContractFunctionReturnType<
+export type SendETHContractReturnType = ContractFunctionReturnType<
   typeof superchainWETHAbi,
   'payable',
   'sendETH'
@@ -52,7 +52,7 @@ export type CrossChainSendETHContractReturnType = ContractFunctionReturnType<
 /**
  * @category Types
  */
-export type CrossChainSendETHErrorType =
+export type SendETHErrorType =
   | EstimateContractGasErrorType
   | WriteContractErrorType
   | ErrorType
@@ -61,17 +61,17 @@ export type CrossChainSendETHErrorType =
  * Sends ETH to the specified recipient on the destination chain
  * @category L2 Wallet Actions
  * @param client - L2 Wallet Client
- * @param parameters - {@link CrossChainSendETHParameters}
- * @returns The crosschainSendETH transaction hash. {@link CrossChainSendETHContractReturnType}
+ * @param parameters - {@link SendETHParameters}
+ * @returns The crosschainSendETH transaction hash. {@link SendETHContractReturnType}
  */
-export async function crossChainSendETH<
+export async function sendETH<
   chain extends Chain | undefined,
   account extends Account | undefined,
   chainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: CrossChainSendETHParameters<chain, account, chainOverride>,
-): Promise<CrossChainSendETHContractReturnType> {
+  parameters: SendETHParameters<chain, account, chainOverride>,
+): Promise<SendETHContractReturnType> {
   const { to, chainId, ...txParameters } = parameters
 
   return baseWriteAction(
@@ -87,19 +87,19 @@ export async function crossChainSendETH<
 }
 
 /**
- * Estimates gas for {@link crossChainSendETH}
+ * Estimates gas for {@link sendETH}
  * @category L2 Wallet Actions
  * @param client - L2 Wallet Client
- * @param parameters - {@link CrossChainSendETHParameters}
+ * @param parameters - {@link SendETHParameters}
  * @returns The estimated gas value.
  */
-export async function estimateCrossChainSendETHGas<
+export async function estimateSendETHGas<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
+  parameters: SendETHParameters<TChain, TAccount, TChainOverride>,
 ): Promise<bigint> {
   const { to, chainId, ...txParameters } = parameters
 
@@ -113,20 +113,20 @@ export async function estimateCrossChainSendETHGas<
 }
 
 /**
- * Simulate contract call for {@link crossChainSendETH}
+ * Simulate contract call for {@link sendETH}
  * @category L2 Public Actions
  * @param client - L2 Public Client
- * @param parameters - {@link CrossChainSendETHParameters}
- * @returns The contract functions return value. {@link CrossChainSendETHContractReturnType}
+ * @param parameters - {@link SendETHParameters}
+ * @returns The contract functions return value. {@link SendETHContractReturnType}
  */
-export async function simulateCrossChainSendETH<
+export async function simulateSendETH<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
-): Promise<CrossChainSendETHContractReturnType> {
+  parameters: SendETHParameters<TChain, TAccount, TChainOverride>,
+): Promise<SendETHContractReturnType> {
   const { account, value, to, chainId } = parameters
 
   const res = await simulateContract(client, {
@@ -139,5 +139,5 @@ export async function simulateCrossChainSendETH<
     value,
   } as SimulateContractParameters)
 
-  return res.result as CrossChainSendETHContractReturnType
+  return res.result as SendETHContractReturnType
 }

--- a/packages/viem/src/actions/interop/sendMessage.spec.ts
+++ b/packages/viem/src/actions/interop/sendMessage.spec.ts
@@ -6,7 +6,7 @@ import { publicClientA, testAccount, walletClientA } from '@/test/clients.js'
 import { ticTacToeAbi, ticTacToeAddress } from '@/test/setupTicTacToe.js'
 import { decodeSentL2ToL2Messages } from '@/utils/l2ToL2CrossDomainMessenger.js'
 
-describe('sendL2ToL2Message', () => {
+describe('sendMessage', () => {
   const calldata = encodeFunctionData({
     abi: ticTacToeAbi,
     functionName: 'createGame',
@@ -15,7 +15,7 @@ describe('sendL2ToL2Message', () => {
 
   describe('write contract', () => {
     it('should return expected request', async () => {
-      const txHash = await walletClientA.interop.sendL2ToL2Message({
+      const txHash = await walletClientA.interop.sendMessage({
         account: testAccount.address,
         destinationChainId: supersimL2B.id,
         target: ticTacToeAddress,
@@ -42,7 +42,7 @@ describe('sendL2ToL2Message', () => {
 
   describe('estimate gas', () => {
     it('should estimate gas', async () => {
-      const gas = await publicClientA.interop.estimateSendL2ToL2MessageGas({
+      const gas = await publicClientA.interop.estimateSendMessageGas({
         account: testAccount.address,
         target: ticTacToeAddress,
         destinationChainId: supersimL2B.id,
@@ -56,7 +56,7 @@ describe('sendL2ToL2Message', () => {
   describe('simulate', () => {
     it('should simulate', async () => {
       expect(() =>
-        publicClientA.interop.simulateSendL2ToL2Message({
+        publicClientA.interop.simulateSendMessage({
           account: testAccount.address,
           destinationChainId: supersimL2B.id,
           target: ticTacToeAddress,

--- a/packages/viem/src/actions/interop/sendMessage.ts
+++ b/packages/viem/src/actions/interop/sendMessage.ts
@@ -1,4 +1,4 @@
-/** @module sendL2ToL2Message */
+/** @module sendMessage */
 import type {
   Account,
   Address,
@@ -25,7 +25,7 @@ import type { ErrorType } from '@/types/utils.js'
 /**
  * @category Types
  */
-export type SendL2ToL2MessageParameters<
+export type SendMessageParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain | undefined,
@@ -47,12 +47,12 @@ export type SendL2ToL2MessageParameters<
 /**
  * @category Types
  */
-export type SendL2ToL2MessageReturnType = Hash
+export type SendMessageReturnType = Hash
 
 /**
  * @category Types
  */
-export type SendL2ToL2MessageContractReturnType = ContractFunctionReturnType<
+export type SendMessageContractReturnType = ContractFunctionReturnType<
   typeof l2ToL2CrossDomainMessengerAbi,
   'nonpayable',
   'sendMessage'
@@ -61,7 +61,7 @@ export type SendL2ToL2MessageContractReturnType = ContractFunctionReturnType<
 /**
  * @category Types
  */
-export type SendL2ToL2MessageErrorType =
+export type SendMessageErrorType =
   | EstimateContractGasErrorType
   | WriteContractErrorType
   | ErrorType
@@ -70,17 +70,17 @@ export type SendL2ToL2MessageErrorType =
  * Initiates the intent of sending a L2 to L2 message. Used in the interop flow.
  * @category L2 Wallet Actions
  * @param client - L2 Wallet Client
- * @param parameters - {@link SendL2ToL2MessageParameters}
- * @returns The sendL2ToL2Message transaction hash. {@link SendL2ToL2MessageReturnType}
+ * @param parameters - {@link SendMessageParameters}
+ * @returns The sendMessage transaction hash. {@link SendMessageReturnType}
  */
-export async function sendL2ToL2Message<
+export async function sendMessage<
   chain extends Chain | undefined,
   account extends Account | undefined,
   chainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, chain, account>,
-  parameters: SendL2ToL2MessageParameters<chain, account, chainOverride>,
-): Promise<SendL2ToL2MessageReturnType> {
+  parameters: SendMessageParameters<chain, account, chainOverride>,
+): Promise<SendMessageReturnType> {
   const { destinationChainId, target, message, ...txParameters } = parameters
 
   return baseWriteAction(
@@ -96,19 +96,19 @@ export async function sendL2ToL2Message<
 }
 
 /**
- * Estimates gas for {@link sendL2ToL2Message}
+ * Estimates gas for {@link sendMessage}
  * @category L2 Wallet Actions
  * @param client - L2 Wallet Client
- * @param parameters - {@link SendL2ToL2MessageParameters}
+ * @param parameters - {@link SendMessageParameters}
  * @returns The estimated gas value.
  */
-export async function estimateSendL2ToL2MessageGas<
+export async function estimateSendMessageGas<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: SendL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
+  parameters: SendMessageParameters<TChain, TAccount, TChainOverride>,
 ): Promise<bigint> {
   const { destinationChainId, target, message, ...txParameters } = parameters
 
@@ -122,20 +122,20 @@ export async function estimateSendL2ToL2MessageGas<
 }
 
 /**
- * Simulate contract call for {@link sendL2ToL2Message}
+ * Simulate contract call for {@link sendMessage}
  * @category L2 Public Actions
  * @param client - L2 Public Client
- * @param parameters - {@link SendL2ToL2MessageParameters}
- * @returns The contract functions return value. {@link SendL2ToL2MessageContractReturnType}
+ * @param parameters - {@link SendMessageParameters}
+ * @returns The contract functions return value. {@link SendMessageContractReturnType}
  */
-export async function simulateSendL2ToL2Message<
+export async function simulateSendMessage<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: Client<Transport, TChain, TAccount>,
-  parameters: SendL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
-): Promise<SendL2ToL2MessageContractReturnType> {
+  parameters: SendMessageParameters<TChain, TAccount, TChainOverride>,
+): Promise<SendMessageContractReturnType> {
   const { account, destinationChainId, target, message } = parameters
 
   const res = await simulateContract(client, {
@@ -147,5 +147,5 @@ export async function simulateSendL2ToL2Message<
     args: [destinationChainId, target, message],
   } as SimulateContractParameters)
 
-  return res.result as SendL2ToL2MessageContractReturnType
+  return res.result as SendMessageContractReturnType
 }

--- a/packages/viem/src/decorators/publicL2.ts
+++ b/packages/viem/src/decorators/publicL2.ts
@@ -3,30 +3,30 @@ import type { PublicActionsL2 as OpPublicActionsL2 } from 'viem/op-stack'
 import { publicActionsL2 as opPublicActionsL2 } from 'viem/op-stack'
 
 import type {
-  CrossChainSendETHContractReturnType,
-  CrossChainSendETHParameters,
   DepositSuperchainWETHContractReturnType,
   DepositSuperchainWETHParameters,
-  RelayL2ToL2MessageContractReturnType,
-  RelayL2ToL2MessageParameters,
-  SendL2ToL2MessageContractReturnType,
-  SendL2ToL2MessageParameters,
+  RelayMessageContractReturnType,
+  RelayMessageParameters,
+  SendETHContractReturnType,
+  SendETHParameters,
+  SendMessageContractReturnType,
+  SendMessageParameters,
   SendSuperchainERC20ContractReturnType,
   SendSuperchainERC20Parameters,
   WithdrawSuperchainWETHContractReturnType,
   WithdrawSuperchainWETHParameters,
 } from '@/actions/interop/index.js'
 import {
-  estimateCrossChainSendETHGas,
   estimateDepositSuperchainWETHGas,
-  estimateRelayL2ToL2MessageGas,
-  estimateSendL2ToL2MessageGas,
+  estimateRelayMessageGas,
+  estimateSendETHGas,
+  estimateSendMessageGas,
   estimateSendSuperchainERC20Gas,
   estimateWithdrawSuperchainWETHGas,
-  simulateCrossChainSendETH,
   simulateDepositSuperchainWETH,
-  simulateRelayL2ToL2Message,
-  simulateSendL2ToL2Message,
+  simulateRelayMessage,
+  simulateSendETH,
+  simulateSendMessage,
   simulateSendSuperchainERC20,
   simulateWithdrawSuperchainWETH,
 } from '@/actions/interop/index.js'
@@ -35,15 +35,15 @@ export type PublicInteropActionsL2<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
 > = {
-  estimateSendL2ToL2MessageGas: <
+  estimateSendMessageGas: <
     TChainOverride extends Chain | undefined = undefined,
   >(
-    parameters: SendL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
+    parameters: SendMessageParameters<TChain, TAccount, TChainOverride>,
   ) => Promise<bigint>
-  estimateRelayL2ToL2MessageGas: <
+  estimateRelayMessageGas: <
     TChainOverride extends Chain | undefined = undefined,
   >(
-    parameters: RelayL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
+    parameters: RelayMessageParameters<TChain, TAccount, TChainOverride>,
   ) => Promise<bigint>
   estimateSendSuperchainERC20Gas: <
     TChainOverride extends Chain | undefined = undefined,
@@ -59,10 +59,8 @@ export type PublicInteropActionsL2<
       TChainOverride
     >,
   ) => Promise<bigint>
-  estimateCrossChainSendETHGas: <
-    TChainOverride extends Chain | undefined = undefined,
-  >(
-    parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
+  estimateSendETHGas: <TChainOverride extends Chain | undefined = undefined>(
+    parameters: SendETHParameters<TChain, TAccount, TChainOverride>,
   ) => Promise<bigint>
   estimateWithdrawSuperchainWETHGas: <
     TChainOverride extends Chain | undefined = undefined,
@@ -73,17 +71,13 @@ export type PublicInteropActionsL2<
       TChainOverride
     >,
   ) => Promise<bigint>
-  simulateSendL2ToL2Message: <
-    TChainOverride extends Chain | undefined = undefined,
-  >(
-    parameters: SendL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
-  ) => Promise<SendL2ToL2MessageContractReturnType>
+  simulateSendMessage: <TChainOverride extends Chain | undefined = undefined>(
+    parameters: SendMessageParameters<TChain, TAccount, TChainOverride>,
+  ) => Promise<SendMessageContractReturnType>
 
-  simulateRelayL2ToL2Message: <
-    TChainOverride extends Chain | undefined = undefined,
-  >(
-    parameters: RelayL2ToL2MessageParameters<TChain, TAccount, TChainOverride>,
-  ) => Promise<RelayL2ToL2MessageContractReturnType>
+  simulateRelayMessage: <TChainOverride extends Chain | undefined = undefined>(
+    parameters: RelayMessageParameters<TChain, TAccount, TChainOverride>,
+  ) => Promise<RelayMessageContractReturnType>
 
   simulateSendSuperchainERC20: <
     TChainOverride extends Chain | undefined = undefined,
@@ -99,11 +93,9 @@ export type PublicInteropActionsL2<
       TChainOverride
     >,
   ) => Promise<DepositSuperchainWETHContractReturnType>
-  simulateCrossChainSendETH: <
-    TChainOverride extends Chain | undefined = undefined,
-  >(
-    parameters: CrossChainSendETHParameters<TChain, TAccount, TChainOverride>,
-  ) => Promise<CrossChainSendETHContractReturnType>
+  simulateSendETH: <TChainOverride extends Chain | undefined = undefined>(
+    parameters: SendETHParameters<TChain, TAccount, TChainOverride>,
+  ) => Promise<SendETHContractReturnType>
   simulateWithdrawSuperchainWETH: <
     TChainOverride extends Chain | undefined = undefined,
   >(
@@ -134,30 +126,25 @@ export function publicActionsL2() {
     return {
       ...opPublicActionsL2(),
       interop: {
-        estimateSendL2ToL2MessageGas: (args) =>
-          estimateSendL2ToL2MessageGas(client, args),
-        estimateRelayL2ToL2MessageGas: (args) =>
-          estimateRelayL2ToL2MessageGas(client, args),
+        estimateSendMessageGas: (args) => estimateSendMessageGas(client, args),
+        estimateRelayMessageGas: (args) =>
+          estimateRelayMessageGas(client, args),
         estimateSendSuperchainERC20Gas: (args) =>
           estimateSendSuperchainERC20Gas(client, args),
         estimateDepositSuperchainWETHGas: (args) =>
           estimateDepositSuperchainWETHGas(client, args),
         estimateWithdrawSuperchainWETHGas: (args) =>
           estimateWithdrawSuperchainWETHGas(client, args),
-        estimateCrossChainSendETHGas: (args) =>
-          estimateCrossChainSendETHGas(client, args),
-        simulateSendL2ToL2Message: (args) =>
-          simulateSendL2ToL2Message(client, args),
-        simulateRelayL2ToL2Message: (args) =>
-          simulateRelayL2ToL2Message(client, args),
+        estimateSendETHGas: (args) => estimateSendETHGas(client, args),
+        simulateSendMessage: (args) => simulateSendMessage(client, args),
+        simulateRelayMessage: (args) => simulateRelayMessage(client, args),
         simulateSendSuperchainERC20: (args) =>
           simulateSendSuperchainERC20(client, args),
         simulateDepositSuperchainWETH: (args) =>
           simulateDepositSuperchainWETH(client, args),
         simulateWithdrawSuperchainWETH: (args) =>
           simulateWithdrawSuperchainWETH(client, args),
-        simulateCrossChainSendETH: (args) =>
-          simulateCrossChainSendETH(client, args),
+        simulateSendETH: (args) => simulateSendETH(client, args),
       },
     } as PublicActionsL2<TChain, TAccount>
   }

--- a/packages/viem/src/decorators/walletL2.ts
+++ b/packages/viem/src/decorators/walletL2.ts
@@ -3,24 +3,24 @@ import type { WalletActionsL2 as OpWalletActionsL2 } from 'viem/op-stack'
 import { walletActionsL2 as opWalletActionsL2 } from 'viem/op-stack'
 
 import type {
-  CrossChainSendETHContractReturnType,
-  CrossChainSendETHParameters,
+  SendETHContractReturnType,
+  SendETHParameters,
   DepositSuperchainWETHParameters,
   DepositSuperchainWETHReturnType,
-  RelayL2ToL2MessageParameters,
-  RelayL2ToL2MessageReturnType,
-  SendL2ToL2MessageParameters,
-  SendL2ToL2MessageReturnType,
+  RelayMessageParameters,
+  RelayMessageReturnType,
+  SendMessageParameters,
+  SendMessageReturnType,
   SendSuperchainERC20Parameters,
   SendSuperchainERC20ReturnType,
   WithdrawSuperchainWETHParameters,
   WithdrawSuperchainWETHReturnType,
 } from '@/actions/interop/index.js'
 import {
-  crossChainSendETH,
+  sendETH,
   depositSuperchainWETH,
-  relayL2ToL2Message,
-  sendL2ToL2Message,
+  relayMessage,
+  sendMessage,
   sendSuperchainERC20,
   withdrawSuperchainWETH,
 } from '@/actions/interop/index.js'
@@ -29,12 +29,12 @@ export type WalletInteropActionsL2<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
 > = {
-  sendL2ToL2Message: <chainOverride extends Chain | undefined = undefined>(
-    parameters: SendL2ToL2MessageParameters<TChain, TAccount, chainOverride>,
-  ) => Promise<SendL2ToL2MessageReturnType>
-  relayL2ToL2Message: <chainOverride extends Chain | undefined = undefined>(
-    parameters: RelayL2ToL2MessageParameters<TChain, TAccount, chainOverride>,
-  ) => Promise<RelayL2ToL2MessageReturnType>
+  sendMessage: <chainOverride extends Chain | undefined = undefined>(
+    parameters: SendMessageParameters<TChain, TAccount, chainOverride>,
+  ) => Promise<SendMessageReturnType>
+  relayMessage: <chainOverride extends Chain | undefined = undefined>(
+    parameters: RelayMessageParameters<TChain, TAccount, chainOverride>,
+  ) => Promise<RelayMessageReturnType>
   sendSuperchainERC20: <chainOverride extends Chain | undefined = undefined>(
     parameters: SendSuperchainERC20Parameters<TChain, TAccount, chainOverride>,
   ) => Promise<SendSuperchainERC20ReturnType>
@@ -52,9 +52,9 @@ export type WalletInteropActionsL2<
       chainOverride
     >,
   ) => Promise<WithdrawSuperchainWETHReturnType>
-  crossChainSendETH: <chainOverride extends Chain | undefined = undefined>(
-    parameters: CrossChainSendETHParameters<TChain, TAccount, chainOverride>,
-  ) => Promise<CrossChainSendETHContractReturnType>
+  sendETH: <chainOverride extends Chain | undefined = undefined>(
+    parameters: SendETHParameters<TChain, TAccount, chainOverride>,
+  ) => Promise<SendETHContractReturnType>
 }
 
 export type WalletActionsL2<
@@ -76,12 +76,12 @@ export function walletActionsL2() {
     return {
       ...opWalletActionsL2(),
       interop: {
-        sendL2ToL2Message: (args) => sendL2ToL2Message(client, args),
-        relayL2ToL2Message: (args) => relayL2ToL2Message(client, args),
+        sendMessage: (args) => sendMessage(client, args),
+        relayMessage: (args) => relayMessage(client, args),
         sendSuperchainERC20: (args) => sendSuperchainERC20(client, args),
         depositSuperchainWETH: (args) => depositSuperchainWETH(client, args),
         withdrawSuperchainWETH: (args) => withdrawSuperchainWETH(client, args),
-        crossChainSendETH: (args) => crossChainSendETH(client, args),
+        sendETH: (args) => sendETH(client, args),
       },
     } as WalletActionsL2<chain, account>
   }

--- a/packages/viem/src/test/e2e/interop.spec.ts
+++ b/packages/viem/src/test/e2e/interop.spec.ts
@@ -27,7 +27,7 @@ describe('Generic Interop Flow', () => {
   })
 
   it('should send and relay cross chain message', async () => {
-    const sentMessageTxHash = await walletClientA.interop.sendL2ToL2Message({
+    const sentMessageTxHash = await walletClientA.interop.sendMessage({
       account: testAccount.address,
       destinationChainId: supersimL2B.id,
       target: ticTacToeAddress,
@@ -39,12 +39,14 @@ describe('Generic Interop Flow', () => {
     })
     const { sentMessages } = await createInteropSentL2ToL2Messages(
       publicClientA,
-      { receipt },
+      {
+        receipt,
+      },
     )
     expect(sentMessages).length(1)
 
     // message was relayed on the other side
-    const relayMessageTxHash = await walletClientB.interop.relayL2ToL2Message({
+    const relayMessageTxHash = await walletClientB.interop.relayMessage({
       account: testAccount.address,
       sentMessageId: sentMessages[0].id,
       sentMessagePayload: sentMessages[0].payload,
@@ -95,11 +97,13 @@ describe('SuperchainERC20 Flow', () => {
 
     const { sentMessages } = await createInteropSentL2ToL2Messages(
       publicClientA,
-      { receipt },
+      {
+        receipt,
+      },
     )
     expect(sentMessages).toHaveLength(1)
 
-    const relayMessageTxHash = await walletClientB.interop.relayL2ToL2Message({
+    const relayMessageTxHash = await walletClientB.interop.relayMessage({
       account: testAccount.address,
       sentMessageId: sentMessages[0].id,
       sentMessagePayload: sentMessages[0].payload,
@@ -133,7 +137,7 @@ describe('Cross chain ETH transfer', () => {
       address: testAccount.address,
     })
 
-    const hash = await walletClientA.interop.crossChainSendETH({
+    const hash = await walletClientA.interop.sendETH({
       to: testAccount.address,
       value: AMOUNT_TO_SEND,
       chainId: supersimL2B.id,
@@ -143,11 +147,13 @@ describe('Cross chain ETH transfer', () => {
 
     const { sentMessages } = await createInteropSentL2ToL2Messages(
       publicClientA,
-      { receipt },
+      {
+        receipt,
+      },
     )
     expect(sentMessages).toHaveLength(1)
 
-    const relayMessageTxHash = await walletClientB.interop.relayL2ToL2Message({
+    const relayMessageTxHash = await walletClientB.interop.relayMessage({
       account: testAccount.address,
       sentMessageId: sentMessages[0].id,
       sentMessagePayload: sentMessages[0].payload,


### PR DESCRIPTION
with scope decorators & actions, no need for the L2ToL2 in the name