### PR TITLE
Update useSendL2ToL2Message.md

### DIFF
--- a/packages/wagmi/docs/useSendL2ToL2Message.md
+++ b/packages/wagmi/docs/useSendL2ToL2Message.md
@@ -26,7 +26,7 @@ const hash = await sendMessage({
 
 - **Type:** `(params: SendL2ToL2MessageParameters) => Promise<`0x${string}`>`
 
-Call this function with the [SendL2ToL2MessageParameters](https://github.com/ethereum-optimism/ecosystem/blob/main/packages/viem/docs/actions/sendL2ToL2Message.md#parameters) to initiate a cross chain message
+Call this function with the [SendL2ToL2MessageParameters](https://github.com/ethereum-optimism/ecosystem/blob/main/packages/wagmi/docs/useSendL2ToL2Message.md#parameters) to initiate a cross chain message
 
 ### `isError`
 


### PR DESCRIPTION
this PR updates the documentation link in useSendL2ToL2Message.md. Specifically, it changes the URL path from /view/docs/ to /wagmi/docs/ in the parameters reference link. This appears to be a documentation fix to point to the correct location of the SendL2ToL2MessageParameters documentation.
