### PR TITLE
feat(autorelayer-interop): only relay pending messages with gas tank funds when gasTankAddress option is set

### DIFF
--- a/.changeset/funny-schools-change.md
+++ b/.changeset/funny-schools-change.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/autorelayer-interop': patch
+---
+
+Only relay pending messages with gas tank funds when gasTankAddress option is set

--- a/apps/autorelayer-interop/src/app.ts
+++ b/apps/autorelayer-interop/src/app.ts
@@ -15,11 +15,15 @@ import { z } from 'zod'
 import type {
   PendingMessage,
   PendingMessages,
+  PendingMessagesWithGasTank,
+  PendingMessageWithGasTank,
   RelayerConfig,
 } from '@/relayer.js'
 import {
   PendingMessageSchema,
   PendingMessagesSchema,
+  PendingMessagesWithGasTankSchema,
+  PendingMessageWithGasTankSchema,
   Relayer,
 } from '@/relayer.js'
 import { jsonFetchParams } from '@/utils/jsonFetchParams.js'
@@ -202,9 +206,13 @@ class RelayerApp extends App {
 
 export {
   type PendingMessage,
-  PendingMessages,
+  type PendingMessages,
   PendingMessageSchema,
   PendingMessagesSchema,
+  type PendingMessagesWithGasTank,
+  PendingMessagesWithGasTankSchema,
+  type PendingMessageWithGasTank,
+  PendingMessageWithGasTankSchema,
   Relayer,
   RelayerApp,
   type RelayerConfig,


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem/issues/839

## Changes
- Updates `autorelayer-interop` to only relay messages if they have a sufficient balance in the `GasTank` to cover the cost of the relay and claim