### PR TITLE
bumps supersim to pull 0.1.0-alpha.32

### DIFF
--- a/.changeset/five-coins-cheat.md
+++ b/.changeset/five-coins-cheat.md
@@ -1,0 +1,5 @@
+---
+"supersim": patch
+---
+
+Bumped supersim to 0.1.0-alpha.32

--- a/packages/supersim/install.js
+++ b/packages/supersim/install.js
@@ -7,7 +7,7 @@ const { exec } = require('child_process')
 const PLATFORM = os.platform()
 const ARCH = os.arch()
 const BIN_PATH = path.join(__dirname, 'bin')
-const SUPERSIM_VERSION = '0.1.0-alpha.31'
+const SUPERSIM_VERSION = '0.1.0-alpha.32'
 
 const archiveFilename = {
   darwin: {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Bumps supersim to `0.1.0-alpha.32`