### PR TITLE
chore: start ponder-interop from env

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,7 @@
 **/dist/
 **/types/
 **/node_modules/
+**/ponder-env.d.ts
+
 
 /.nx/cache

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Governance discussion can also be found on the [Optimism Governance Forum](https
 <pre>
 ├── <a href="./apps">apps</a>
 ├── ├── <a href="./apps/sponsored-sender">sponsored-sender</a>: Util service that locally spins up single-url tx submission json-rpc endpoint
+├── ├── <a href="./apps/ponder-interop">ponder-interop</a>: Ponder indexer for Superchain interop contracts.
 ├── <a href="./packages">packages</a>
 ├── ├── <a href="./packages/supersim">supersim</a>: Util supersim package that works with npx
 │   ├── <a href="./packages/viem">viem</a>: Optimism Viem Extensions

--- a/apps/ponder-interop/package.json
+++ b/apps/ponder-interop/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "ponder dev",
+    "dev:devnet": "pnpm dev --config ponder.config.devnet.ts",
+    "dev:alphanet": "pnpm dev --config ponder.config.alphanet.ts",
+    "dev:supersim": "pnpm dev --config ponder.config.supersim.ts",
     "start": "ponder start",
     "db": "ponder db",
     "codegen": "ponder codegen",
@@ -15,7 +18,9 @@
   "dependencies": {
     "hono": "^4.5.0",
     "ponder": "^0.10.6",
-    "viem": "^2.21.3",
-    "@eth-optimism/viem": "workspace:*"
+    "viem": "^2.17.9",
+    "@eth-optimism/viem": "workspace:*",
+    "zod": "^3.24.2",
+    "zod-validation-error": "^3.4.0"
   }
 }

--- a/apps/ponder-interop/ponder-env.d.ts
+++ b/apps/ponder-interop/ponder-env.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="ponder/virtual" />
 
-declare module 'ponder:internal' {
-  const config: typeof import('./ponder.config.js')
-  const schema: typeof import('./ponder.schema.ts')
+declare module "ponder:internal" {
+  const config: typeof import("./ponder.config.ts");
+  const schema: typeof import("./ponder.schema.ts");
 }
 
-declare module 'ponder:schema' {
-  export * from './ponder.schema.ts'
+declare module "ponder:schema" {
+  export * from "./ponder.schema.ts";
 }
 
 // This file enables type checking and editor autocomplete for this Ponder project.

--- a/apps/ponder-interop/ponder.config.alphanet.ts
+++ b/apps/ponder-interop/ponder.config.alphanet.ts
@@ -1,0 +1,18 @@
+import { interopRcAlpha0, interopRcAlpha1 } from '@eth-optimism/viem/chains'
+import { http } from 'viem'
+
+import type { Endpoints } from '@/createPonderConfig.js'
+import { createPonderConfig } from '@/createPonderConfig.js'
+
+const endpoints: Endpoints = {
+  interopRcAlpha0: {
+    chainId: interopRcAlpha0.id,
+    transport: http(interopRcAlpha0.rpcUrls.default.http[0]),
+  },
+  interopRcAlpha1: {
+    chainId: interopRcAlpha1.id,
+    transport: http(interopRcAlpha1.rpcUrls.default.http[0]),
+  },
+}
+
+export default createPonderConfig(endpoints)

--- a/apps/ponder-interop/ponder.config.devnet.ts
+++ b/apps/ponder-interop/ponder.config.devnet.ts
@@ -1,32 +1,18 @@
-import { contracts, l2ToL2CrossDomainMessengerAbi } from '@eth-optimism/viem'
 import { interopAlpha0, interopAlpha1 } from '@eth-optimism/viem/chains'
-import { createConfig } from 'ponder'
 import { http } from 'viem'
 
-export default createConfig({
-  ordering: 'multichain',
-  networks: {
-    interopAlpha0: {
-      chainId: interopAlpha0.id,
-      transport: http(interopAlpha0.rpcUrls.default.http[0]),
-    },
-    interopAlpha1: {
-      chainId: interopAlpha1.id,
-      transport: http(interopAlpha1.rpcUrls.default.http[0]),
-    },
+import type { Endpoints } from '@/createPonderConfig.js'
+import { createPonderConfig } from '@/createPonderConfig.js'
+
+const endpoints: Endpoints = {
+  interopAlpha0: {
+    chainId: interopAlpha0.id,
+    transport: http(interopAlpha0.rpcUrls.default.http[0]),
   },
-  contracts: {
-    L2ToL2CDM: {
-      abi: l2ToL2CrossDomainMessengerAbi,
-      startBlock: 1,
-      network: {
-        interopAlpha0: {
-          address: contracts.l2ToL2CrossDomainMessenger.address,
-        },
-        interopAlpha1: {
-          address: contracts.l2ToL2CrossDomainMessenger.address,
-        },
-      },
-    },
+  interopAlpha1: {
+    chainId: interopAlpha1.id,
+    transport: http(interopAlpha1.rpcUrls.default.http[0]),
   },
-})
+}
+
+export default createPonderConfig(endpoints)

--- a/apps/ponder-interop/ponder.config.supersim.ts
+++ b/apps/ponder-interop/ponder.config.supersim.ts
@@ -1,0 +1,18 @@
+import { supersimL2A, supersimL2B } from '@eth-optimism/viem/chains'
+import { http } from 'viem'
+
+import type { Endpoints } from '@/createPonderConfig.js'
+import { createPonderConfig } from '@/createPonderConfig.js'
+
+const endpoints: Endpoints = {
+  supersimL2A: {
+    chainId: supersimL2A.id,
+    transport: http(supersimL2A.rpcUrls.default.http[0]),
+  },
+  supersimL2B: {
+    chainId: supersimL2B.id,
+    transport: http(supersimL2B.rpcUrls.default.http[0]),
+  },
+}
+
+export default createPonderConfig(endpoints)

--- a/apps/ponder-interop/src/createPonderConfig.ts
+++ b/apps/ponder-interop/src/createPonderConfig.ts
@@ -1,0 +1,44 @@
+import {
+  contracts as addrs,
+  l2ToL2CrossDomainMessengerAbi,
+} from '@eth-optimism/viem'
+import { createConfig } from 'ponder'
+import type { Transport } from 'viem'
+
+export type Endpoint = { chainId: number; transport: Transport }
+
+/**
+ * A map of name to {@link Endpoint}
+ */
+export type Endpoints = Record<string, Endpoint>
+
+/**
+ * Create a Ponder config for interop
+ * @param endpoints - Interoperable endpoints to index -- {@link Endpoints}
+ * @returns Ponder configuration
+ */
+export function createPonderConfig(endpoints: Endpoints) {
+  if (Object.keys(endpoints).length === 0) {
+    throw new Error('no endpoints provided')
+  }
+
+  // relevant interop contracts
+  const contracts = {
+    L2ToL2CDM: {
+      abi: l2ToL2CrossDomainMessengerAbi,
+      startBlock: 1,
+      network: Object.fromEntries(
+        Object.keys(endpoints).map((key) => [
+          key,
+          { address: addrs.l2ToL2CrossDomainMessenger.address },
+        ]),
+      ),
+    },
+  }
+
+  return createConfig({
+    ordering: 'multichain',
+    networks: endpoints,
+    contracts,
+  })
+}

--- a/apps/ponder-interop/tsconfig.json
+++ b/apps/ponder-interop/tsconfig.json
@@ -11,6 +11,11 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
 
+    // Paths
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
     // Language and environment
     "moduleResolution": "bundler",
     "module": "ESNext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,14 @@ importers:
         specifier: ^0.10.6
         version: 0.10.7(@opentelemetry/api@1.9.0)(@types/node@22.5.4)(hono@4.7.5)(terser@5.31.3)(typescript@5.4.5)(viem@2.24.3(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.24.2))(zod@3.24.2)
       viem:
-        specifier: ^2.21.3
+        specifier: ^2.17.9
         version: 2.24.3(bufferutil@4.0.8)(typescript@5.4.5)(utf-8-validate@6.0.3)(zod@3.24.2)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+      zod-validation-error:
+        specifier: ^3.4.0
+        version: 3.4.0(zod@3.24.2)
 
   apps/sponsored-sender:
     dependencies:


### PR DESCRIPTION
For people running this app against a seperate network, we dont want them to edit the code for config.

So the default config is bootstrapped from env.
- dev:(alphanet|devnet|supersim) command to autostart known networks.
- Consolidate ponder config generation between the different ways to configure this.

Aside:
- add the url to the chains api so other apps can just bootstrap from this (autorelayer)
- fix api responses
