### PR TITLE
feat(ponder-interop): add api endpoint for fetching pending claims for a given gas provider

### DIFF
--- a/.changeset/dirty-cats-tap.md
+++ b/.changeset/dirty-cats-tap.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ponder-interop': patch
+---
+
+added api endpoint for fetching pending claims for a given gas provider


### PR DESCRIPTION
Part of https://github.com/ethereum-optimism/ecosystem-private/issues/398

## Changes
- Adds the `/messages/pending/claims/:gasProvider/:chainId` endpoint to the ponder api, which returns the total pending relay costs that can be claimed against a specified gas provider