### PR TITLE
feat(autorelayer-interop): relay messages via GasTank

### DIFF
--- a/.changeset/sixty-chairs-teach.md
+++ b/.changeset/sixty-chairs-teach.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/autorelayer-interop': patch
+---
+
+add GAS_TANK_ADDRESS option for enabling relays via GasTank

--- a/apps/autorelayer-interop/docker-compose.yml
+++ b/apps/autorelayer-interop/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  relayer:
+    profiles:
+      - app
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      target: autorelayer-interop
+      args:
+        - DOCKER_TARGET=autorelayer-interop
+    env_file: .env
+    environment:
+      - PONDER_INTEROP_API_URL=http://host.docker.internal:42069
+      - SPONSORED_ENDPOINT_URL=http://host.docker.internal:8460
+      - CHAIN_ENDPOINT_OVERRIDES=http://host.docker.internal:9545,http://host.docker.internal:9546
+      - GAS_TANK_ADDRESS=0x420beeF000000000000000000000000000000002
+    healthcheck:
+      test: curl http://0.0.0.0:7500/healthz
+    volumes:
+      - ../../certs/extra-ca-certificates.crt:/usr/local/share/ca-certificates/extra-ca-certificates.crt
+    ports:
+      - 8500:7500

--- a/apps/autorelayer-interop/package.json
+++ b/apps/autorelayer-interop/package.json
@@ -25,6 +25,8 @@
   "scripts": {
     "build": "pnpm clean && tsc && resolve-tspaths",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "docker:up": "docker compose --profile app up -d",
+    "docker:down": "docker compose down",
     "lint": "eslint \"**/*.{ts,tsx}\" && pnpm prettier --check \"**/*.{ts,tsx}\" --ignore-path \"../../.prettierignore\"",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix && pnpm prettier \"**/*.{ts,tsx}\" --write --loglevel=warn --ignore-path \"../../.prettierignore\"",
     "dev": "tsx src/index.ts",

--- a/apps/autorelayer-interop/src/app.ts
+++ b/apps/autorelayer-interop/src/app.ts
@@ -1,8 +1,14 @@
 import { App } from '@eth-optimism/utils-app'
 import { Option } from 'commander'
 import type { Logger } from 'pino'
-import type { Hex, PublicClient, WalletClient } from 'viem'
-import { createPublicClient, createWalletClient, http, isHex } from 'viem'
+import type { Address, Hex, PublicClient, WalletClient } from 'viem'
+import {
+  createPublicClient,
+  createWalletClient,
+  getAddress,
+  http,
+  isHex,
+} from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { z } from 'zod'
 
@@ -38,6 +44,7 @@ const ConfigSchema = z.object({
       if (!key) return true
       return isHex(key) && privateKeyToAccount(key) !== undefined
     }, 'private key must be a valid hex string'),
+  gasTankAddress: z.custom<Address>().optional(),
 })
 
 type Chains = z.infer<typeof ChainSchema>
@@ -89,6 +96,12 @@ class RelayerApp extends App {
       )
         .conflicts('sponsoredEndpoint')
         .env('SENDER_PRIVATE_KEY'),
+      new Option(
+        '--gas-tank-address <address>',
+        'address of the gas tank to use for the relayer',
+      )
+        .env('GAS_TANK_ADDRESS')
+        .argParser((val) => getAddress(val)),
     ]
   }
 
@@ -168,6 +181,7 @@ class RelayerApp extends App {
       ponderInteropApi: config.ponderInteropApi,
       clients,
       walletClients,
+      gasTankAddress: config.gasTankAddress,
     })
   }
 


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem/issues/854

## Changes
- adds env var `GAS_TANK_ADDRESS` that when set will relay messages via gas tank and points to gas tank contract
- refactors and updates relay logic to relay through gas tank when `GAS_TANK_ADDRESS` is defined
- adds `docker-compose.yml` for `autorelayer-interop`

For now this just relays all messages through the gas tank when the `GAS_TANK_ADDRESS` var is defined regardless of whether or not the gas tank actually is funded for that message. Balance checking will be handled in subsequent PR.