### PR TITLE
feat(ponder-interop): /schema endpoint

### DIFF
--- a/apps/ponder-interop/src/api/index.ts
+++ b/apps/ponder-interop/src/api/index.ts
@@ -30,6 +30,10 @@ app.get('/chains', async (c) => {
   return c.json(chains)
 })
 
+app.get('/schema', async (c) => {
+  return c.json(process.env.DATABASE_SCHEMA)
+})
+
 // Count of all messages (sent, relayed, pending)
 app.get('/messages/count', async (c) => {
   const sent = await db


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem-private/issues/342

The /schema endpoint exposes the current schema that the ponder instance is on. This is helpful for any clients running queries against the ponder db, so that they can be aware of which schema to run their queries against.