### PR TITLE
feat(ponder-interop): api endpoint for fetching pending GasTank claims

### DIFF
--- a/.changeset/cyan-kids-trade.md
+++ b/.changeset/cyan-kids-trade.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ponder-interop': patch
+---
+
+add api endpoint for fetching pending GasTank claims

--- a/apps/ponder-interop/ponder.schema.ts
+++ b/apps/ponder-interop/ponder.schema.ts
@@ -116,11 +116,24 @@ export const gasTankClaimedMessages = onchainTable(
 export const gasTankRelayedMessageReceipts = onchainTable(
   'gas_tank_relayed_message_receipts',
   (t) => ({
+    // unique identifier
     messageHash: t.hex().notNull().primaryKey(),
+
+    // message fields
+    origin: t.hex().notNull(),
+    blockNumber: t.bigint().notNull(),
+    logIndex: t.bigint().notNull(),
+    timestamp: t.bigint().notNull(),
     chainId: t.bigint().notNull(),
+    logPayload: t.hex().notNull(),
+
+    // receipt fields
     relayer: t.hex().notNull(),
     relayCost: t.bigint().notNull(),
     nestedMessageHashes: t.hex().array().notNull(),
     relayedAt: t.bigint().notNull(),
+  }),
+  (table) => ({
+    relayerIdx: index().on(table.relayer),
   }),
 )


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem/issues/840

## Changes 
- Updates the `gas_tank_relayed_message_receipts` to store the message identifier and log payload of the `RelayedMessageGasReceipt` event
- Adds the `/messages/pending/claims` endpoint to the ponder api, which returns a list of relayed messages that should be claimed from the `GasTank`