### PR TITLE
feat(ponder-interop): return pending withdrawals with pending message gas providers

### DIFF
--- a/.changeset/slow-rules-rest.md
+++ b/.changeset/slow-rules-rest.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ponder-interop': patch
+---
+
+Return pending withdrawals alongside pending messages and fix query limits


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem-private/issues/397

## Changes
- Return withdrawal info alongside `GasProvider` for pending messages.
- Return withdrawal info alongside `GasProvider` for pending claims.
- Group the pending messages query by distinct `messageHash` and limit to 10, then `JOIN` the `gasProvider` information for each message.
- Group the pending claims query by distinct `messageHash` and limit to 10, then `JOIN` the `gasProvider` information for each message. 

## Context
The query changes fix a bug where if 1 message had 10 different `gasProvider`s, then the query would return just one message along with each of its 10 gas providers. Now the query will always return up to 10 distinct messages and groups together all the `gasProvider`s for each message