### PR TITLE
feat: release supersim 0.1.0-alpha.44 and update viem `buildExecutingMessage` action

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 node = "18.18.1"
 
-"ubi:ethereum-optimism/supersim"="0.1.0-alpha.43"
+"ubi:ethereum-optimism/supersim"="0.1.0-alpha.44"
 
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same

--- a/nx.json
+++ b/nx.json
@@ -34,7 +34,8 @@
       "{workspaceRoot}/.prettierrc.js",
       "{workspaceRoot}/tsconfig.json",
       "{workspaceRoot}/eslintrc.js",
-      "{workspaceRoot}/nx.json"
+      "{workspaceRoot}/nx.json",
+      "{workspaceRoot}/mise.toml"
     ],
     "production": ["default"]
   }

--- a/packages/supersim/install.js
+++ b/packages/supersim/install.js
@@ -7,7 +7,7 @@ const { exec } = require('child_process')
 const PLATFORM = os.platform()
 const ARCH = os.arch()
 const BIN_PATH = path.join(__dirname, 'bin')
-const SUPERSIM_VERSION = '0.1.0-alpha.43'
+const SUPERSIM_VERSION = '0.1.0-alpha.44'
 
 const archiveFilename = {
   darwin: {

--- a/packages/supersim/package.json
+++ b/packages/supersim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supersim",
-  "version": "0.1.0-alpha.43",
+  "version": "0.1.0-alpha.44",
   "description": "Supersim is a lightweight tool to simulate the Superchain locally",
   "license": "MIT",
   "author": "Optimism PBC",

--- a/packages/viem/docs/actions/interop/functions/buildExecutingMessage.md
+++ b/packages/viem/docs/actions/interop/functions/buildExecutingMessage.md
@@ -46,4 +46,4 @@ const params = await buildExecutingMessage(publicClientOp, { log: receipt.logs[0
 
 ## Defined in
 
-[packages/viem/src/actions/interop/buildExecutingMessage.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/buildExecutingMessage.ts#L56)
+[packages/viem/src/actions/interop/buildExecutingMessage.ts:59](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/buildExecutingMessage.ts#L59)

--- a/packages/viem/docs/actions/interop/functions/depositSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/depositSuperchainWETH.md
@@ -48,4 +48,4 @@ const hash = await depositSuperchainWETH(client, { account: '0x...', value: 1n }
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:71](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L71)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:71](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L71)

--- a/packages/viem/docs/actions/interop/functions/estimateDepositSuperchainWETHGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateDepositSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:98](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L98)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:98](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L98)

--- a/packages/viem/docs/actions/interop/functions/estimateRelayCrossDomainMessageGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateRelayCrossDomainMessageGas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:120](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L120)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:120](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L120)

--- a/packages/viem/docs/actions/interop/functions/estimateSendCrossDomainMessageGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateSendCrossDomainMessageGas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L106)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L106)

--- a/packages/viem/docs/actions/interop/functions/estimateSendETHGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateSendETHGas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendETH.ts#L96)
+[packages/viem/src/actions/interop/sendETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L96)

--- a/packages/viem/docs/actions/interop/functions/estimateSendSuperchainERC20Gas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateSendSuperchainERC20Gas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L106)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L106)

--- a/packages/viem/docs/actions/interop/functions/estimateWithdrawSuperchainWETHGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateWithdrawSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L96)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L96)

--- a/packages/viem/docs/actions/interop/functions/getCrossDomainMessageStatus.md
+++ b/packages/viem/docs/actions/interop/functions/getCrossDomainMessageStatus.md
@@ -50,4 +50,4 @@ const status = await getCrossDomainMessageStatus(publicClientUnichain, { message
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L53)
+[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L53)

--- a/packages/viem/docs/actions/interop/functions/getCrossDomainMessages.md
+++ b/packages/viem/docs/actions/interop/functions/getCrossDomainMessages.md
@@ -47,4 +47,4 @@ const messages = await getCrossDomainMessages(publicClientOp, { logs: receipt.lo
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessages.ts:33](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L33)
+[packages/viem/src/actions/interop/getCrossDomainMessages.ts:33](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L33)

--- a/packages/viem/docs/actions/interop/functions/relayCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/relayCrossDomainMessage.md
@@ -55,4 +55,4 @@ const hash = await relayCrossDomainMessage(publicClientUnichain, params)
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:87](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L87)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:87](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L87)

--- a/packages/viem/docs/actions/interop/functions/sendCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/sendCrossDomainMessage.md
@@ -36,4 +36,4 @@ transaction hash - [SendCrossDomainMessageReturnType](../type-aliases/SendCrossD
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L77)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L77)

--- a/packages/viem/docs/actions/interop/functions/sendETH.md
+++ b/packages/viem/docs/actions/interop/functions/sendETH.md
@@ -36,4 +36,4 @@ transaction hash - [SendETHContractReturnType](../type-aliases/SendETHContractRe
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendETH.ts#L67)
+[packages/viem/src/actions/interop/sendETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L67)

--- a/packages/viem/docs/actions/interop/functions/sendSuperchainERC20.md
+++ b/packages/viem/docs/actions/interop/functions/sendSuperchainERC20.md
@@ -36,4 +36,4 @@ transaction hash - [SendSuperchainERC20ReturnType](../type-aliases/SendSuperchai
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L77)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L77)

--- a/packages/viem/docs/actions/interop/functions/simulateDepositSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/simulateDepositSuperchainWETH.md
@@ -36,4 +36,4 @@ contract return value - [DepositSuperchainWETHContractReturnType](../type-aliase
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L122)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L122)

--- a/packages/viem/docs/actions/interop/functions/simulateRelayCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/simulateRelayCrossDomainMessage.md
@@ -36,4 +36,4 @@ contract return value - [RelayCrossDomainMessageContractReturnType](../type-alia
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:150](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L150)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:150](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L150)

--- a/packages/viem/docs/actions/interop/functions/simulateSendCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/simulateSendCrossDomainMessage.md
@@ -36,4 +36,4 @@ contract return value - [SendCrossDomainMessageContractReturnType](../type-alias
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:136](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L136)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:136](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L136)

--- a/packages/viem/docs/actions/interop/functions/simulateSendETH.md
+++ b/packages/viem/docs/actions/interop/functions/simulateSendETH.md
@@ -36,4 +36,4 @@ contract return value - [SendETHContractReturnType](../type-aliases/SendETHContr
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendETH.ts#L122)
+[packages/viem/src/actions/interop/sendETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L122)

--- a/packages/viem/docs/actions/interop/functions/simulateSendSuperchainERC20.md
+++ b/packages/viem/docs/actions/interop/functions/simulateSendSuperchainERC20.md
@@ -36,4 +36,4 @@ contract return value - [SendSuperchainERC20ContractReturnType](../type-aliases/
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:132](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L132)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:132](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L132)

--- a/packages/viem/docs/actions/interop/functions/simulateWithdrawSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/simulateWithdrawSuperchainWETH.md
@@ -36,4 +36,4 @@ contract return value - [WithdrawSuperchainWETHContractReturnType](../type-alias
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:126](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L126)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:126](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L126)

--- a/packages/viem/docs/actions/interop/functions/withdrawSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/withdrawSuperchainWETH.md
@@ -36,4 +36,4 @@ transaction hash - [WithdrawSuperchainWETHReturnType](../type-aliases/WithdrawSu
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L67)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L67)

--- a/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/buildExecutingMessage.ts:14](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/buildExecutingMessage.ts#L14)
+[packages/viem/src/actions/interop/buildExecutingMessage.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/buildExecutingMessage.ts#L16)

--- a/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageReturnType.md
@@ -10,6 +10,10 @@
 
 ## Type declaration
 
+### accessList
+
+> **accessList**: `AccessList`
+
 ### id
 
 > **id**: [`MessageIdentifier`](../../../index/type-aliases/MessageIdentifier.md)
@@ -20,4 +24,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/buildExecutingMessage.ts:19](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/buildExecutingMessage.ts#L19)
+[packages/viem/src/actions/interop/buildExecutingMessage.ts:21](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/buildExecutingMessage.ts#L21)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L45)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L45)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L51)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L51)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHParameters.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:25](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L25)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:25](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L25)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:40](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L40)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:40](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L40)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:13](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L13)
+[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:13](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L13)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:20](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L20)
+[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:20](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L20)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessages.ts:10](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L10)
+[packages/viem/src/actions/interop/getCrossDomainMessages.ts:10](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L10)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessages.ts:15](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L15)
+[packages/viem/src/actions/interop/getCrossDomainMessages.ts:15](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L15)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L50)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L50)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:60](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L60)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:60](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L60)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageParameters.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L28)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L28)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L45)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L45)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L55)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L55)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L65)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L65)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageParameters.md
@@ -40,4 +40,4 @@ Target contract or wallet address.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L28)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L28)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L50)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L50)

--- a/packages/viem/docs/actions/interop/type-aliases/SendETHContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendETH.ts#L46)
+[packages/viem/src/actions/interop/sendETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L46)

--- a/packages/viem/docs/actions/interop/type-aliases/SendETHErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendETH.ts#L55)
+[packages/viem/src/actions/interop/sendETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L55)

--- a/packages/viem/docs/actions/interop/type-aliases/SendETHParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendETHParameters.md
@@ -34,4 +34,4 @@ Address to send ETH to.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendETH.ts#L26)
+[packages/viem/src/actions/interop/sendETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L26)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L56)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L56)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L65)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L65)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20Parameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20Parameters.md
@@ -46,4 +46,4 @@ Token to send.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L27)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L27)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L51)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L51)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:49](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L49)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:49](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L49)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L55)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L55)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHParameters.md
@@ -28,4 +28,4 @@ Amount of SuperchainWETH to withdraw.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L26)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L26)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:44](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L44)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:44](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L44)

--- a/packages/viem/docs/chains/variables/arenaZ.md
+++ b/packages/viem/docs/chains/variables/arenaZ.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L8)
+[packages/viem/src/chains/mainnet.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L8)

--- a/packages/viem/docs/chains/variables/arenaZSepolia.md
+++ b/packages/viem/docs/chains/variables/arenaZSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L8)
+[packages/viem/src/chains/sepolia.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L8)

--- a/packages/viem/docs/chains/variables/automata.md
+++ b/packages/viem/docs/chains/variables/automata.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L67)
+[packages/viem/src/chains/mainnet.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L67)

--- a/packages/viem/docs/chains/variables/base.md
+++ b/packages/viem/docs/chains/variables/base.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L131)
+[packages/viem/src/chains/mainnet.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L131)

--- a/packages/viem/docs/chains/variables/baseSepolia.md
+++ b/packages/viem/docs/chains/variables/baseSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:72](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L72)
+[packages/viem/src/chains/sepolia.ts:72](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L72)

--- a/packages/viem/docs/chains/variables/cyber.md
+++ b/packages/viem/docs/chains/variables/cyber.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L195)
+[packages/viem/src/chains/mainnet.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L195)

--- a/packages/viem/docs/chains/variables/cyberSepolia.md
+++ b/packages/viem/docs/chains/variables/cyberSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L131)
+[packages/viem/src/chains/sepolia.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L131)

--- a/packages/viem/docs/chains/variables/ethernity.md
+++ b/packages/viem/docs/chains/variables/ethernity.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L259)
+[packages/viem/src/chains/mainnet.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L259)

--- a/packages/viem/docs/chains/variables/ethernitySepolia.md
+++ b/packages/viem/docs/chains/variables/ethernitySepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L195)
+[packages/viem/src/chains/sepolia.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L195)

--- a/packages/viem/docs/chains/variables/funki.md
+++ b/packages/viem/docs/chains/variables/funki.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L323)
+[packages/viem/src/chains/mainnet.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L323)

--- a/packages/viem/docs/chains/variables/funkiSepolia.md
+++ b/packages/viem/docs/chains/variables/funkiSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L259)
+[packages/viem/src/chains/sepolia.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L259)

--- a/packages/viem/docs/chains/variables/ink.md
+++ b/packages/viem/docs/chains/variables/ink.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:387](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L387)
+[packages/viem/src/chains/mainnet.ts:387](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L387)

--- a/packages/viem/docs/chains/variables/inkSepolia.md
+++ b/packages/viem/docs/chains/variables/inkSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L323)
+[packages/viem/src/chains/sepolia.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L323)

--- a/packages/viem/docs/chains/variables/interopAlpha0.md
+++ b/packages/viem/docs/chains/variables/interopAlpha0.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/interopAlpha.ts:22](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/interopAlpha.ts#L22)
+[packages/viem/src/chains/interopAlpha.ts:22](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/interopAlpha.ts#L22)

--- a/packages/viem/docs/chains/variables/interopAlpha1.md
+++ b/packages/viem/docs/chains/variables/interopAlpha1.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/interopAlpha.ts:57](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/interopAlpha.ts#L57)
+[packages/viem/src/chains/interopAlpha.ts:57](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/interopAlpha.ts#L57)

--- a/packages/viem/docs/chains/variables/interopAlphaChains.md
+++ b/packages/viem/docs/chains/variables/interopAlphaChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/interopAlpha.ts:83](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/interopAlpha.ts#L83)
+[packages/viem/src/chains/interopAlpha.ts:83](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/interopAlpha.ts#L83)

--- a/packages/viem/docs/chains/variables/lisk.md
+++ b/packages/viem/docs/chains/variables/lisk.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L446)
+[packages/viem/src/chains/mainnet.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L446)

--- a/packages/viem/docs/chains/variables/liskSepolia.md
+++ b/packages/viem/docs/chains/variables/liskSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:382](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L382)
+[packages/viem/src/chains/sepolia.ts:382](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L382)

--- a/packages/viem/docs/chains/variables/lyra.md
+++ b/packages/viem/docs/chains/variables/lyra.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:510](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L510)
+[packages/viem/src/chains/mainnet.ts:510](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L510)

--- a/packages/viem/docs/chains/variables/mainnetChains.md
+++ b/packages/viem/docs/chains/variables/mainnetChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1363](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L1363)
+[packages/viem/src/chains/mainnet.ts:1363](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1363)

--- a/packages/viem/docs/chains/variables/metal.md
+++ b/packages/viem/docs/chains/variables/metal.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L569)
+[packages/viem/src/chains/mainnet.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L569)

--- a/packages/viem/docs/chains/variables/metalSepolia.md
+++ b/packages/viem/docs/chains/variables/metalSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L446)
+[packages/viem/src/chains/sepolia.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L446)

--- a/packages/viem/docs/chains/variables/minatoSepolia.md
+++ b/packages/viem/docs/chains/variables/minatoSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:505](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L505)
+[packages/viem/src/chains/sepolia.ts:505](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L505)

--- a/packages/viem/docs/chains/variables/mode.md
+++ b/packages/viem/docs/chains/variables/mode.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L628)
+[packages/viem/src/chains/mainnet.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L628)

--- a/packages/viem/docs/chains/variables/modeSepolia.md
+++ b/packages/viem/docs/chains/variables/modeSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L569)
+[packages/viem/src/chains/sepolia.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L569)

--- a/packages/viem/docs/chains/variables/op.md
+++ b/packages/viem/docs/chains/variables/op.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L687)
+[packages/viem/src/chains/mainnet.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L687)

--- a/packages/viem/docs/chains/variables/opSepolia.md
+++ b/packages/viem/docs/chains/variables/opSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L628)
+[packages/viem/src/chains/sepolia.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L628)

--- a/packages/viem/docs/chains/variables/orderly.md
+++ b/packages/viem/docs/chains/variables/orderly.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L746)
+[packages/viem/src/chains/mainnet.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L746)

--- a/packages/viem/docs/chains/variables/race.md
+++ b/packages/viem/docs/chains/variables/race.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:805](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L805)
+[packages/viem/src/chains/mainnet.ts:805](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L805)

--- a/packages/viem/docs/chains/variables/raceSepolia.md
+++ b/packages/viem/docs/chains/variables/raceSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L687)
+[packages/viem/src/chains/sepolia.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L687)

--- a/packages/viem/docs/chains/variables/redstone.md
+++ b/packages/viem/docs/chains/variables/redstone.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:864](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L864)
+[packages/viem/src/chains/mainnet.ts:864](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L864)

--- a/packages/viem/docs/chains/variables/sepoliaChains.md
+++ b/packages/viem/docs/chains/variables/sepoliaChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:1053](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L1053)
+[packages/viem/src/chains/sepolia.ts:1053](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L1053)

--- a/packages/viem/docs/chains/variables/shape.md
+++ b/packages/viem/docs/chains/variables/shape.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:928](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L928)
+[packages/viem/src/chains/mainnet.ts:928](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L928)

--- a/packages/viem/docs/chains/variables/shapeSepolia.md
+++ b/packages/viem/docs/chains/variables/shapeSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L746)
+[packages/viem/src/chains/sepolia.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L746)

--- a/packages/viem/docs/chains/variables/sseed.md
+++ b/packages/viem/docs/chains/variables/sseed.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:992](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L992)
+[packages/viem/src/chains/mainnet.ts:992](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L992)

--- a/packages/viem/docs/chains/variables/supersimChains.md
+++ b/packages/viem/docs/chains/variables/supersimChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:142](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L142)
+[packages/viem/src/chains/supersim.ts:142](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L142)

--- a/packages/viem/docs/chains/variables/supersimL1.md
+++ b/packages/viem/docs/chains/variables/supersimL1.md
@@ -436,4 +436,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L17)
+[packages/viem/src/chains/supersim.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L17)

--- a/packages/viem/docs/chains/variables/supersimL2A.md
+++ b/packages/viem/docs/chains/variables/supersimL2A.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:36](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L36)
+[packages/viem/src/chains/supersim.ts:36](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L36)

--- a/packages/viem/docs/chains/variables/supersimL2B.md
+++ b/packages/viem/docs/chains/variables/supersimL2B.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:58](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L58)
+[packages/viem/src/chains/supersim.ts:58](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L58)

--- a/packages/viem/docs/chains/variables/supersimL2C.md
+++ b/packages/viem/docs/chains/variables/supersimL2C.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:80](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L80)
+[packages/viem/src/chains/supersim.ts:80](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L80)

--- a/packages/viem/docs/chains/variables/supersimL2D.md
+++ b/packages/viem/docs/chains/variables/supersimL2D.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:102](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L102)
+[packages/viem/src/chains/supersim.ts:102](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L102)

--- a/packages/viem/docs/chains/variables/supersimL2E.md
+++ b/packages/viem/docs/chains/variables/supersimL2E.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:124](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/supersim.ts#L124)
+[packages/viem/src/chains/supersim.ts:124](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L124)

--- a/packages/viem/docs/chains/variables/swan.md
+++ b/packages/viem/docs/chains/variables/swan.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1056](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L1056)
+[packages/viem/src/chains/mainnet.ts:1056](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1056)

--- a/packages/viem/docs/chains/variables/swell.md
+++ b/packages/viem/docs/chains/variables/swell.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1120](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L1120)
+[packages/viem/src/chains/mainnet.ts:1120](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1120)

--- a/packages/viem/docs/chains/variables/tbn.md
+++ b/packages/viem/docs/chains/variables/tbn.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1179](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L1179)
+[packages/viem/src/chains/mainnet.ts:1179](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1179)

--- a/packages/viem/docs/chains/variables/tbnSepolia.md
+++ b/packages/viem/docs/chains/variables/tbnSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:810](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L810)
+[packages/viem/src/chains/sepolia.ts:810](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L810)

--- a/packages/viem/docs/chains/variables/unichainSepolia.md
+++ b/packages/viem/docs/chains/variables/unichainSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:874](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L874)
+[packages/viem/src/chains/sepolia.ts:874](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L874)

--- a/packages/viem/docs/chains/variables/worldchain.md
+++ b/packages/viem/docs/chains/variables/worldchain.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1243](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L1243)
+[packages/viem/src/chains/mainnet.ts:1243](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1243)

--- a/packages/viem/docs/chains/variables/worldchainSepolia.md
+++ b/packages/viem/docs/chains/variables/worldchainSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:933](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L933)
+[packages/viem/src/chains/sepolia.ts:933](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L933)

--- a/packages/viem/docs/chains/variables/zora.md
+++ b/packages/viem/docs/chains/variables/zora.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1307](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/mainnet.ts#L1307)
+[packages/viem/src/chains/mainnet.ts:1307](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1307)

--- a/packages/viem/docs/chains/variables/zoraSepolia.md
+++ b/packages/viem/docs/chains/variables/zoraSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:997](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/chains/sepolia.ts#L997)
+[packages/viem/src/chains/sepolia.ts:997](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L997)

--- a/packages/viem/docs/index/type-aliases/MessageIdentifier.md
+++ b/packages/viem/docs/index/type-aliases/MessageIdentifier.md
@@ -44,4 +44,4 @@ The timestamp that the log was emitted. Used to enforce the timestamp invariant
 
 ## Defined in
 
-[packages/viem/src/types/interop/executingMessage.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/types/interop/executingMessage.ts#L7)
+[packages/viem/src/types/interop/executingMessage.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/types/interop/executingMessage.ts#L7)

--- a/packages/viem/docs/index/variables/contracts.md
+++ b/packages/viem/docs/index/variables/contracts.md
@@ -110,4 +110,4 @@ OP Stack Predeploy Addresses
 
 ## Defined in
 
-[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/contracts.ts#L8)
+[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/contracts.ts#L8)

--- a/packages/viem/docs/index/variables/crossDomainMessengerAbi.md
+++ b/packages/viem/docs/index/variables/crossDomainMessengerAbi.md
@@ -6,10 +6,10 @@
 
 # crossDomainMessengerAbi
 
-> `const` **crossDomainMessengerAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **crossDomainMessengerAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `CrossDomainMessenger`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L7)
+[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L7)

--- a/packages/viem/docs/index/variables/crossL2InboxAbi.md
+++ b/packages/viem/docs/index/variables/crossL2InboxAbi.md
@@ -6,10 +6,10 @@
 
 # crossL2InboxAbi
 
-> `const` **crossL2InboxAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **crossL2InboxAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `CrossL2Inbox`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:401](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L401)
+[packages/viem/src/abis.ts:440](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L440)

--- a/packages/viem/docs/index/variables/l2ToL2CrossDomainMessengerAbi.md
+++ b/packages/viem/docs/index/variables/l2ToL2CrossDomainMessengerAbi.md
@@ -6,10 +6,10 @@
 
 # l2ToL2CrossDomainMessengerAbi
 
-> `const` **l2ToL2CrossDomainMessengerAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **l2ToL2CrossDomainMessengerAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `L2ToL2CrossDomainMessenger`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:622](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L622)
+[packages/viem/src/abis.ts:627](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L627)

--- a/packages/viem/docs/index/variables/optimismMintableERC20Abi.md
+++ b/packages/viem/docs/index/variables/optimismMintableERC20Abi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `OptimismMintableERC20`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:928](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L928)
+[packages/viem/src/abis.ts:918](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L918)

--- a/packages/viem/docs/index/variables/optimismMintableERC20FactoryAbi.md
+++ b/packages/viem/docs/index/variables/optimismMintableERC20FactoryAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `OptimismMintableERC20Factory`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:1508](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L1508)
+[packages/viem/src/abis.ts:1498](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L1498)

--- a/packages/viem/docs/index/variables/standardBridgeAbi.md
+++ b/packages/viem/docs/index/variables/standardBridgeAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `StandardBridge`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:1740](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L1740)
+[packages/viem/src/abis.ts:1730](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L1730)

--- a/packages/viem/docs/index/variables/superchainERC20Abi.md
+++ b/packages/viem/docs/index/variables/superchainERC20Abi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `SuperchainERC20`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:2179](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L2179)
+[packages/viem/src/abis.ts:2169](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L2169)

--- a/packages/viem/docs/index/variables/superchainTokenBridgeAbi.md
+++ b/packages/viem/docs/index/variables/superchainTokenBridgeAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `SuperchainTokenBridge`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:3183](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L3183)
+[packages/viem/src/abis.ts:3178](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L3178)

--- a/packages/viem/docs/index/variables/superchainWETHAbi.md
+++ b/packages/viem/docs/index/variables/superchainWETHAbi.md
@@ -6,10 +6,10 @@
 
 # superchainWETHAbi
 
-> `const` **superchainWETHAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
+> `const` **superchainWETHAbi**: readonly [`object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`, `object`]
 
 ABI for the OP Stack contract `SuperchainWETH`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:2646](https://github.com/ethereum-optimism/ecosystem/blob/17cffb9f4d194af60c7c1f0d0e30d41e88fba084/packages/viem/src/abis.ts#L2646)
+[packages/viem/src/abis.ts:2636](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L2636)

--- a/packages/viem/src/abis.ts
+++ b/packages/viem/src/abis.ts
@@ -7,6 +7,32 @@
 export const crossDomainMessengerAbi = [
   {
     type: 'function',
+    name: 'ENCODING_OVERHEAD',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'FLOOR_CALLDATA_OVERHEAD',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     name: 'MESSAGE_VERSION',
     inputs: [],
     outputs: [
@@ -112,6 +138,19 @@ export const crossDomainMessengerAbi = [
   {
     type: 'function',
     name: 'RELAY_RESERVED_GAS',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'TX_BASE_GAS',
     inputs: [],
     outputs: [
       {
@@ -401,88 +440,54 @@ export const crossDomainMessengerAbi = [
 export const crossL2InboxAbi = [
   {
     type: 'function',
-    name: 'blockNumber',
-    inputs: [],
-    outputs: [
+    name: 'calculateChecksum',
+    inputs: [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
+        name: '_id',
+        type: 'tuple',
+        internalType: 'struct Identifier',
+        components: [
+          {
+            name: 'origin',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'blockNumber',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'logIndex',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'timestamp',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'chainId',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+        ],
+      },
+      {
+        name: '_msgHash',
+        type: 'bytes32',
+        internalType: 'bytes32',
       },
     ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'chainId',
-    inputs: [],
     outputs: [
       {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
+        name: 'checksum_',
+        type: 'bytes32',
+        internalType: 'bytes32',
       },
     ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'interopStart',
-    inputs: [],
-    outputs: [
-      {
-        name: 'interopStart_',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'logIndex',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'origin',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'address',
-        internalType: 'address',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'setInteropStart',
-    inputs: [],
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    name: 'timestamp',
-    inputs: [],
-    outputs: [
-      {
-        name: '',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
+    stateMutability: 'pure',
   },
   {
     type: 'function',
@@ -590,7 +595,12 @@ export const crossL2InboxAbi = [
   },
   {
     type: 'error',
-    name: 'InteropStartAlreadySet',
+    name: 'BlockNumberTooHigh',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'LogIndexTooHigh',
     inputs: [],
   },
   {
@@ -600,17 +610,12 @@ export const crossL2InboxAbi = [
   },
   {
     type: 'error',
-    name: 'NotDepositor',
+    name: 'NotInAccessList',
     inputs: [],
   },
   {
     type: 'error',
-    name: 'NotEntered',
-    inputs: [],
-  },
-  {
-    type: 'error',
-    name: 'ReentrantCall',
+    name: 'TimestampTooHigh',
     inputs: [],
   },
 ] as const
@@ -876,11 +881,6 @@ export const l2ToL2CrossDomainMessengerAbi = [
   },
   {
     type: 'error',
-    name: 'InvalidChainId',
-    inputs: [],
-  },
-  {
-    type: 'error',
     name: 'MessageAlreadyRelayed',
     inputs: [],
   },
@@ -896,11 +896,6 @@ export const l2ToL2CrossDomainMessengerAbi = [
   },
   {
     type: 'error',
-    name: 'MessageTargetCrossL2Inbox',
-    inputs: [],
-  },
-  {
-    type: 'error',
     name: 'MessageTargetL2ToL2CrossDomainMessenger',
     inputs: [],
   },
@@ -912,11 +907,6 @@ export const l2ToL2CrossDomainMessengerAbi = [
   {
     type: 'error',
     name: 'ReentrantCall',
-    inputs: [],
-  },
-  {
-    type: 'error',
-    name: 'TargetCallFailed',
     inputs: [],
   },
 ] as const
@@ -3162,6 +3152,11 @@ export const superchainWETHAbi = [
   {
     type: 'error',
     name: 'InvalidCrossDomainSender',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Permit2AllowanceIsFixedAtInfinity',
     inputs: [],
   },
   {

--- a/packages/viem/src/actions/depositCrossDomainMessage.spec.ts
+++ b/packages/viem/src/actions/depositCrossDomainMessage.spec.ts
@@ -1,4 +1,3 @@
-import type { Address } from 'viem'
 import { createPublicClient, http, parseEventLogs } from 'viem'
 import { extractTransactionDepositedLogs } from 'viem/op-stack'
 import { describe, expect, it } from 'vitest'
@@ -11,11 +10,11 @@ import {
 } from '@/actions/depositCrossDomainMessage.js'
 import { supersimL1 } from '@/chains/supersim.js'
 import { testAccount } from '@/test/clients.js'
+import { supersimL2AL1CrossDomainMessengerAddress } from '@/test/testConstants.js'
 
 describe('depositCrossDomainMessage', () => {
   // Hardcoded since we don't have a good way to pull the L1 contracts for supersim yet.
-  const l1CrossDomainMessengerAddress: Address =
-    '0x9E4EE2B682076951592Cb4da5559833fE62A8C01'
+  const l1CrossDomainMessengerAddress = supersimL2AL1CrossDomainMessengerAddress
 
   const publicL1Client = createPublicClient({
     chain: supersimL1,

--- a/packages/viem/src/actions/depositERC20.spec.ts
+++ b/packages/viem/src/actions/depositERC20.spec.ts
@@ -1,4 +1,3 @@
-import type { Address } from 'viem'
 import { createPublicClient, createWalletClient, erc20Abi, http } from 'viem'
 import { extractTransactionDepositedLogs } from 'viem/op-stack'
 import { describe, expect, it } from 'vitest'
@@ -11,11 +10,11 @@ import {
 import { supersimL1 } from '@/chains/index.js'
 import { contracts } from '@/contracts.js'
 import { testAccount } from '@/test/clients.js'
+import { supersimL2AL1StandardBridgeAddress } from '@/test/testConstants.js'
 
 describe('depositERC20', async () => {
   // Hardcoded since we don't have a good way to pull the L1 contracts for supersim yet.
-  const l1StandardBridgeAddress: Address =
-    '0x31e3C5A665B5b9dBf6D91A72415c6ad71FdD1181'
+  const l1StandardBridgeAddress = supersimL2AL1StandardBridgeAddress
 
   const publicL1Client = createPublicClient({
     chain: supersimL1,

--- a/packages/viem/src/actions/interop/relayCrossDomainMessage.ts
+++ b/packages/viem/src/actions/interop/relayCrossDomainMessage.ts
@@ -159,7 +159,7 @@ export async function simulateRelayCrossDomainMessage<
     TChainOverride
   >,
 ): Promise<RelayCrossDomainMessageContractReturnType> {
-  const { account, id, payload } = parameters
+  const { account, id, payload, accessList } = parameters
 
   const res = await simulateContract(client, {
     account,
@@ -168,6 +168,7 @@ export async function simulateRelayCrossDomainMessage<
     chain: client.chain,
     functionName: 'relayMessage',
     args: [id, payload],
+    accessList,
   } as SimulateContractParameters)
 
   return res.result as RelayCrossDomainMessageContractReturnType

--- a/packages/viem/src/actions/withdrawOptimismERC20.spec.ts
+++ b/packages/viem/src/actions/withdrawOptimismERC20.spec.ts
@@ -16,10 +16,11 @@ import {
 import { supersimL1 } from '@/chains/supersim.js'
 import { contracts } from '@/contracts.js'
 import { publicClientA, testAccount, walletClientA } from '@/test/clients.js'
+import { supersimL2AL1StandardBridgeAddress } from '@/test/testConstants.js'
 
 describe('withdrawOptimismERC20', async () => {
   // Hardcoded since we don't have a good way to pull the L1 contracts for supersim yet.
-  const l1StandardBridgeAddress = '0x31e3C5A665B5b9dBf6D91A72415c6ad71FdD1181'
+  const l1StandardBridgeAddress = supersimL2AL1StandardBridgeAddress
 
   const publicL1Client = createPublicClient({
     chain: supersimL1,

--- a/packages/viem/src/core/baseWriteAction.ts
+++ b/packages/viem/src/core/baseWriteAction.ts
@@ -28,7 +28,6 @@ export type BaseWriteContractActionParameters<
 > = UnionEvaluate<
   UnionOmit<
     FormattedTransactionRequest<derivedChain>,
-    | 'accessList'
     | 'blobs'
     | 'data'
     | 'from'
@@ -82,6 +81,7 @@ export async function baseWriteAction<
     maxPriorityFeePerGas,
     nonce,
     value,
+    accessList,
   } = parameters
 
   const gas_ =
@@ -97,6 +97,7 @@ export async function baseWriteAction<
           maxPriorityFeePerGas,
           nonce,
           value,
+          accessList,
         } as EstimateContractGasParameters)
       : gas ?? undefined
 
@@ -112,5 +113,6 @@ export async function baseWriteAction<
     maxPriorityFeePerGas,
     nonce,
     value,
+    accessList,
   } satisfies WriteContractParameters as any)
 }

--- a/packages/viem/src/test/testConstants.ts
+++ b/packages/viem/src/test/testConstants.ts
@@ -1,0 +1,7 @@
+// Hardcoded since we don't have a good way to pull the L1 contracts for supersim yet.
+export const supersimL2AL1StandardBridgeAddress =
+  '0xe5779130C1b1265Cfb811fCd6c7D47Ca4fE890dd'
+
+// Hardcoded since we don't have a good way to pull the L1 contracts for supersim yet.
+export const supersimL2AL1CrossDomainMessengerAddress =
+  '0x67b53cC5074ddB89A50358C4eabF5EED6A5AE135'

--- a/packages/viem/src/utils/interop/calculateChecksum.ts
+++ b/packages/viem/src/utils/interop/calculateChecksum.ts
@@ -1,0 +1,43 @@
+import type { Hex } from 'viem'
+import { encodePacked, keccak256, maxUint32, maxUint64, toHex } from 'viem'
+
+import type { MessageIdentifier } from '@/types/interop/executingMessage.js'
+
+/**
+ * Calculates the checksum for a cross chain message following the same logic as CrossL2Inbox.sol
+ */
+export function calculateChecksum(
+  id: MessageIdentifier,
+  msgHash: `0x${string}`,
+): Hex {
+  // Validate size constraints
+  if (id.blockNumber > maxUint64) throw new Error('BlockNumberTooHigh')
+  if (id.logIndex > maxUint32) throw new Error('LogIndexTooHigh')
+  if (id.timestamp > maxUint64) throw new Error('TimestampTooHigh')
+
+  const logHash = keccak256(
+    encodePacked(['address', 'bytes32'], [id.origin, msgHash]),
+  )
+
+  const idPacked = encodePacked(
+    ['uint96', 'uint64', 'uint64', 'uint32'],
+    [0n, id.blockNumber, id.timestamp, Number(id.logIndex)],
+  )
+
+  const idLogHash = keccak256(
+    encodePacked(['bytes32', 'bytes32'], [logHash, idPacked]),
+  )
+
+  const bareChecksum = keccak256(
+    encodePacked(['bytes32', 'uint256'], [idLogHash, id.chainId]),
+  )
+
+  const MSB_MASK =
+    '0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+  const TYPE_3_MASK =
+    '0x0300000000000000000000000000000000000000000000000000000000000000'
+  const checksum =
+    (BigInt(bareChecksum) & BigInt(MSB_MASK)) | BigInt(TYPE_3_MASK)
+
+  return toHex(checksum, { size: 32 })
+}

--- a/packages/viem/src/utils/interop/index.ts
+++ b/packages/viem/src/utils/interop/index.ts
@@ -1,3 +1,4 @@
+export { calculateChecksum } from '@/utils/interop/calculateChecksum.js'
 export { encodeMessagePayload } from '@/utils/interop/encodeMessagePayload.js'
 export { extractSentMessageLogs } from '@/utils/interop/extractSentMessageLogs.js'
 export { hashCrossDomainMessage } from '@/utils/interop/hashCrossDomainMessage.js'

--- a/scripts/update-supersim-version.ts
+++ b/scripts/update-supersim-version.ts
@@ -85,11 +85,23 @@ async function updateSupersimVersion(version: string) {
   packageJson.version = version
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, '  ') + '\n')
 
+  // 3. Update mise.toml
+  const miseTomlPath = resolve(__dirname, '../mise.toml')
+  let miseTomlContent = readFileSync(miseTomlPath, 'utf-8')
+
+  miseTomlContent = miseTomlContent.replace(
+    /^"ubi:ethereum-optimism\/supersim"=.*$/m,
+    `"ubi:ethereum-optimism/supersim"="${version}"`,
+  )
+
+  writeFileSync(miseTomlPath, miseTomlContent)
+
   console.log(
     `✅ Updated supersim version from ${currentVersion} to ${version} in:`,
   )
   console.log(`  - install.js`)
   console.log(`  - package.json`)
+  console.log(`  - mise.toml`)
 }
 
 // Get version from command line argument or fetch latest


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem/issues/697

This PR makes the following changes:
- Bumps the version of supersim to 0.1.0-alpha.44
- Adds `accessList` to `buildExecutingMessage` compliant with https://github.com/ethereum-optimism/design-docs/pull/214