### PR TITLE
feat: add script to bump supersim version

### DIFF
--- a/.changeset/brave-cats-sing.md
+++ b/.changeset/brave-cats-sing.md
@@ -1,0 +1,5 @@
+---
+'supersim': 0.1.0-alpha.36
+---
+
+bumped supersim to 0.1.0-alpha.36

--- a/package.json
+++ b/package.json
@@ -13,18 +13,21 @@
     "create:app": "cd apps && pnpm create vite --template=react-ts ",
     "create:react:library": "cd packages && pnpm create vite --template=react-ts ",
     "release:publish": "pnpm install --frozen-lockfile && pnpm nx run-many --target=build && changeset publish",
-    "release:version": "changeset version && pnpm install --lockfile-only"
+    "release:version": "changeset version && pnpm install --lockfile-only",
+    "update:supersim": "tsx scripts/update-supersim-version.ts"
   },
   "private": true,
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@nx/js": "17.1.3",
     "@nx/plugin": "17.1.3",
+    "@types/node": "^20.11.30",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-jsdoc": "^46.9.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-storybook": "^0.6.15",
-    "nx": "17.1.3"
+    "nx": "17.1.3",
+    "tsx": "^4.7.1"
   },
   "dependencies": {
     "@changesets/cli": "^2.27.1"

--- a/packages/supersim/install.js
+++ b/packages/supersim/install.js
@@ -7,7 +7,7 @@ const { exec } = require('child_process')
 const PLATFORM = os.platform()
 const ARCH = os.arch()
 const BIN_PATH = path.join(__dirname, 'bin')
-const SUPERSIM_VERSION = '0.1.0-alpha.34'
+const SUPERSIM_VERSION = '0.1.0-alpha.36'
 
 const archiveFilename = {
   darwin: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,10 +17,13 @@ importers:
         version: 0.5.0(encoding@0.1.13)
       '@nx/js':
         specifier: 17.1.3
-        version: 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)
+        version: 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)
       '@nx/plugin':
         specifier: 17.1.3
-        version: 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)
+        version: 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.14.11
       eslint-config-react-app:
         specifier: ^7.0.1
         version: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.24.4))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.24.4))(eslint@9.4.0)(typescript@5.4.5)
@@ -36,6 +39,9 @@ importers:
       nx:
         specifier: 17.1.3
         version: 17.1.3
+      tsx:
+        specifier: ^4.7.1
+        version: 4.19.2
 
   apps/bridge-app:
     dependencies:
@@ -1893,6 +1899,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
@@ -1902,6 +1914,12 @@ packages:
   '@esbuild/android-arm64@0.20.2':
     resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -1917,6 +1935,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
@@ -1926,6 +1950,12 @@ packages:
   '@esbuild/android-x64@0.20.2':
     resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -1941,6 +1971,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.19.12':
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
@@ -1950,6 +1986,12 @@ packages:
   '@esbuild/darwin-x64@0.20.2':
     resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -1965,6 +2007,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.19.12':
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
@@ -1974,6 +2022,12 @@ packages:
   '@esbuild/freebsd-x64@0.20.2':
     resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -1989,6 +2043,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.19.12':
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
@@ -1998,6 +2058,12 @@ packages:
   '@esbuild/linux-arm@0.20.2':
     resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -2013,6 +2079,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.19.12':
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
@@ -2022,6 +2094,12 @@ packages:
   '@esbuild/linux-loong64@0.20.2':
     resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -2037,6 +2115,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.19.12':
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
@@ -2046,6 +2130,12 @@ packages:
   '@esbuild/linux-ppc64@0.20.2':
     resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -2061,6 +2151,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.19.12':
     resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
@@ -2070,6 +2166,12 @@ packages:
   '@esbuild/linux-s390x@0.20.2':
     resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -2085,6 +2187,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-x64@0.19.12':
     resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
     engines: {node: '>=12'}
@@ -2097,6 +2205,18 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.19.12':
     resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
@@ -2106,6 +2226,12 @@ packages:
   '@esbuild/openbsd-x64@0.20.2':
     resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -2121,6 +2247,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.19.12':
     resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
@@ -2130,6 +2262,12 @@ packages:
   '@esbuild/win32-arm64@0.20.2':
     resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -2145,6 +2283,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.19.12':
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
@@ -2154,6 +2298,12 @@ packages:
   '@esbuild/win32-x64@0.20.2':
     resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -6804,6 +6954,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -7491,6 +7646,9 @@ packages:
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.0:
+    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
@@ -10214,6 +10372,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve-tspaths@0.8.18:
     resolution: {integrity: sha512-68fFbsR+m8l1KLQxcUp+yd6H5QWtaORIXnC9iln5rfex5RzBTXqJ/I9Cgi6nr2fVODYI5ptcGv/CmcLCoaChVg==}
     hasBin: true
@@ -11102,6 +11263,11 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tsx@4.19.2:
+    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tty-table@4.2.3:
     resolution: {integrity: sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==}
@@ -14570,10 +14736,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.20.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
   '@esbuild/android-arm64@0.19.12':
     optional: true
 
   '@esbuild/android-arm64@0.20.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm@0.19.12':
@@ -14582,10 +14754,16 @@ snapshots:
   '@esbuild/android-arm@0.20.2':
     optional: true
 
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
   '@esbuild/android-x64@0.19.12':
     optional: true
 
   '@esbuild/android-x64@0.20.2':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.12':
@@ -14594,10 +14772,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.20.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.19.12':
     optional: true
 
   '@esbuild/darwin-x64@0.20.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.12':
@@ -14606,10 +14790,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.20.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.19.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.20.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/linux-arm64@0.19.12':
@@ -14618,10 +14808,16 @@ snapshots:
   '@esbuild/linux-arm64@0.20.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
   '@esbuild/linux-arm@0.19.12':
     optional: true
 
   '@esbuild/linux-arm@0.20.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-ia32@0.19.12':
@@ -14630,10 +14826,16 @@ snapshots:
   '@esbuild/linux-ia32@0.20.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.19.12':
     optional: true
 
   '@esbuild/linux-loong64@0.20.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.12':
@@ -14642,10 +14844,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.20.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.19.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.20.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.12':
@@ -14654,10 +14862,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.20.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.19.12':
     optional: true
 
   '@esbuild/linux-s390x@0.20.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.23.1':
     optional: true
 
   '@esbuild/linux-x64@0.19.12':
@@ -14666,10 +14880,19 @@ snapshots:
   '@esbuild/linux-x64@0.20.2':
     optional: true
 
+  '@esbuild/linux-x64@0.23.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.19.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.20.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.12':
@@ -14678,10 +14901,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.20.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.23.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.19.12':
     optional: true
 
   '@esbuild/sunos-x64@0.20.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.19.12':
@@ -14690,16 +14919,25 @@ snapshots:
   '@esbuild/win32-arm64@0.20.2':
     optional: true
 
+  '@esbuild/win32-arm64@0.23.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
   '@esbuild/win32-ia32@0.20.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
   '@esbuild/win32-x64@0.19.12':
     optional: true
 
   '@esbuild/win32-x64@0.20.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -14976,7 +15214,7 @@ snapshots:
 
   '@ethereumjs/tx@3.4.0':
     dependencies:
-      '@ethereumjs/common': 2.6.0
+      '@ethereumjs/common': 2.6.5
       ethereumjs-util: 7.1.3
 
   '@ethereumjs/tx@3.5.2':
@@ -15001,7 +15239,7 @@ snapshots:
     dependencies:
       '@ethereumjs/block': 3.6.3
       '@ethereumjs/blockchain': 5.5.3
-      '@ethereumjs/common': 2.6.0
+      '@ethereumjs/common': 2.6.5
       '@ethereumjs/tx': 3.5.2
       async-eventemitter: 0.2.4
       core-js-pure: 3.37.1
@@ -15897,7 +16135,7 @@ snapshots:
       '@types/debug': 4.1.12
       debug: 4.3.5
       pony-cause: 2.1.11
-      semver: 7.6.2
+      semver: 7.6.3
       superstruct: 1.0.4
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -15908,7 +16146,7 @@ snapshots:
       '@motionone/easing': 10.17.0
       '@motionone/types': 10.17.0
       '@motionone/utils': 10.17.0
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@motionone/dom@10.17.0':
     dependencies:
@@ -15917,7 +16155,7 @@ snapshots:
       '@motionone/types': 10.17.0
       '@motionone/utils': 10.17.0
       hey-listen: 1.0.8
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@motionone/easing@10.17.0':
     dependencies:
@@ -15933,7 +16171,7 @@ snapshots:
   '@motionone/svelte@10.16.4':
     dependencies:
       '@motionone/dom': 10.17.0
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@motionone/types@10.17.0': {}
 
@@ -15941,12 +16179,12 @@ snapshots:
     dependencies:
       '@motionone/types': 10.17.0
       hey-listen: 1.0.8
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@motionone/vue@10.16.4':
     dependencies:
       '@motionone/dom': 10.17.0
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@ndelangen/get-tarball@3.0.9':
     dependencies:
@@ -16131,9 +16369,9 @@ snapshots:
     transitivePeerDependencies:
       - nx
 
-  '@nrwl/jest@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)':
+  '@nrwl/jest@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)':
     dependencies:
-      '@nx/jest': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)
+      '@nx/jest': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -16149,9 +16387,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.2.2)':
+  '@nrwl/js@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.2.2)':
     dependencies:
-      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.2.2)
+      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.2.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -16164,9 +16402,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)':
+  '@nrwl/js@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)':
     dependencies:
-      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)
+      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -16179,9 +16417,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/nx-plugin@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)':
+  '@nrwl/nx-plugin@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)':
     dependencies:
-      '@nx/plugin': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)
+      '@nx/plugin': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -16226,11 +16464,11 @@ snapshots:
       tmp: 0.2.3
       tslib: 2.6.2
 
-  '@nx/eslint@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(eslint@9.4.0)(nx@17.1.3)':
+  '@nx/eslint@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(eslint@9.4.0)(nx@17.1.3)':
     dependencies:
       '@nx/devkit': 17.1.3(nx@17.1.3)
-      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.2.2)
-      '@nx/linter': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(eslint@9.4.0)(nx@17.1.3)
+      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.2.2)
+      '@nx/linter': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(eslint@9.4.0)(nx@17.1.3)
       tslib: 2.6.2
       typescript: 5.2.2
     optionalDependencies:
@@ -16246,17 +16484,17 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)':
+  '@nx/jest@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)':
     dependencies:
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@nrwl/jest': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)
+      '@nrwl/jest': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
       '@nx/devkit': 17.1.3(nx@17.1.3)
-      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)
+      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
       chalk: 4.1.2
       identity-obj-proxy: 3.0.0
-      jest-config: 29.7.0(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))
       jest-resolve: 29.7.0
       jest-util: 29.7.0
       resolve.exports: 1.1.0
@@ -16276,7 +16514,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.2.2)':
+  '@nx/js@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.2.2)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
@@ -16285,7 +16523,7 @@ snapshots:
       '@babel/preset-env': 7.24.4(@babel/core@7.24.4)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.4)
       '@babel/runtime': 7.24.4
-      '@nrwl/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.2.2)
+      '@nrwl/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.2.2)
       '@nx/devkit': 17.1.3(nx@17.1.3)
       '@nx/workspace': 17.1.3
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.2.2)
@@ -16305,7 +16543,7 @@ snapshots:
       ora: 5.3.0
       semver: 7.5.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@types/node@22.5.4)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@20.14.11)(typescript@5.2.2)
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -16319,7 +16557,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/js@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)':
+  '@nx/js@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
@@ -16328,7 +16566,7 @@ snapshots:
       '@babel/preset-env': 7.24.4(@babel/core@7.24.4)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.4)
       '@babel/runtime': 7.24.4
-      '@nrwl/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)
+      '@nrwl/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)
       '@nx/devkit': 17.1.3(nx@17.1.3)
       '@nx/workspace': 17.1.3
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
@@ -16348,7 +16586,7 @@ snapshots:
       ora: 5.3.0
       semver: 7.5.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@types/node@22.5.4)(typescript@5.4.5)
+      ts-node: 10.9.1(@types/node@20.14.11)(typescript@5.4.5)
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -16362,9 +16600,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/linter@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(eslint@9.4.0)(nx@17.1.3)':
+  '@nx/linter@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(eslint@9.4.0)(nx@17.1.3)':
     dependencies:
-      '@nx/eslint': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(eslint@9.4.0)(nx@17.1.3)
+      '@nx/eslint': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(eslint@9.4.0)(nx@17.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -16407,13 +16645,13 @@ snapshots:
   '@nx/nx-win32-x64-msvc@17.1.3':
     optional: true
 
-  '@nx/plugin@17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)':
+  '@nx/plugin@17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)':
     dependencies:
-      '@nrwl/nx-plugin': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)
+      '@nrwl/nx-plugin': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(eslint@9.4.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
       '@nx/devkit': 17.1.3(nx@17.1.3)
-      '@nx/eslint': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(eslint@9.4.0)(nx@17.1.3)
-      '@nx/jest': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5))(typescript@5.4.5)
-      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@22.5.4)(nx@17.1.3)(typescript@5.4.5)
+      '@nx/eslint': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(eslint@9.4.0)(nx@17.1.3)
+      '@nx/jest': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(nx@17.1.3)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5))(typescript@5.4.5)
+      '@nx/js': 17.1.3(@babel/traverse@7.24.8)(@types/node@20.14.11)(nx@17.1.3)(typescript@5.4.5)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
       fs-extra: 11.2.0
       tslib: 2.6.2
@@ -20495,7 +20733,7 @@ snapshots:
   '@yarnpkg/esbuild-plugin-pnp@3.0.0-rc.15(esbuild@0.20.2)':
     dependencies:
       esbuild: 0.20.2
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   '@yarnpkg/fslib@2.10.3':
     dependencies:
@@ -20809,7 +21047,7 @@ snapshots:
 
   ast-types@0.16.1:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
 
   astral-regex@1.0.0: {}
 
@@ -22358,6 +22596,33 @@ snapshots:
       '@esbuild/win32-ia32': 0.20.2
       '@esbuild/win32-x64': 0.20.2
 
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+
   escalade@3.1.2: {}
 
   escape-html@1.0.3: {}
@@ -23340,6 +23605,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
 
+  get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
@@ -24203,7 +24472,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.5.4)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
@@ -24228,8 +24497,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.5.4
-      ts-node: 10.9.2(@types/node@22.5.4)(typescript@5.4.5)
+      '@types/node': 20.14.11
+      ts-node: 10.9.2(@types/node@20.14.11)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26941,6 +27210,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve-tspaths@0.8.18(typescript@5.4.5):
     dependencies:
       ansi-colors: 4.1.3
@@ -27914,14 +28185,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.1(@types/node@22.5.4)(typescript@5.2.2):
+  ts-node@10.9.1(@types/node@20.14.11)(typescript@5.2.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.5.4
+      '@types/node': 20.14.11
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -27932,14 +28203,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@22.5.4)(typescript@5.4.5):
+  ts-node@10.9.1(@types/node@20.14.11)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.5.4
+      '@types/node': 20.14.11
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -27967,6 +28238,25 @@ snapshots:
       typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@20.14.11)(typescript@5.4.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.11
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@22.5.4)(typescript@5.4.5):
     dependencies:
@@ -28035,6 +28325,13 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.4.5
+
+  tsx@4.19.2:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tty-table@4.2.3:
     dependencies:

--- a/scripts/update-supersim-version.ts
+++ b/scripts/update-supersim-version.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env tsx
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs'
+import { resolve, join, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Get the directory name of the current module
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Function to check if a specific release version exists on GitHub
+async function checkVersionExists(version: string): Promise<boolean> {
+  const testUrl = `https://github.com/ethereum-optimism/supersim/releases/download/${version}/supersim_Darwin_arm64.tar.gz`
+
+  try {
+    const response = await fetch(testUrl)
+    return response.status === 200
+  } catch (error) {
+    console.error(
+      `❌ Version ${version} does not exist on GitHub releases`,
+      error,
+    )
+    return false
+  }
+}
+
+// Function to generate a random changeset name
+function generateChangesetName(): string {
+  const adjectives = [
+    'happy',
+    'silly',
+    'grumpy',
+    'brave',
+    'clever',
+    'quiet',
+    'loud',
+  ]
+  const nouns = ['dogs', 'cats', 'birds', 'terms', 'lions', 'bears', 'fish']
+  const verbs = ['jump', 'run', 'taste', 'sleep', 'dance', 'sing', 'play']
+
+  const randomElement = (arr: string[]) =>
+    arr[Math.floor(Math.random() * arr.length)]
+  return `${randomElement(adjectives)}-${randomElement(nouns)}-${randomElement(verbs)}`
+}
+
+async function updateSupersimVersion(version: string) {
+  // First check if the version exists
+  console.log(`Checking if version ${version} exists...`)
+  const exists = await checkVersionExists(version)
+  if (!exists) {
+    console.error(`❌ Version ${version} does not exist on GitHub releases`)
+    process.exit(1)
+  }
+
+  // 1. Update install.js
+  const installJsPath = resolve(__dirname, '../packages/supersim/install.js')
+  let installJsContent = readFileSync(installJsPath, 'utf-8')
+
+  installJsContent = installJsContent.replace(
+    /const SUPERSIM_VERSION = ['"].*['"]/,
+    `const SUPERSIM_VERSION = '${version}'`,
+  )
+
+  writeFileSync(installJsPath, installJsContent)
+
+  // 2. Create changeset file
+  const changesetDir = resolve(__dirname, '../.changeset')
+  if (!existsSync(changesetDir)) {
+    mkdirSync(changesetDir, { recursive: true })
+  }
+
+  const changesetContent = `---
+'supersim': ${version}
+---
+
+bumped supersim to ${version}
+`
+
+  const changesetPath = join(changesetDir, `${generateChangesetName()}.md`)
+  writeFileSync(changesetPath, changesetContent)
+
+  console.log(`✅ Updated supersim version to ${version}`)
+  console.log(`✅ Created changeset file: ${basename(changesetPath)}`)
+}
+
+// Get version from command line argument
+const version = process.argv[2]
+if (!version) {
+  console.error('Please provide a version number as an argument')
+  process.exit(1)
+}
+
+// Make the main function async
+;(async () => {
+  try {
+    await updateSupersimVersion(version)
+  } catch (err) {
+    console.error('Error updating supersim version:', err)
+    process.exit(1)
+  }
+})()


### PR DESCRIPTION
when running 

```
pnpm update:supersim 0.1.0-alpha.36
```

it will
1. check that that release is available on github releases
2. generate a changesets file
3. update install.js with correct version

this will help align our npm package version to the goreleaser version