### PR TITLE
Fix broken doc links for L2ToL2Message hooks

### DIFF
--- a/packages/wagmi/docs/useRelayL2ToL2Message.md
+++ b/packages/wagmi/docs/useRelayL2ToL2Message.md
@@ -25,7 +25,7 @@ const hash = await relayMessage({
 
 - **Type:** `(params: RelayL2ToL2MessageParameters) => Promise<`0x${string}`>`
 
-Call this function with the [RelayL2ToL2MessageParameters](https://github.com/ethereum-optimism/ecosystem/blob/main/packages/viem/docs/actions/relayL2ToL2Message.md#parameters) to execute a cross chain message
+Call this function with the [RelayL2ToL2MessageParameters](https://github.com/ethereum-optimism/ecosystem/blob/main/packages/wagmi/docs/useRelayL2ToL2Message.md) to execute a cross chain message
 
 ### `isError`
 

--- a/packages/wagmi/docs/useSendL2ToL2Message.md
+++ b/packages/wagmi/docs/useSendL2ToL2Message.md
@@ -26,7 +26,7 @@ const hash = await sendMessage({
 
 - **Type:** `(params: SendL2ToL2MessageParameters) => Promise<`0x${string}`>`
 
-Call this function with the [SendL2ToL2MessageParameters](https://github.com/ethereum-optimism/ecosystem/blob/main/packages/viem/docs/actions/sendL2ToL2Message.md#parameters) to initiate a cross chain message
+Call this function with the [SendL2ToL2MessageParameters](https://github.com/ethereum-optimism/ecosystem/blob/main/packages/wagmi/docs/useSendL2ToL2Message.md) to initiate a cross chain message
 
 ### `isError`
 


### PR DESCRIPTION
 Description:

Updated Markdown links to point to valid .md files in packages/wagmi/docs

Affects: useRelayL2ToL2Message.md, useSendL2ToL2Message.md

  Fixes broken docs
  Matches current file structure