### PR TITLE
feat(viem): add interop-rc-alpha chain def

### DIFF
--- a/.changeset/stale-points-fail.md
+++ b/.changeset/stale-points-fail.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/viem': patch
+---
+
+Add interop rc alpha to chain definitions

--- a/packages/viem/docs/actions/interop/functions/buildExecutingMessage.md
+++ b/packages/viem/docs/actions/interop/functions/buildExecutingMessage.md
@@ -46,4 +46,4 @@ const params = await buildExecutingMessage(publicClientOp, { log: receipt.logs[0
 
 ## Defined in
 
-[packages/viem/src/actions/interop/buildExecutingMessage.ts:59](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/buildExecutingMessage.ts#L59)
+[packages/viem/src/actions/interop/buildExecutingMessage.ts:59](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/buildExecutingMessage.ts#L59)

--- a/packages/viem/docs/actions/interop/functions/depositSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/depositSuperchainWETH.md
@@ -48,4 +48,4 @@ const hash = await depositSuperchainWETH(client, { account: '0x...', value: 1n }
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:71](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L71)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:71](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L71)

--- a/packages/viem/docs/actions/interop/functions/estimateDepositSuperchainWETHGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateDepositSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:98](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L98)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:98](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L98)

--- a/packages/viem/docs/actions/interop/functions/estimateRelayCrossDomainMessageGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateRelayCrossDomainMessageGas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:120](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L120)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:120](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L120)

--- a/packages/viem/docs/actions/interop/functions/estimateSendCrossDomainMessageGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateSendCrossDomainMessageGas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L106)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L106)

--- a/packages/viem/docs/actions/interop/functions/estimateSendETHGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateSendETHGas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L96)
+[packages/viem/src/actions/interop/sendETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendETH.ts#L96)

--- a/packages/viem/docs/actions/interop/functions/estimateSendSuperchainERC20Gas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateSendSuperchainERC20Gas.md
@@ -36,4 +36,4 @@ estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L106)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:106](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L106)

--- a/packages/viem/docs/actions/interop/functions/estimateWithdrawSuperchainWETHGas.md
+++ b/packages/viem/docs/actions/interop/functions/estimateWithdrawSuperchainWETHGas.md
@@ -36,4 +36,4 @@ The estimated gas value.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L96)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:96](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L96)

--- a/packages/viem/docs/actions/interop/functions/getCrossDomainMessageStatus.md
+++ b/packages/viem/docs/actions/interop/functions/getCrossDomainMessageStatus.md
@@ -50,4 +50,4 @@ const status = await getCrossDomainMessageStatus(publicClientUnichain, { message
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L53)
+[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:53](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L53)

--- a/packages/viem/docs/actions/interop/functions/getCrossDomainMessages.md
+++ b/packages/viem/docs/actions/interop/functions/getCrossDomainMessages.md
@@ -47,4 +47,4 @@ const messages = await getCrossDomainMessages(publicClientOp, { logs: receipt.lo
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessages.ts:33](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L33)
+[packages/viem/src/actions/interop/getCrossDomainMessages.ts:33](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L33)

--- a/packages/viem/docs/actions/interop/functions/relayCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/relayCrossDomainMessage.md
@@ -55,4 +55,4 @@ const hash = await relayCrossDomainMessage(publicClientUnichain, params)
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:87](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L87)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:87](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L87)

--- a/packages/viem/docs/actions/interop/functions/sendCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/sendCrossDomainMessage.md
@@ -36,4 +36,4 @@ transaction hash - [SendCrossDomainMessageReturnType](../type-aliases/SendCrossD
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L77)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L77)

--- a/packages/viem/docs/actions/interop/functions/sendETH.md
+++ b/packages/viem/docs/actions/interop/functions/sendETH.md
@@ -36,4 +36,4 @@ transaction hash - [SendETHContractReturnType](../type-aliases/SendETHContractRe
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L67)
+[packages/viem/src/actions/interop/sendETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendETH.ts#L67)

--- a/packages/viem/docs/actions/interop/functions/sendSuperchainERC20.md
+++ b/packages/viem/docs/actions/interop/functions/sendSuperchainERC20.md
@@ -36,4 +36,4 @@ transaction hash - [SendSuperchainERC20ReturnType](../type-aliases/SendSuperchai
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L77)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:77](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L77)

--- a/packages/viem/docs/actions/interop/functions/simulateDepositSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/simulateDepositSuperchainWETH.md
@@ -36,4 +36,4 @@ contract return value - [DepositSuperchainWETHContractReturnType](../type-aliase
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L122)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L122)

--- a/packages/viem/docs/actions/interop/functions/simulateRelayCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/simulateRelayCrossDomainMessage.md
@@ -36,4 +36,4 @@ contract return value - [RelayCrossDomainMessageContractReturnType](../type-alia
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:150](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L150)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:150](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L150)

--- a/packages/viem/docs/actions/interop/functions/simulateSendCrossDomainMessage.md
+++ b/packages/viem/docs/actions/interop/functions/simulateSendCrossDomainMessage.md
@@ -36,4 +36,4 @@ contract return value - [SendCrossDomainMessageContractReturnType](../type-alias
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:136](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L136)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:136](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L136)

--- a/packages/viem/docs/actions/interop/functions/simulateSendETH.md
+++ b/packages/viem/docs/actions/interop/functions/simulateSendETH.md
@@ -36,4 +36,4 @@ contract return value - [SendETHContractReturnType](../type-aliases/SendETHContr
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L122)
+[packages/viem/src/actions/interop/sendETH.ts:122](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendETH.ts#L122)

--- a/packages/viem/docs/actions/interop/functions/simulateSendSuperchainERC20.md
+++ b/packages/viem/docs/actions/interop/functions/simulateSendSuperchainERC20.md
@@ -36,4 +36,4 @@ contract return value - [SendSuperchainERC20ContractReturnType](../type-aliases/
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:132](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L132)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:132](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L132)

--- a/packages/viem/docs/actions/interop/functions/simulateWithdrawSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/simulateWithdrawSuperchainWETH.md
@@ -36,4 +36,4 @@ contract return value - [WithdrawSuperchainWETHContractReturnType](../type-alias
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:126](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L126)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:126](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L126)

--- a/packages/viem/docs/actions/interop/functions/withdrawSuperchainWETH.md
+++ b/packages/viem/docs/actions/interop/functions/withdrawSuperchainWETH.md
@@ -36,4 +36,4 @@ transaction hash - [WithdrawSuperchainWETHReturnType](../type-aliases/WithdrawSu
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L67)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L67)

--- a/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/buildExecutingMessage.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/buildExecutingMessage.ts#L16)
+[packages/viem/src/actions/interop/buildExecutingMessage.ts:16](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/buildExecutingMessage.ts#L16)

--- a/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/BuildExecutingMessageReturnType.md
@@ -24,4 +24,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/buildExecutingMessage.ts:21](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/buildExecutingMessage.ts#L21)
+[packages/viem/src/actions/interop/buildExecutingMessage.ts:21](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/buildExecutingMessage.ts#L21)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L45)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L45)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L51)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L51)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHParameters.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:25](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L25)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:25](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L25)

--- a/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/DepositSuperchainWETHReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/depositSuperchainWETH.ts:40](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L40)
+[packages/viem/src/actions/interop/depositSuperchainWETH.ts:40](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/depositSuperchainWETH.ts#L40)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:13](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L13)
+[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:13](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L13)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessageStatusReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:20](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L20)
+[packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts:20](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/getCrossDomainMessageStatus.ts#L20)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesParameters.md
@@ -16,4 +16,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessages.ts:10](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L10)
+[packages/viem/src/actions/interop/getCrossDomainMessages.ts:10](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L10)

--- a/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/GetCrossDomainMessagesReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/getCrossDomainMessages.ts:15](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L15)
+[packages/viem/src/actions/interop/getCrossDomainMessages.ts:15](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/getCrossDomainMessages.ts#L15)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L50)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L50)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:60](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L60)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:60](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L60)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageParameters.md
@@ -20,4 +20,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L28)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L28)

--- a/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/RelayCrossDomainMessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L45)
+[packages/viem/src/actions/interop/relayCrossDomainMessage.ts:45](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/relayCrossDomainMessage.ts#L45)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L55)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L55)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L65)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L65)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageParameters.md
@@ -40,4 +40,4 @@ Target contract or wallet address.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L28)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:28](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L28)

--- a/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendCrossDomainMessageReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L50)
+[packages/viem/src/actions/interop/sendCrossDomainMessage.ts:50](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendCrossDomainMessage.ts#L50)

--- a/packages/viem/docs/actions/interop/type-aliases/SendETHContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L46)
+[packages/viem/src/actions/interop/sendETH.ts:46](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendETH.ts#L46)

--- a/packages/viem/docs/actions/interop/type-aliases/SendETHErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L55)
+[packages/viem/src/actions/interop/sendETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendETH.ts#L55)

--- a/packages/viem/docs/actions/interop/type-aliases/SendETHParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendETHParameters.md
@@ -34,4 +34,4 @@ Address to send ETH to.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendETH.ts#L26)
+[packages/viem/src/actions/interop/sendETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendETH.ts#L26)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L56)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:56](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L56)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L65)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:65](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L65)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20Parameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20Parameters.md
@@ -46,4 +46,4 @@ Token to send.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L27)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:27](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L27)

--- a/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/SendSuperchainERC20ReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/sendSuperchainERC20.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L51)
+[packages/viem/src/actions/interop/sendSuperchainERC20.ts:51](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/sendSuperchainERC20.ts#L51)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHContractReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHContractReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:49](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L49)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:49](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L49)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHErrorType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHErrorType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L55)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:55](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L55)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHParameters.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHParameters.md
@@ -28,4 +28,4 @@ Amount of SuperchainWETH to withdraw.
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L26)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:26](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L26)

--- a/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHReturnType.md
+++ b/packages/viem/docs/actions/interop/type-aliases/WithdrawSuperchainWETHReturnType.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:44](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L44)
+[packages/viem/src/actions/interop/withdrawSuperchainWETH.ts:44](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/actions/interop/withdrawSuperchainWETH.ts#L44)

--- a/packages/viem/docs/chains/README.md
+++ b/packages/viem/docs/chains/README.md
@@ -24,6 +24,7 @@
 - [ink](variables/ink.md)
 - [inkSepolia](variables/inkSepolia.md)
 - [interopAlphaChains](variables/interopAlphaChains.md)
+- [interopRcAlphaChains](variables/interopRcAlphaChains.md)
 - [lisk](variables/lisk.md)
 - [liskSepolia](variables/liskSepolia.md)
 - [lyra](variables/lyra.md)
@@ -67,3 +68,8 @@
 
 - [interopAlpha0](variables/interopAlpha0.md)
 - [interopAlpha1](variables/interopAlpha1.md)
+
+### interop-rc-alpha
+
+- [interopRcAlpha0](variables/interopRcAlpha0.md)
+- [interopRcAlpha1](variables/interopRcAlpha1.md)

--- a/packages/viem/docs/chains/variables/arenaZ.md
+++ b/packages/viem/docs/chains/variables/arenaZ.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L8)
+[packages/viem/src/chains/mainnet.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L8)

--- a/packages/viem/docs/chains/variables/arenaZSepolia.md
+++ b/packages/viem/docs/chains/variables/arenaZSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L8)
+[packages/viem/src/chains/sepolia.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L8)

--- a/packages/viem/docs/chains/variables/base.md
+++ b/packages/viem/docs/chains/variables/base.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L131)
+[packages/viem/src/chains/mainnet.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L131)

--- a/packages/viem/docs/chains/variables/baseSepolia.md
+++ b/packages/viem/docs/chains/variables/baseSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:72](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L72)
+[packages/viem/src/chains/sepolia.ts:72](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L72)

--- a/packages/viem/docs/chains/variables/cyber.md
+++ b/packages/viem/docs/chains/variables/cyber.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L195)
+[packages/viem/src/chains/mainnet.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L195)

--- a/packages/viem/docs/chains/variables/cyberSepolia.md
+++ b/packages/viem/docs/chains/variables/cyberSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L131)
+[packages/viem/src/chains/sepolia.ts:131](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L131)

--- a/packages/viem/docs/chains/variables/ethernity.md
+++ b/packages/viem/docs/chains/variables/ethernity.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L259)
+[packages/viem/src/chains/mainnet.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L259)

--- a/packages/viem/docs/chains/variables/ethernitySepolia.md
+++ b/packages/viem/docs/chains/variables/ethernitySepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L195)
+[packages/viem/src/chains/sepolia.ts:195](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L195)

--- a/packages/viem/docs/chains/variables/funki.md
+++ b/packages/viem/docs/chains/variables/funki.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L323)
+[packages/viem/src/chains/mainnet.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L323)

--- a/packages/viem/docs/chains/variables/funkiSepolia.md
+++ b/packages/viem/docs/chains/variables/funkiSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L259)
+[packages/viem/src/chains/sepolia.ts:259](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L259)

--- a/packages/viem/docs/chains/variables/ink.md
+++ b/packages/viem/docs/chains/variables/ink.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:387](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L387)
+[packages/viem/src/chains/mainnet.ts:387](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L387)

--- a/packages/viem/docs/chains/variables/inkSepolia.md
+++ b/packages/viem/docs/chains/variables/inkSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L323)
+[packages/viem/src/chains/sepolia.ts:323](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L323)

--- a/packages/viem/docs/chains/variables/interopAlpha0.md
+++ b/packages/viem/docs/chains/variables/interopAlpha0.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/interopAlpha.ts:22](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/interopAlpha.ts#L22)
+[packages/viem/src/chains/interopAlpha.ts:22](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/interopAlpha.ts#L22)

--- a/packages/viem/docs/chains/variables/interopAlpha1.md
+++ b/packages/viem/docs/chains/variables/interopAlpha1.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/interopAlpha.ts:57](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/interopAlpha.ts#L57)
+[packages/viem/src/chains/interopAlpha.ts:57](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/interopAlpha.ts#L57)

--- a/packages/viem/docs/chains/variables/interopAlphaChains.md
+++ b/packages/viem/docs/chains/variables/interopAlphaChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/interopAlpha.ts:83](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/interopAlpha.ts#L83)
+[packages/viem/src/chains/interopAlpha.ts:83](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/interopAlpha.ts#L83)

--- a/packages/viem/docs/chains/variables/interopRcAlpha0.md
+++ b/packages/viem/docs/chains/variables/interopRcAlpha0.md
@@ -2,13 +2,13 @@
 
 ***
 
-[@eth-optimism/viem](../../README.md) / [chains](../README.md) / automata
+[@eth-optimism/viem](../../README.md) / [chains](../README.md) / interopRcAlpha0
 
-# automata
+# interopRcAlpha0
 
-> `const` **automata**: `object`
+> `const` **interopRcAlpha0**: `object`
 
-Chain Definition for Automata
+L2 chain A definition for interop-rc-alpha-0
 
 ## Type declaration
 
@@ -24,11 +24,11 @@ Collection of block explorers
 
 ### blockExplorers.default.name
 
-> `readonly` **name**: `"Automata Explorer"` = `'Automata Explorer'`
+> `readonly` **name**: `"Interop RC Alpha 0 Block Explorer"` = `'Interop RC Alpha 0 Block Explorer'`
 
 ### blockExplorers.default.url
 
-> `readonly` **url**: `"https://explorer.ata.network"` = `'https://explorer.ata.network'`
+> `readonly` **url**: `""` = `''`
 
 ### contracts
 
@@ -36,17 +36,21 @@ Collection of block explorers
 
 Collection of contracts
 
+### contracts.addressManager
+
+> `readonly` **addressManager**: `object`
+
+### contracts.anchorStateRegistry
+
+> `readonly` **anchorStateRegistry**: `object`
+
 ### contracts.disputeGameFactory
 
 > `readonly` **disputeGameFactory**: `object`
 
-### contracts.disputeGameFactory.1
+### contracts.faultDisputeGame
 
-> `readonly` **1**: `object`
-
-### contracts.disputeGameFactory.1.address
-
-> `readonly` **address**: `"0xB52337F38747D6931f2976eEa24A3f3F6B7CDEA2"` = `'0xB52337F38747D6931f2976eEa24A3f3F6B7CDEA2'`
+> `readonly` **faultDisputeGame**: `object`
 
 ### contracts.gasPriceOracle
 
@@ -68,37 +72,13 @@ Collection of contracts
 
 > `readonly` **l1CrossDomainMessenger**: `object`
 
-### contracts.l1CrossDomainMessenger.1
+### contracts.l1Erc721BridgeProxy
 
-> `readonly` **1**: `object`
-
-### contracts.l1CrossDomainMessenger.1.address
-
-> `readonly` **address**: `"0x825C858149F1E775a0f4Aeb172037B970bE7B736"` = `'0x825C858149F1E775a0f4Aeb172037B970bE7B736'`
-
-### contracts.l1Erc721Bridge
-
-> `readonly` **l1Erc721Bridge**: `object`
-
-### contracts.l1Erc721Bridge.1
-
-> `readonly` **1**: `object`
-
-### contracts.l1Erc721Bridge.1.address
-
-> `readonly` **address**: `"0x00bd00c5C7F60e222D9CB8040270Ba929241A280"` = `'0x00bd00c5C7F60e222D9CB8040270Ba929241A280'`
+> `readonly` **l1Erc721BridgeProxy**: `object`
 
 ### contracts.l1StandardBridge
 
 > `readonly` **l1StandardBridge**: `object`
-
-### contracts.l1StandardBridge.1
-
-> `readonly` **1**: `object`
-
-### contracts.l1StandardBridge.1.address
-
-> `readonly` **address**: `"0xE639919b92AB6DD238aEACc6F2A8d6e355D17bd5"` = `'0xE639919b92AB6DD238aEACc6F2A8d6e355D17bd5'`
 
 ### contracts.l2CrossDomainMessenger
 
@@ -116,18 +96,6 @@ Collection of contracts
 
 > `readonly` **address**: `"0x4200000000000000000000000000000000000014"`
 
-### contracts.l2OutputOracle
-
-> `readonly` **l2OutputOracle**: `object`
-
-### contracts.l2OutputOracle.1
-
-> `readonly` **1**: `object`
-
-### contracts.l2OutputOracle.1.address
-
-> `readonly` **address**: `"0xdbf381984c4515Fe3285D3C55fDfb3054C52c261"` = `'0xdbf381984c4515Fe3285D3C55fDfb3054C52c261'`
-
 ### contracts.l2StandardBridge
 
 > `readonly` **l2StandardBridge**: `object`
@@ -144,29 +112,25 @@ Collection of contracts
 
 > `readonly` **address**: `"0x4200000000000000000000000000000000000016"`
 
-### contracts.portal
+### contracts.opChainProxyAdmin
 
-> `readonly` **portal**: `object`
+> `readonly` **opChainProxyAdmin**: `object`
 
-### contracts.portal.1
+### contracts.optimismMintableErc20FactoryProxy
 
-> `readonly` **1**: `object`
+> `readonly` **optimismMintableErc20FactoryProxy**: `object`
 
-### contracts.portal.1.address
+### contracts.optimismPortal
 
-> `readonly` **address**: `"0xD52ba64CBE1e3B44167f810622fBef36bE24d95c"` = `'0xD52ba64CBE1e3B44167f810622fBef36bE24d95c'`
+> `readonly` **optimismPortal**: `object`
+
+### contracts.permissionedDisputeGame
+
+> `readonly` **permissionedDisputeGame**: `object`
 
 ### contracts.systemConfig
 
 > `readonly` **systemConfig**: `object`
-
-### contracts.systemConfig.1
-
-> `readonly` **1**: `object`
-
-### contracts.systemConfig.1.address
-
-> `readonly` **address**: `"0x72934D7AEDC1A2d889ca89Aaf064CD9455E64d00"` = `'0x72934D7AEDC1A2d889ca89Aaf064CD9455E64d00'`
 
 ### custom?
 
@@ -448,13 +412,13 @@ Modifies how data is formatted and typed (e.g. blocks and transactions)
 
 ### id
 
-> **id**: `65536`
+> **id**: `420120003`
 
 ID in number form
 
 ### name
 
-> **name**: `"Automata"`
+> **name**: `"Interop RC Alpha 0"`
 
 Human-readable name
 
@@ -470,11 +434,11 @@ Currency used by chain
 
 ### nativeCurrency.name
 
-> `readonly` **name**: `"Automata"` = `'Automata'`
+> `readonly` **name**: `"Ether"` = `'Ether'`
 
 ### nativeCurrency.symbol
 
-> `readonly` **symbol**: `"ATA"` = `'ATA'`
+> `readonly` **symbol**: `"ETH"` = `'ETH'`
 
 ### rpcUrls
 
@@ -488,7 +452,7 @@ Collection of RPC endpoints
 
 ### rpcUrls.default.http
 
-> `readonly` **http**: readonly [`"https://rpc.ata.network"`]
+> `readonly` **http**: readonly [`"https://interop-rc-alpha-0.optimism.io"`]
 
 ### serializers
 
@@ -512,16 +476,16 @@ Modifies how data is serialized (e.g. transactions).
 
 ### sourceId
 
-> **sourceId**: `1`
+> **sourceId**: `11155111`
 
 Source Chain ID (ie. the L1 chain)
 
-### testnet?
+### testnet
 
-> `optional` **testnet**: `boolean`
+> **testnet**: `true`
 
 Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L67)
+packages/viem/src/chains/interopRcAlpha.ts:17

--- a/packages/viem/docs/chains/variables/interopRcAlpha1.md
+++ b/packages/viem/docs/chains/variables/interopRcAlpha1.md
@@ -2,13 +2,13 @@
 
 ***
 
-[@eth-optimism/viem](../../README.md) / [chains](../README.md) / automata
+[@eth-optimism/viem](../../README.md) / [chains](../README.md) / interopRcAlpha1
 
-# automata
+# interopRcAlpha1
 
-> `const` **automata**: `object`
+> `const` **interopRcAlpha1**: `object`
 
-Chain Definition for Automata
+L2 chain A definition for interop-rc-alpha-1
 
 ## Type declaration
 
@@ -24,11 +24,11 @@ Collection of block explorers
 
 ### blockExplorers.default.name
 
-> `readonly` **name**: `"Automata Explorer"` = `'Automata Explorer'`
+> `readonly` **name**: `"Interop RC Alpha 0 Block Explorer"` = `'Interop RC Alpha 0 Block Explorer'`
 
 ### blockExplorers.default.url
 
-> `readonly` **url**: `"https://explorer.ata.network"` = `'https://explorer.ata.network'`
+> `readonly` **url**: `""` = `''`
 
 ### contracts
 
@@ -36,17 +36,21 @@ Collection of block explorers
 
 Collection of contracts
 
+### contracts.addressManager
+
+> `readonly` **addressManager**: `object`
+
+### contracts.anchorStateRegistry
+
+> `readonly` **anchorStateRegistry**: `object`
+
 ### contracts.disputeGameFactory
 
 > `readonly` **disputeGameFactory**: `object`
 
-### contracts.disputeGameFactory.1
+### contracts.faultDisputeGame
 
-> `readonly` **1**: `object`
-
-### contracts.disputeGameFactory.1.address
-
-> `readonly` **address**: `"0xB52337F38747D6931f2976eEa24A3f3F6B7CDEA2"` = `'0xB52337F38747D6931f2976eEa24A3f3F6B7CDEA2'`
+> `readonly` **faultDisputeGame**: `object`
 
 ### contracts.gasPriceOracle
 
@@ -68,37 +72,13 @@ Collection of contracts
 
 > `readonly` **l1CrossDomainMessenger**: `object`
 
-### contracts.l1CrossDomainMessenger.1
+### contracts.l1Erc721BridgeProxy
 
-> `readonly` **1**: `object`
-
-### contracts.l1CrossDomainMessenger.1.address
-
-> `readonly` **address**: `"0x825C858149F1E775a0f4Aeb172037B970bE7B736"` = `'0x825C858149F1E775a0f4Aeb172037B970bE7B736'`
-
-### contracts.l1Erc721Bridge
-
-> `readonly` **l1Erc721Bridge**: `object`
-
-### contracts.l1Erc721Bridge.1
-
-> `readonly` **1**: `object`
-
-### contracts.l1Erc721Bridge.1.address
-
-> `readonly` **address**: `"0x00bd00c5C7F60e222D9CB8040270Ba929241A280"` = `'0x00bd00c5C7F60e222D9CB8040270Ba929241A280'`
+> `readonly` **l1Erc721BridgeProxy**: `object`
 
 ### contracts.l1StandardBridge
 
 > `readonly` **l1StandardBridge**: `object`
-
-### contracts.l1StandardBridge.1
-
-> `readonly` **1**: `object`
-
-### contracts.l1StandardBridge.1.address
-
-> `readonly` **address**: `"0xE639919b92AB6DD238aEACc6F2A8d6e355D17bd5"` = `'0xE639919b92AB6DD238aEACc6F2A8d6e355D17bd5'`
 
 ### contracts.l2CrossDomainMessenger
 
@@ -116,18 +96,6 @@ Collection of contracts
 
 > `readonly` **address**: `"0x4200000000000000000000000000000000000014"`
 
-### contracts.l2OutputOracle
-
-> `readonly` **l2OutputOracle**: `object`
-
-### contracts.l2OutputOracle.1
-
-> `readonly` **1**: `object`
-
-### contracts.l2OutputOracle.1.address
-
-> `readonly` **address**: `"0xdbf381984c4515Fe3285D3C55fDfb3054C52c261"` = `'0xdbf381984c4515Fe3285D3C55fDfb3054C52c261'`
-
 ### contracts.l2StandardBridge
 
 > `readonly` **l2StandardBridge**: `object`
@@ -144,29 +112,25 @@ Collection of contracts
 
 > `readonly` **address**: `"0x4200000000000000000000000000000000000016"`
 
-### contracts.portal
+### contracts.opChainProxyAdmin
 
-> `readonly` **portal**: `object`
+> `readonly` **opChainProxyAdmin**: `object`
 
-### contracts.portal.1
+### contracts.optimismMintableErc20FactoryProxy
 
-> `readonly` **1**: `object`
+> `readonly` **optimismMintableErc20FactoryProxy**: `object`
 
-### contracts.portal.1.address
+### contracts.optimismPortal
 
-> `readonly` **address**: `"0xD52ba64CBE1e3B44167f810622fBef36bE24d95c"` = `'0xD52ba64CBE1e3B44167f810622fBef36bE24d95c'`
+> `readonly` **optimismPortal**: `object`
+
+### contracts.permissionedDisputeGame
+
+> `readonly` **permissionedDisputeGame**: `object`
 
 ### contracts.systemConfig
 
 > `readonly` **systemConfig**: `object`
-
-### contracts.systemConfig.1
-
-> `readonly` **1**: `object`
-
-### contracts.systemConfig.1.address
-
-> `readonly` **address**: `"0x72934D7AEDC1A2d889ca89Aaf064CD9455E64d00"` = `'0x72934D7AEDC1A2d889ca89Aaf064CD9455E64d00'`
 
 ### custom?
 
@@ -448,13 +412,13 @@ Modifies how data is formatted and typed (e.g. blocks and transactions)
 
 ### id
 
-> **id**: `65536`
+> **id**: `420120004`
 
 ID in number form
 
 ### name
 
-> **name**: `"Automata"`
+> **name**: `"Interop RC Alpha 1"`
 
 Human-readable name
 
@@ -470,11 +434,11 @@ Currency used by chain
 
 ### nativeCurrency.name
 
-> `readonly` **name**: `"Automata"` = `'Automata'`
+> `readonly` **name**: `"Ether"` = `'Ether'`
 
 ### nativeCurrency.symbol
 
-> `readonly` **symbol**: `"ATA"` = `'ATA'`
+> `readonly` **symbol**: `"ETH"` = `'ETH'`
 
 ### rpcUrls
 
@@ -488,7 +452,7 @@ Collection of RPC endpoints
 
 ### rpcUrls.default.http
 
-> `readonly` **http**: readonly [`"https://rpc.ata.network"`]
+> `readonly` **http**: readonly [`"https://interop-rc-alpha-1.optimism.io"`]
 
 ### serializers
 
@@ -512,16 +476,16 @@ Modifies how data is serialized (e.g. transactions).
 
 ### sourceId
 
-> **sourceId**: `1`
+> **sourceId**: `11155111`
 
 Source Chain ID (ie. the L1 chain)
 
-### testnet?
+### testnet
 
-> `optional` **testnet**: `boolean`
+> **testnet**: `true`
 
 Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:67](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L67)
+packages/viem/src/chains/interopRcAlpha.ts:45

--- a/packages/viem/docs/chains/variables/interopRcAlphaChains.md
+++ b/packages/viem/docs/chains/variables/interopRcAlphaChains.md
@@ -1,0 +1,13 @@
+[**@eth-optimism/viem**](../../README.md) • **Docs**
+
+***
+
+[@eth-optimism/viem](../../README.md) / [chains](../README.md) / interopRcAlphaChains
+
+# interopRcAlphaChains
+
+> `const` **interopRcAlphaChains**: (`object` \| `object`)[]
+
+## Defined in
+
+packages/viem/src/chains/interopRcAlpha.ts:69

--- a/packages/viem/docs/chains/variables/lisk.md
+++ b/packages/viem/docs/chains/variables/lisk.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L446)
+[packages/viem/src/chains/mainnet.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L446)

--- a/packages/viem/docs/chains/variables/liskSepolia.md
+++ b/packages/viem/docs/chains/variables/liskSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:382](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L382)
+[packages/viem/src/chains/sepolia.ts:382](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L382)

--- a/packages/viem/docs/chains/variables/lyra.md
+++ b/packages/viem/docs/chains/variables/lyra.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:510](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L510)
+[packages/viem/src/chains/mainnet.ts:510](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L510)

--- a/packages/viem/docs/chains/variables/mainnetChains.md
+++ b/packages/viem/docs/chains/variables/mainnetChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1363](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1363)
+[packages/viem/src/chains/mainnet.ts:1363](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L1363)

--- a/packages/viem/docs/chains/variables/metal.md
+++ b/packages/viem/docs/chains/variables/metal.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L569)
+[packages/viem/src/chains/mainnet.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L569)

--- a/packages/viem/docs/chains/variables/metalSepolia.md
+++ b/packages/viem/docs/chains/variables/metalSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L446)
+[packages/viem/src/chains/sepolia.ts:446](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L446)

--- a/packages/viem/docs/chains/variables/minatoSepolia.md
+++ b/packages/viem/docs/chains/variables/minatoSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:505](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L505)
+[packages/viem/src/chains/sepolia.ts:505](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L505)

--- a/packages/viem/docs/chains/variables/mode.md
+++ b/packages/viem/docs/chains/variables/mode.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L628)
+[packages/viem/src/chains/mainnet.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L628)

--- a/packages/viem/docs/chains/variables/modeSepolia.md
+++ b/packages/viem/docs/chains/variables/modeSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L569)
+[packages/viem/src/chains/sepolia.ts:569](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L569)

--- a/packages/viem/docs/chains/variables/op.md
+++ b/packages/viem/docs/chains/variables/op.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L687)
+[packages/viem/src/chains/mainnet.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L687)

--- a/packages/viem/docs/chains/variables/opSepolia.md
+++ b/packages/viem/docs/chains/variables/opSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L628)
+[packages/viem/src/chains/sepolia.ts:628](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L628)

--- a/packages/viem/docs/chains/variables/orderly.md
+++ b/packages/viem/docs/chains/variables/orderly.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L746)
+[packages/viem/src/chains/mainnet.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L746)

--- a/packages/viem/docs/chains/variables/race.md
+++ b/packages/viem/docs/chains/variables/race.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:805](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L805)
+[packages/viem/src/chains/mainnet.ts:805](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L805)

--- a/packages/viem/docs/chains/variables/raceSepolia.md
+++ b/packages/viem/docs/chains/variables/raceSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L687)
+[packages/viem/src/chains/sepolia.ts:687](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L687)

--- a/packages/viem/docs/chains/variables/redstone.md
+++ b/packages/viem/docs/chains/variables/redstone.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:864](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L864)
+[packages/viem/src/chains/mainnet.ts:864](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L864)

--- a/packages/viem/docs/chains/variables/sepoliaChains.md
+++ b/packages/viem/docs/chains/variables/sepoliaChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:1053](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L1053)
+[packages/viem/src/chains/sepolia.ts:1053](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L1053)

--- a/packages/viem/docs/chains/variables/shape.md
+++ b/packages/viem/docs/chains/variables/shape.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:928](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L928)
+[packages/viem/src/chains/mainnet.ts:928](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L928)

--- a/packages/viem/docs/chains/variables/shapeSepolia.md
+++ b/packages/viem/docs/chains/variables/shapeSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L746)
+[packages/viem/src/chains/sepolia.ts:746](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L746)

--- a/packages/viem/docs/chains/variables/sseed.md
+++ b/packages/viem/docs/chains/variables/sseed.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:992](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L992)
+[packages/viem/src/chains/mainnet.ts:992](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L992)

--- a/packages/viem/docs/chains/variables/supersimChains.md
+++ b/packages/viem/docs/chains/variables/supersimChains.md
@@ -10,4 +10,4 @@
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:142](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L142)
+[packages/viem/src/chains/supersim.ts:142](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L142)

--- a/packages/viem/docs/chains/variables/supersimL1.md
+++ b/packages/viem/docs/chains/variables/supersimL1.md
@@ -436,4 +436,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L17)
+[packages/viem/src/chains/supersim.ts:17](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L17)

--- a/packages/viem/docs/chains/variables/supersimL2A.md
+++ b/packages/viem/docs/chains/variables/supersimL2A.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:36](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L36)
+[packages/viem/src/chains/supersim.ts:36](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L36)

--- a/packages/viem/docs/chains/variables/supersimL2B.md
+++ b/packages/viem/docs/chains/variables/supersimL2B.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:58](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L58)
+[packages/viem/src/chains/supersim.ts:58](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L58)

--- a/packages/viem/docs/chains/variables/supersimL2C.md
+++ b/packages/viem/docs/chains/variables/supersimL2C.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:80](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L80)
+[packages/viem/src/chains/supersim.ts:80](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L80)

--- a/packages/viem/docs/chains/variables/supersimL2D.md
+++ b/packages/viem/docs/chains/variables/supersimL2D.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:102](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L102)
+[packages/viem/src/chains/supersim.ts:102](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L102)

--- a/packages/viem/docs/chains/variables/supersimL2E.md
+++ b/packages/viem/docs/chains/variables/supersimL2E.md
@@ -484,4 +484,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/supersim.ts:124](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/supersim.ts#L124)
+[packages/viem/src/chains/supersim.ts:124](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/supersim.ts#L124)

--- a/packages/viem/docs/chains/variables/swan.md
+++ b/packages/viem/docs/chains/variables/swan.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1056](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1056)
+[packages/viem/src/chains/mainnet.ts:1056](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L1056)

--- a/packages/viem/docs/chains/variables/swell.md
+++ b/packages/viem/docs/chains/variables/swell.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1120](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1120)
+[packages/viem/src/chains/mainnet.ts:1120](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L1120)

--- a/packages/viem/docs/chains/variables/tbn.md
+++ b/packages/viem/docs/chains/variables/tbn.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1179](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1179)
+[packages/viem/src/chains/mainnet.ts:1179](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L1179)

--- a/packages/viem/docs/chains/variables/tbnSepolia.md
+++ b/packages/viem/docs/chains/variables/tbnSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:810](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L810)
+[packages/viem/src/chains/sepolia.ts:810](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L810)

--- a/packages/viem/docs/chains/variables/unichainSepolia.md
+++ b/packages/viem/docs/chains/variables/unichainSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:874](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L874)
+[packages/viem/src/chains/sepolia.ts:874](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L874)

--- a/packages/viem/docs/chains/variables/worldchain.md
+++ b/packages/viem/docs/chains/variables/worldchain.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1243](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1243)
+[packages/viem/src/chains/mainnet.ts:1243](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L1243)

--- a/packages/viem/docs/chains/variables/worldchainSepolia.md
+++ b/packages/viem/docs/chains/variables/worldchainSepolia.md
@@ -524,4 +524,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:933](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L933)
+[packages/viem/src/chains/sepolia.ts:933](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L933)

--- a/packages/viem/docs/chains/variables/zora.md
+++ b/packages/viem/docs/chains/variables/zora.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/mainnet.ts:1307](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/mainnet.ts#L1307)
+[packages/viem/src/chains/mainnet.ts:1307](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/mainnet.ts#L1307)

--- a/packages/viem/docs/chains/variables/zoraSepolia.md
+++ b/packages/viem/docs/chains/variables/zoraSepolia.md
@@ -512,4 +512,4 @@ Flag for test networks
 
 ## Defined in
 
-[packages/viem/src/chains/sepolia.ts:997](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/chains/sepolia.ts#L997)
+[packages/viem/src/chains/sepolia.ts:997](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/chains/sepolia.ts#L997)

--- a/packages/viem/docs/index/type-aliases/MessageIdentifier.md
+++ b/packages/viem/docs/index/type-aliases/MessageIdentifier.md
@@ -44,4 +44,4 @@ The timestamp that the log was emitted. Used to enforce the timestamp invariant
 
 ## Defined in
 
-[packages/viem/src/types/interop/executingMessage.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/types/interop/executingMessage.ts#L7)
+[packages/viem/src/types/interop/executingMessage.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/types/interop/executingMessage.ts#L7)

--- a/packages/viem/docs/index/variables/contracts.md
+++ b/packages/viem/docs/index/variables/contracts.md
@@ -110,4 +110,4 @@ OP Stack Predeploy Addresses
 
 ## Defined in
 
-[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/contracts.ts#L8)
+[packages/viem/src/contracts.ts:8](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/contracts.ts#L8)

--- a/packages/viem/docs/index/variables/crossDomainMessengerAbi.md
+++ b/packages/viem/docs/index/variables/crossDomainMessengerAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `CrossDomainMessenger`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L7)
+[packages/viem/src/abis.ts:7](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L7)

--- a/packages/viem/docs/index/variables/crossL2InboxAbi.md
+++ b/packages/viem/docs/index/variables/crossL2InboxAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `CrossL2Inbox`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:440](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L440)
+[packages/viem/src/abis.ts:440](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L440)

--- a/packages/viem/docs/index/variables/l2ToL2CrossDomainMessengerAbi.md
+++ b/packages/viem/docs/index/variables/l2ToL2CrossDomainMessengerAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `L2ToL2CrossDomainMessenger`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:627](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L627)
+[packages/viem/src/abis.ts:627](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L627)

--- a/packages/viem/docs/index/variables/optimismMintableERC20Abi.md
+++ b/packages/viem/docs/index/variables/optimismMintableERC20Abi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `OptimismMintableERC20`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:918](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L918)
+[packages/viem/src/abis.ts:918](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L918)

--- a/packages/viem/docs/index/variables/optimismMintableERC20FactoryAbi.md
+++ b/packages/viem/docs/index/variables/optimismMintableERC20FactoryAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `OptimismMintableERC20Factory`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:1498](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L1498)
+[packages/viem/src/abis.ts:1498](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L1498)

--- a/packages/viem/docs/index/variables/standardBridgeAbi.md
+++ b/packages/viem/docs/index/variables/standardBridgeAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `StandardBridge`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:1730](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L1730)
+[packages/viem/src/abis.ts:1730](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L1730)

--- a/packages/viem/docs/index/variables/superchainERC20Abi.md
+++ b/packages/viem/docs/index/variables/superchainERC20Abi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `SuperchainERC20`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:2169](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L2169)
+[packages/viem/src/abis.ts:2169](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L2169)

--- a/packages/viem/docs/index/variables/superchainTokenBridgeAbi.md
+++ b/packages/viem/docs/index/variables/superchainTokenBridgeAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `SuperchainTokenBridge`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:3178](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L3178)
+[packages/viem/src/abis.ts:3178](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L3178)

--- a/packages/viem/docs/index/variables/superchainWETHAbi.md
+++ b/packages/viem/docs/index/variables/superchainWETHAbi.md
@@ -12,4 +12,4 @@ ABI for the OP Stack contract `SuperchainWETH`
 
 ## Defined in
 
-[packages/viem/src/abis.ts:2636](https://github.com/ethereum-optimism/ecosystem/blob/e811aa63ad2d81436ee2008e44d114c24dafedef/packages/viem/src/abis.ts#L2636)
+[packages/viem/src/abis.ts:2636](https://github.com/ethereum-optimism/ecosystem/blob/ddb96adf4653afc97ea0f64c5d67dd4ec467ac08/packages/viem/src/abis.ts#L2636)

--- a/packages/viem/src/chains/index.ts
+++ b/packages/viem/src/chains/index.ts
@@ -1,4 +1,5 @@
 export * from './interopAlpha.js'
+export * from './interopRcAlpha.js'
 export * from './mainnet.js'
 export * from './sepolia.js'
 export * from './supersim.js'

--- a/packages/viem/src/chains/interopRcAlpha.ts
+++ b/packages/viem/src/chains/interopRcAlpha.ts
@@ -1,0 +1,69 @@
+import { defineChain } from 'viem'
+import { sepolia } from 'viem/chains'
+import { chainConfig } from 'viem/op-stack'
+
+import { addressesToViemContractConstant } from '@/addressSet.js'
+import {
+  interopRcAlpha0Addresses,
+  interopRcAlpha1Addresses,
+} from '@/chains/interopRcAlphaAddresses.js'
+
+const sourceId = sepolia.id
+
+/**
+ * L2 chain A definition for interop-rc-alpha-0
+ * @category interop-rc-alpha
+ */
+export const interopRcAlpha0 = defineChain({
+  ...chainConfig,
+  id: 420120003,
+  name: 'Interop RC Alpha 0',
+  rpcUrls: {
+    default: {
+      http: ['https://interop-rc-alpha-0.optimism.io'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Interop RC Alpha 0 Block Explorer',
+      url: '',
+    },
+  },
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  sourceId,
+  testnet: true,
+  contracts: {
+    ...chainConfig.contracts,
+    ...addressesToViemContractConstant(interopRcAlpha0Addresses, sourceId),
+  },
+})
+
+/**
+ * L2 chain A definition for interop-rc-alpha-1
+ * @category interop-rc-alpha
+ */
+export const interopRcAlpha1 = defineChain({
+  ...chainConfig,
+  id: 420120004,
+  name: 'Interop RC Alpha 1',
+  rpcUrls: {
+    default: {
+      http: ['https://interop-rc-alpha-1.optimism.io'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Interop RC Alpha 0 Block Explorer',
+      url: '',
+    },
+  },
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  sourceId,
+  testnet: true,
+  contracts: {
+    ...chainConfig.contracts,
+    ...addressesToViemContractConstant(interopRcAlpha1Addresses, sourceId),
+  },
+})
+
+export const interopRcAlphaChains = [interopRcAlpha0, interopRcAlpha1]

--- a/packages/viem/src/chains/interopRcAlphaAddresses.ts
+++ b/packages/viem/src/chains/interopRcAlphaAddresses.ts
@@ -1,0 +1,41 @@
+import type { AddressSet } from '@/addressSet.js'
+
+export const interopRcAlpha0Addresses = {
+  OpChainProxyAdmin: '0x8a2df05608b2ae0eb75809b210527dd1d2705e31',
+  AddressManager: '0x436adaadea096e6c8f61ef3dcf76f83604a4495d',
+  L1ERC721BridgeProxy: '0xb1eb4f07d7ef21952eb7736ab0f048d3dff34011',
+  SystemConfigProxy: '0x38cfb302cda19fd376be2237d220d35c404a36ba',
+  OptimismMintableERC20FactoryProxy:
+    '0x35d43f9e909105168917b004726edb7dcbd6f275',
+  L1StandardBridgeProxy: '0x6be35d2af0ad0e6955145da1214e16bbffca74d4',
+  L1CrossDomainMessengerProxy: '0x3393ffdc32d1b4eb4eed15ea076af4941ca20870',
+  OptimismPortalProxy: '0xbd80b66b60a6c6580aa0a92783bdb4c42b1405c4',
+  DisputeGameFactoryProxy: '0x64b013223986389e1594369e01c9cd01667c4aac',
+  AnchorStateRegistryProxy: '0x04b4318d950d669669520609be753d31bd4de88d',
+  FaultDisputeGame: '0x0000000000000000000000000000000000000000',
+  PermissionedDisputeGame: '0xf5dbdcbfea04961249425c7127fb9779e930daee',
+  DelayedWETHPermissionedGameProxy:
+    '0x652c61e8a59c218f8facfdf23379b0e851aacc56',
+  DelayedWETHPermissionlessGameProxy:
+    '0x0000000000000000000000000000000000000000',
+} as const satisfies AddressSet
+
+export const interopRcAlpha1Addresses = {
+  OpChainProxyAdmin: '0x6220fd818ea70803b65dfaba7deb8e72c8fb396e',
+  AddressManager: '0xed401f324b7b8d1bbbf453402969de37c2d20f6a',
+  L1ERC721BridgeProxy: '0x879c7072c856a0f0efb71a6b8222da5edf993061',
+  SystemConfigProxy: '0xce1da8571d67d139a8040eba35bef8cfd34a0f2f',
+  OptimismMintableERC20FactoryProxy:
+    '0xe7e22560b1945120705c50b573960ecb427ff2ee',
+  L1StandardBridgeProxy: '0x690194141578fffc38598d60ddbeb24716c5a049',
+  L1CrossDomainMessengerProxy: '0xd40ea45998b8abae23541249d2522ef97bbb604e',
+  OptimismPortalProxy: '0x92b3b2d4032492cd177fefa20e67c64826ccbc70',
+  DisputeGameFactoryProxy: '0xe0ff87008d8b6e77de390092f523b8fa412828bd',
+  AnchorStateRegistryProxy: '0x352264750cad1dee3b91045150d4efecd2f36ede',
+  FaultDisputeGame: '0x0000000000000000000000000000000000000000',
+  PermissionedDisputeGame: '0x9a77e6f08585e5aec9fc64f1aae2469eea7ff420',
+  DelayedWETHPermissionedGameProxy:
+    '0x908f99cd4c0383db228033be08bac37a2c2c1953',
+  DelayedWETHPermissionlessGameProxy:
+    '0x0000000000000000000000000000000000000000',
+} as const satisfies AddressSet


### PR DESCRIPTION
Adds Interop RC Alpha 1 and Interop RC Alpha 2 chain definitions as per https://docs.optimism.io/stack/interop/tools/rc-alpha and https://github.com/ethereum-optimism/devnets/blob/main/alphanets/interop-rc-alpha/interop-rc-alpha-0/chain.yaml and https://github.com/ethereum-optimism/devnets/blob/main/alphanets/interop-rc-alpha/interop-rc-alpha-1/chain.yaml