### PR TITLE
feat(relayer): Update relays through the GasTank to specify GasProvider when relaying message

### DIFF
--- a/.changeset/curvy-wolves-relax.md
+++ b/.changeset/curvy-wolves-relax.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/ponder-interop': patch
----
-
-Update to index GasProvider from RelayedMessageGasReceipt

--- a/.changeset/curvy-wolves-relax.md
+++ b/.changeset/curvy-wolves-relax.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/ponder-interop': patch
+---
+
+Update to index GasProvider from RelayedMessageGasReceipt

--- a/.changeset/shaggy-boxes-notice.md
+++ b/.changeset/shaggy-boxes-notice.md
@@ -1,0 +1,7 @@
+---
+'@eth-optimism/autorelayer-interop': patch
+'@eth-optimism/ponder-interop': patch
+'@eth-optimism/viem': patch
+---
+
+Update relays through the GasTank to specify GasProvider when relaying message

--- a/.changeset/two-turtles-reply.md
+++ b/.changeset/two-turtles-reply.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/viem': patch
+---
+
+Update GasTank abi to latest version

--- a/.changeset/two-turtles-reply.md
+++ b/.changeset/two-turtles-reply.md
@@ -1,5 +1,0 @@
----
-'@eth-optimism/viem': patch
----
-
-Update GasTank abi to latest version

--- a/apps/ponder-interop/ponder.schema.ts
+++ b/apps/ponder-interop/ponder.schema.ts
@@ -128,6 +128,8 @@ export const gasTankRelayedMessageReceipts = onchainTable(
     logPayload: t.hex().notNull(),
 
     // receipt fields
+    gasProvider: t.hex().notNull(),
+    gasProviderChainId: t.bigint().notNull(),
     relayer: t.hex().notNull(),
     relayCost: t.bigint().notNull(),
     nestedMessageHashes: t.hex().array().notNull(),

--- a/apps/ponder-interop/src/index.ts
+++ b/apps/ponder-interop/src/index.ts
@@ -214,6 +214,8 @@ ponder.on('GasTank:RelayedMessageGasReceipt', async ({ event, context }) => {
       topics: event.log.topics.filter((topic) => topic !== null),
     } as Log),
 
+    gasProvider: event.args.gasProvider,
+    gasProviderChainId: event.args.gasProviderChainID,
     relayer: event.args.relayer,
     relayCost: event.args.relayCost,
     nestedMessageHashes: [...event.args.nestedMessageHashes],

--- a/packages/viem/src/abis/experimental/index.ts
+++ b/packages/viem/src/abis/experimental/index.ts
@@ -147,35 +147,6 @@ export const gasTankAbi = [
   },
   {
     type: 'function',
-    name: 'claimOverhead',
-    inputs: [
-      {
-        name: '_numHashes',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: '_baseFee',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-      {
-        name: '_data',
-        type: 'bytes',
-        internalType: 'bytes',
-      },
-    ],
-    outputs: [
-      {
-        name: 'overhead_',
-        type: 'uint256',
-        internalType: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
     name: 'claimed',
     inputs: [
       {
@@ -341,6 +312,30 @@ export const gasTankAbi = [
       },
     ],
     stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'simulateClaimOverhead',
+    inputs: [
+      {
+        name: '_numHashes',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_baseFee',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: 'overhead_',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'pure',
   },
   {
     type: 'function',

--- a/packages/viem/src/abis/experimental/index.ts
+++ b/packages/viem/src/abis/experimental/index.ts
@@ -7,13 +7,13 @@
 export const gasTankAbi = [
   {
     type: 'function',
-    name: 'MAX_DEPOSIT',
+    name: 'GAS_PRICE_ORACLE',
     inputs: [],
     outputs: [
       {
         name: '',
-        type: 'uint256',
-        internalType: 'uint256',
+        type: 'address',
+        internalType: 'contract IGasPriceOracle',
       },
     ],
     stateMutability: 'view',
@@ -49,9 +49,9 @@ export const gasTankAbi = [
     name: 'authorizeClaim',
     inputs: [
       {
-        name: '_messageHash',
-        type: 'bytes32',
-        internalType: 'bytes32',
+        name: '_messageHashes',
+        type: 'bytes32[]',
+        internalType: 'bytes32[]',
       },
     ],
     outputs: [],
@@ -137,11 +137,6 @@ export const gasTankAbi = [
         ],
       },
       {
-        name: '_gasProvider',
-        type: 'address',
-        internalType: 'address',
-      },
-      {
         name: '_payload',
         type: 'bytes',
         internalType: 'bytes',
@@ -164,6 +159,11 @@ export const gasTankAbi = [
         type: 'uint256',
         internalType: 'uint256',
       },
+      {
+        name: '_data',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
     ],
     outputs: [
       {
@@ -172,7 +172,7 @@ export const gasTankAbi = [
         internalType: 'uint256',
       },
     ],
-    stateMutability: 'pure',
+    stateMutability: 'view',
   },
   {
     type: 'function',
@@ -213,6 +213,16 @@ export const gasTankAbi = [
         name: 'relayer_',
         type: 'address',
         internalType: 'address',
+      },
+      {
+        name: 'gasProvider_',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'gasProviderChainID_',
+        type: 'uint256',
+        internalType: 'uint256',
       },
       {
         name: 'relayCost_',
@@ -306,6 +316,16 @@ export const gasTankAbi = [
         name: '_sentMessage',
         type: 'bytes',
         internalType: 'bytes',
+      },
+      {
+        name: '_gasProvider',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_gasProviderChainID',
+        type: 'uint256',
+        internalType: 'uint256',
       },
     ],
     outputs: [
@@ -444,6 +464,18 @@ export const gasTankAbi = [
         internalType: 'address',
       },
       {
+        name: 'gasProvider',
+        type: 'address',
+        indexed: false,
+        internalType: 'address',
+      },
+      {
+        name: 'gasProviderChainID',
+        type: 'uint256',
+        indexed: false,
+        internalType: 'uint256',
+      },
+      {
         name: 'relayCost',
         type: 'uint256',
         indexed: false,
@@ -514,6 +546,11 @@ export const gasTankAbi = [
   },
   {
     type: 'error',
+    name: 'InvalidChainID',
+    inputs: [],
+  },
+  {
+    type: 'error',
     name: 'InvalidLength',
     inputs: [],
   },
@@ -525,11 +562,6 @@ export const gasTankAbi = [
   {
     type: 'error',
     name: 'InvalidPayload',
-    inputs: [],
-  },
-  {
-    type: 'error',
-    name: 'MaxDepositExceeded',
     inputs: [],
   },
   {


### PR DESCRIPTION
## Context

The `GasTank` abi was recently updated such that now the `GasProvider` is specified at the time of relay, rather than at the time of claiming a message. This change was needed in order to ensure that the a relay receipt could not be claimed multiple times.

## Changes
- (viem): Update the `GasTank` abi
- (ponder-interop): Index the `GasProvider` from the `RelayMessageReceipt`
- (ponder-interop): update pending claims API endpoint to just return the relay receipt
- (autorelayer-interop): update relays to group by gas provider and specify gas provider when relaying message