### PR TITLE
feat: admin server for every App

### DIFF
--- a/.changeset/rude-ants-applaud.md
+++ b/.changeset/rude-ants-applaud.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/utils-app': patch
+---
+
+support spinning up a default admin server for every App

--- a/apps/autorelayer-interop/src/runRelayer.ts
+++ b/apps/autorelayer-interop/src/runRelayer.ts
@@ -1,3 +1,0 @@
-import { RelayerApp } from '@/app.js'
-
-await new RelayerApp().run()

--- a/packages/utils-app/README.md
+++ b/packages/utils-app/README.md
@@ -5,3 +5,30 @@ A general framework for creating typescript applications.
 - Handles application lifecycle
 - Metrics server configuration
 - CLI configuration
+
+## Configuration
+
+A set of default options are provided to every instance of `App`.
+
+```bash
+--log-level <level>                     Set log level (choices: "debug", "info", "warn", "error", "silent", default: "debug", env: LOG_LEVEL)
+--admin-enabled                         Enable admin API server (default: false, env: ADMIN_ENABLED)
+--admin-port <port>                     Port for admin API (default: "9000", env: ADMIN_PORT)
+--metrics-enabled                       Enable metrics collection (default: false, env: METRICS_ENABLED)
+--metrics-port <port>                   Port for metrics server (default: "7300", env: METRICS_PORT)
+```
+
+- The [Hono](https://hono.dev/docs/getting-started/nodejs) admin api, logger, and all [commander options](https://www.npmjs.com/package/commander) are available as properties on `App`.
+
+- An overridable method on `App` is available, `protected additionalOptions(): []Options`, used to specify any additional cli options needed.
+
+- If enabled, the metrics server emits metrics under the `/metrics` path.
+
+## Lifecycle
+
+The application lifecycle follows
+
+1. preMain(): _validate options and admin api registration prior to running app_
+2. main(): _implementation of app logic_
+3. shutdown() : _triggered on interruption or executed after the return of main_
+   - _This MUST cause the resolution of the main promise in order for graceful shutdown. After the 5th interruption, the process is forcefully exited._

--- a/packages/utils-app/package.json
+++ b/packages/utils-app/package.json
@@ -27,15 +27,14 @@
     "build": "tsc && resolve-tspaths",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\" --ignore-path \"../../.prettierignore\"",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn --ignore-path \"../../.prettierignore\"",
-    "start": "tsx src/index.ts",
     "typecheck": "tsc"
   },
-  "dependencies": {
-    "commander": "^13.1.0",
-    "prom-client": "^15.1.0"
-  },
   "peerDependencies": {
+    "@hono/node-server": "^1.14.0",
+    "hono": "^4.5.0",
+    "commander": "^13.1.0",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0"
+    "pino-pretty": "^13.0.0",
+    "prom-client": "^15.1.0"
   }
 }

--- a/packages/utils-app/src/App.ts
+++ b/packages/utils-app/src/App.ts
@@ -1,6 +1,7 @@
+import { serve } from '@hono/node-server'
 import type { OptionValues } from 'commander'
 import { Command, Option } from 'commander'
-import { createServer } from 'http'
+import { Hono } from 'hono'
 import type { Logger } from 'pino'
 import { pino } from 'pino'
 import { Registry } from 'prom-client'
@@ -18,12 +19,14 @@ export abstract class App {
   // Must be set on run(), available to all hookds
   protected logger!: Logger
   protected options!: OptionValues
+  protected adminApi!: Hono
 
   // A signal available to main() to resolve the
   // main promise during something like an interrupt.
   protected isShuttingDown = false
 
-  private metricsServer: ReturnType<typeof createServer> | null = null
+  private metricsServer: ReturnType<typeof serve> | null = null
+  private adminServer: ReturnType<typeof serve> | null = null
 
   constructor(config: Config) {
     this.program = new Command()
@@ -43,6 +46,16 @@ export abstract class App {
           .default('debug')
           .choices(['debug', 'info', 'warn', 'error', 'silent'])
           .env('LOG_LEVEL'),
+      )
+      .addOption(
+        new Option('--admin-enabled', 'Enable admin API server')
+          .default(false)
+          .env('ADMIN_ENABLED'),
+      )
+      .addOption(
+        new Option('--admin-port <port>', 'Port for admin API')
+          .default('9000')
+          .env('ADMIN_PORT'),
       )
       .addOption(
         new Option('--metrics-enabled', 'Enable metrics collection')
@@ -90,14 +103,16 @@ export abstract class App {
         await this.__startMetricsServer(this.options.metricsPort)
       }
 
+      // Start admin api server if enabled
+      if (this.options.adminEnabled) {
+        await this.__startAdminApiServer(this.options.adminPort)
+      }
+
       // Run pre-main hook
       await this.preMain()
 
       // Run main hook
       await this.main()
-
-      // Run post-main hook
-      await this.postMain()
 
       // Run shutdown
       await this.__shutdown()
@@ -116,24 +131,41 @@ export abstract class App {
 
   /** Optional hook to run before the main function, after parsing arguments */
   protected async preMain(): Promise<void> {}
-  /** Optional hook to run after main returns */
-  protected async postMain(): Promise<void> {}
+
+  /** Optional hook to signal ready state for admin api */
+  protected async ready(): Promise<boolean> {
+    return true
+  }
+
   /** Optional hook to run on interruption */
   protected async shutdown(): Promise<void> {}
 
   private async __startMetricsServer(port: string): Promise<void> {
-    this.metricsServer = createServer(async (req, res) => {
-      if (req.url === '/metrics') {
-        res.setHeader('Content-Type', this.metricsRegistry.contentType)
-        res.end(await this.metricsRegistry.metrics())
-      } else {
-        res.statusCode = 404
-        res.end('Not found')
-      }
+    const metricsApi = new Hono()
+    metricsApi.get('/metrics', async (c) => {
+      c.header('Content-Type', this.metricsRegistry.contentType)
+      return c.body(await this.metricsRegistry.metrics())
     })
 
     this.logger.info(`starting metrics server on port :${port}`)
-    this.metricsServer.listen(port, () => {})
+    this.metricsServer = serve({
+      ...metricsApi,
+      port: Number(port),
+    })
+  }
+
+  private async __startAdminApiServer(port: string): Promise<void> {
+    this.adminApi = new Hono()
+    this.adminApi.get('/healthz', (c) => c.text('OK'))
+    this.adminApi.get('/readyz', async (c) => {
+      return c.body((await this.ready()) ? 'OK' : 'NOT_READY')
+    })
+
+    this.logger.info(`starting admin api server on port :${port}`)
+    this.adminServer = serve({
+      fetch: this.adminApi.fetch,
+      port: Number(port),
+    })
   }
 
   private async __stopMetricsServer(): Promise<void> {
@@ -143,6 +175,22 @@ export abstract class App {
         this.metricsServer!.close((error) => {
           if (error) {
             this.logger.error({ error }, 'error closing metrics server')
+            reject(error)
+          } else {
+            resolve()
+          }
+        })
+      })
+    }
+  }
+
+  private async __stopAdminServer(): Promise<void> {
+    if (this.adminServer) {
+      return new Promise((resolve, reject) => {
+        this.logger.info('stopping admin server...')
+        this.adminServer!.close((error) => {
+          if (error) {
+            this.logger.error({ error }, 'error closing admin api server')
             reject(error)
           } else {
             resolve()
@@ -181,7 +229,11 @@ export abstract class App {
     this.isShuttingDown = true
 
     // shutdown processes
-    await Promise.allSettled([this.shutdown(), this.__stopMetricsServer()])
+    await Promise.allSettled([
+      this.shutdown(),
+      this.__stopMetricsServer(),
+      this.__stopAdminServer(),
+    ])
   }
 
   protected abstract main(): Promise<void>


### PR DESCRIPTION
ADMIN_PORT=
ADMIN_ENABLED=

- A protected member, `adminApi`, is accessible to add any admin api routes in the `preMain` lifecycle prior to spinning up the server
- Provides /healthz & /readyz routes by default.
    - /healthz: Returns OK as long as the process is running
    - /readyz: Returns OK depending on the return value of `ready()`. This can be overriden by the application
