### PR TITLE
fix(utils-app): start admin api server after `preMain` hook

### DIFF
--- a/.changeset/ten-icons-smell.md
+++ b/.changeset/ten-icons-smell.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/utils-app': patch
+---
+
+fix: start admin api server after preMain hook

--- a/packages/utils-app/src/App.ts
+++ b/packages/utils-app/src/App.ts
@@ -105,13 +105,13 @@ export abstract class App {
         await this.__startMetricsServer(this.options.metricsPort)
       }
 
+      // Run pre-main hook
+      await this.preMain()
+
       // Start admin api server if enabled
       if (this.options.adminEnabled) {
         await this.__startAdminApiServer(this.options.adminPort)
       }
-
-      // Run pre-main hook
-      await this.preMain()
 
       // Run main hook
       await this.main()


### PR DESCRIPTION
Run `preMain` hook before starting the admin api server, so that the admin api server can use state initialized inside `preMain`.