### PR TITLE
feat(ponder-interop): add endpoint for fetching pending messages from gas tank

### DIFF
--- a/.changeset/shy-ties-hunt.md
+++ b/.changeset/shy-ties-hunt.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ponder-interop': patch
+---
+
+Add /messages/pending/gas-tank endpoint for fetching pending messages with gas tank funds

--- a/apps/ponder-interop/docker-compose.yml
+++ b/apps/ponder-interop/docker-compose.yml
@@ -6,11 +6,7 @@ services:
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
-      test:
-        [
-          'CMD-SHELL',
-          'pg_isready -q -U local-db-user -d ponder-interop',
-        ]
+      test: ['CMD-SHELL', 'pg_isready -q -U local-db-user -d ponder-interop']
       interval: 5s
       timeout: 10s
       retries: 3
@@ -32,6 +28,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://local-db-user:@postgres:5432/ponder-interop
+      - GAS_TANK_CONTRACT_ADDRESS=0x420beeF000000000000000000000000000000002
     volumes:
       - ../../certs/extra-ca-certificates.crt:/usr/local/share/ca-certificates/extra-ca-certificates.crt
     healthcheck:

--- a/apps/ponder-interop/src/constants/envVars.ts
+++ b/apps/ponder-interop/src/constants/envVars.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 
-import { getAddress, isAddress } from 'viem'
+import { getAddress } from 'viem'
 import { inferSchemas, parseEnv } from 'znv'
 import { z } from 'zod'
 
@@ -9,12 +9,8 @@ export const envVarsSchema = inferSchemas({
     schema: z
       .string()
       .optional()
-      .refine(
-        (address) => address === undefined || isAddress(address),
-        'must be a valid address',
-      )
       .transform((address) =>
-        address === undefined ? address : getAddress(address),
+        address === undefined ? undefined : getAddress(address),
       ),
   },
 })


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem/issues/839

## Changes
- Adds `/messages/pending/gas-tank` endpoint to ponder api, which returns all pending messages that have been authorized to be relayed and that contain a gas provider balance > 0