### PR TITLE
feat(ponder-interop): use hash of message identifier as primary key on `l2_to_l2_cdm_sent_messages` table

### DIFF
--- a/.changeset/dull-students-reply.md
+++ b/.changeset/dull-students-reply.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ponder-interop': patch
+---
+
+add messageIdentifierHash column to l2_to_l2_cdm_relayed_messages and l2_to_l2_cdm_sent_messages tables

--- a/apps/ponder-interop/ponder.schema.ts
+++ b/apps/ponder-interop/ponder.schema.ts
@@ -1,36 +1,46 @@
 // Hack to resolve https://github.com/ponder-sh/ponder/issues/1722
 import 'drizzle-orm/pg-core'
 
-import { onchainTable } from 'ponder'
+import { index, onchainTable, uniqueIndex } from 'ponder'
 
-export const sentMessages = onchainTable('l2_to_l2_cdm_sent_messages', (t) => ({
-  // unique identifier
-  messageHash: t.hex().primaryKey(),
+export const sentMessages = onchainTable(
+  'l2_to_l2_cdm_sent_messages',
+  (t) => ({
+    // unique identifier
+    messageIdentifierHash: t.hex().primaryKey(),
 
-  // parsed message fields
-  source: t.bigint().notNull(),
-  destination: t.bigint().notNull(),
-  nonce: t.bigint().notNull(),
-  sender: t.hex().notNull(),
-  target: t.hex().notNull(),
-  message: t.hex().notNull(),
+    // parsed message fields
+    messageHash: t.hex(),
+    source: t.bigint().notNull(),
+    destination: t.bigint().notNull(),
+    nonce: t.bigint().notNull(),
+    sender: t.hex().notNull(),
+    target: t.hex().notNull(),
+    message: t.hex().notNull(),
 
-  // log fields
-  logIndex: t.bigint().notNull(),
-  logPayload: t.hex().notNull(),
+    // log fields
+    logIndex: t.bigint().notNull(),
+    logPayload: t.hex().notNull(),
 
-  // general fields
-  timestamp: t.bigint().notNull(),
-  blockNumber: t.bigint().notNull(),
-  transactionHash: t.hex().notNull(),
-  txOrigin: t.hex().notNull(),
-}))
+    // general fields
+    timestamp: t.bigint().notNull(),
+    blockNumber: t.bigint().notNull(),
+    transactionHash: t.hex().notNull(),
+    txOrigin: t.hex().notNull(),
+  }),
+  (table) => ({
+    messageHashIdx: index().on(table.messageHash),
+  }),
+)
 
 export const relayedMessages = onchainTable(
   'l2_to_l2_cdm_relayed_messages',
   (t) => ({
     // unique identifier
     messageHash: t.hex().primaryKey(),
+
+    // message fields
+    messageIdentifierHash: t.hex(),
 
     // Some unique metadata on the relaying side
     relayer: t.hex().notNull(),
@@ -43,5 +53,8 @@ export const relayedMessages = onchainTable(
     timestamp: t.bigint().notNull(),
     blockNumber: t.bigint().notNull(),
     transactionHash: t.hex().notNull(),
+  }),
+  (table) => ({
+    messageIdentifierHashIdx: uniqueIndex().on(table.messageIdentifierHash),
   }),
 )

--- a/apps/ponder-interop/src/utils/hashMessageIdentifier.ts
+++ b/apps/ponder-interop/src/utils/hashMessageIdentifier.ts
@@ -1,0 +1,23 @@
+import type { MessageIdentifier } from '@eth-optimism/viem'
+import type { Hash } from 'viem'
+import { encodeAbiParameters, keccak256, parseAbiParameters } from 'viem'
+
+/**
+ * Hash an L2 to L2 cross domain message identifier
+ * @param message {@link MessageIdentifier}
+ * @returns Hash of the cross domain message identifier
+ */
+export function hashMessageIdentifier(message: MessageIdentifier): Hash {
+  const encoded = encodeAbiParameters(
+    parseAbiParameters('address,uint256,uint256,uint256,uint256'),
+    [
+      message.origin,
+      message.blockNumber,
+      message.logIndex,
+      message.timestamp,
+      message.chainId,
+    ],
+  )
+
+  return keccak256(encoded)
+}


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem-private/issues/351

With re-emitted messages it is possible for two `SentMesage` events to have identical message hashes. With the primary key of the `l2_to_l2_cdm_sent_messages` ponder table being the message hash, it does not support inserting re-emitted messages. To fix this, this PR updates the primary key of the `l2_to_l2_cdm_sent_messages` to be a hash of the `MessageIdentifier`. 

**Note**: the primary key for the `l2_to_l2_cdm_relayed_messages` can remain as the message hash, since messages cannot be relayed more than once.