### PR TITLE
fix: ponder-interop should bundle the entire codebase

### DIFF
--- a/apps/ponder-interop/package.json
+++ b/apps/ponder-interop/package.json
@@ -11,9 +11,6 @@
   },
   "version": "0.0.7",
   "type": "module",
-  "files": [
-    "dist"
-  ],
   "main": "./dist/ponder.schema.js",
   "types": "./dist/ponder.schema.d.ts",
   "exports": {


### PR DESCRIPTION
ponder cli runs the source directly