### PR TITLE
feat(autorelayer-interop): incorporate pending claims into GasProvider balance calculations

### DIFF
--- a/.changeset/good-teachers-itch.md
+++ b/.changeset/good-teachers-itch.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/autorelayer-interop': patch
+---
+
+incorporate pending claims into GasProvider balance calculations


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem-private/issues/398

## Changes
- When calculating the balance for a given `GasProvider` deducts any unclaimed relays from the `GasProvider`s balance