### PR TITLE
feat(autorelayer-interop): add support for relaying sponsored messages

### DIFF
--- a/.changeset/shaggy-eyes-hammer.md
+++ b/.changeset/shaggy-eyes-hammer.md
@@ -1,0 +1,5 @@
+---
+'@eth-optimism/autorelayer-interop': patch
+---
+
+Add support for sponsoring relays for specific message targets

--- a/apps/autorelayer-interop/src/api/ponderApi.ts
+++ b/apps/autorelayer-interop/src/api/ponderApi.ts
@@ -1,0 +1,70 @@
+import type { RelayerConfig } from '@/config/relayerConfig.js'
+import {
+  PendingMessagesSchema,
+  PendingMessagesWithGasTankSchema,
+} from '@/schemas/index.js'
+import type {
+  PendingMessages,
+  PendingMessagesWithGasTank,
+} from '@/types/index.js'
+import { jsonFetchParams } from '@/utils/jsonFetchParams.js'
+import { serializeSponsoredTargets } from '@/utils/sponsoredTargets.js'
+import { formatZodError } from '@/utils/zodHelpers.js'
+
+export async function fetchSponsoredMessages({
+  sponsoredTargets,
+  ponderInteropApi,
+}: {
+  sponsoredTargets: RelayerConfig['sponsoredTargets']
+  ponderInteropApi: string
+}): Promise<PendingMessages> {
+  if (!sponsoredTargets || sponsoredTargets.length === 0) {
+    return []
+  }
+
+  const url = new URL(`${ponderInteropApi}/messages/pending`)
+  url.searchParams.set(
+    'filteredTargets',
+    serializeSponsoredTargets(sponsoredTargets),
+  )
+
+  const resp = await fetch(url, jsonFetchParams)
+  if (!resp.ok) {
+    throw new Error(`http response: ${resp.statusText}`)
+  }
+
+  const body = await resp.json()
+  const { data: msgs, error } = PendingMessagesSchema.safeParse(body)
+  if (error) {
+    throw new Error(`api response: ${formatZodError(error)}`)
+  }
+  return msgs
+}
+
+export async function fetchPendingMessagesWithGasTankFunds({
+  sponsoredTargets,
+  ponderInteropApi,
+}: {
+  sponsoredTargets: RelayerConfig['sponsoredTargets']
+  ponderInteropApi: string
+}): Promise<PendingMessagesWithGasTank> {
+  const url = new URL(`${ponderInteropApi}/messages/pending/gas-tank`)
+  if (sponsoredTargets) {
+    url.searchParams.set(
+      'excludedTargets',
+      serializeSponsoredTargets(sponsoredTargets),
+    )
+  }
+
+  const resp = await fetch(url, jsonFetchParams)
+  if (!resp.ok) {
+    throw new Error(`http response: ${resp.statusText}`)
+  }
+
+  const body = await resp.json()
+  const { data: msgs, error } = PendingMessagesWithGasTankSchema.safeParse(body)
+  if (error) {
+    throw new Error(`api response: ${formatZodError(error)}`)
+  }
+  return msgs
+}

--- a/apps/autorelayer-interop/src/config/relayerConfig.ts
+++ b/apps/autorelayer-interop/src/config/relayerConfig.ts
@@ -1,0 +1,9 @@
+import type { Address, PublicClient, WalletClient } from 'viem'
+
+export interface RelayerConfig {
+  ponderInteropApi: string
+  clients: Record<number, PublicClient>
+  walletClients: Record<number, WalletClient>
+  sponsoredTargets?: Array<{ address: Address; chainId: bigint }>
+  gasTankAddress?: Address
+}

--- a/apps/autorelayer-interop/src/schemas/index.ts
+++ b/apps/autorelayer-interop/src/schemas/index.ts
@@ -1,0 +1,75 @@
+import { isAddress, isHash, isHex } from 'viem'
+import { z } from 'zod'
+
+export const PendingClaimSchema = z.object({
+  relayReceipt: z.object({
+    messageHash: z.string().refine(isHex, 'invalid message hash'),
+    origin: z.string().refine(isAddress, 'invalid origin'),
+    blockNumber: z.number(),
+    logIndex: z.number(),
+    timestamp: z.number(),
+    chainId: z.number(),
+    logPayload: z.string().refine(isHex, 'invalid log payload'),
+    gasProvider: z.string().refine(isAddress, 'invalid gas provider'),
+    gasProviderChainId: z.number(),
+    relayer: z.string().refine(isAddress, 'invalid relayer'),
+    relayCost: z.number(),
+    relayedAt: z.number(),
+    nestedMessageHashes: z.array(
+      z.string().refine(isHex, 'invalid nested message hash'),
+    ),
+  }),
+})
+
+export const PendingClaimsSchema = z.array(PendingClaimSchema)
+
+export const PendingRelayCostForGasProviderSchema = z
+  .object({
+    gasProviderAddress: z
+      .string()
+      .refine(isAddress, 'invalid gas provider address'),
+    gasProviderChainId: z.number(),
+    totalPendingRelayCost: z.coerce.number(),
+    pendingReceiptsCount: z.number(),
+  })
+  .nullable()
+
+export const PendingMessageSchema = z.object({
+  // Identifier
+  messageHash: z.string().refine(isHex, 'invalid message hash'),
+  // Message Direction
+  source: z.number(),
+  destination: z.number(),
+  target: z.string().refine(isAddress, 'invalid target'),
+  txOrigin: z.string().refine(isAddress, 'invalid transaction origin'),
+  // ExecutingMessage
+  logIndex: z.number(),
+  logPayload: z.string().refine(isHex, 'invalid log payload'),
+  timestamp: z.number(),
+  blockNumber: z.number(),
+  transactionHash: z.string().refine(isHash, 'invalid transaction hash'),
+})
+
+export const PendingMessagesSchema = z.array(PendingMessageSchema)
+
+export const GasTankProviderSchema = z.object({
+  gasTankChainId: z.number(),
+  gasProviderBalance: z.number(),
+  gasProviderAddress: z
+    .string()
+    .refine(isAddress, 'invalid gas provider address'),
+  pendingWithdrawal: z
+    .object({
+      amount: z.number(),
+      initiatedAt: z.number(),
+    })
+    .optional(),
+})
+
+export const PendingMessageWithGasTankSchema = PendingMessageSchema.extend({
+  gasTankProviders: z.array(GasTankProviderSchema),
+})
+
+export const PendingMessagesWithGasTankSchema = z.array(
+  PendingMessageWithGasTankSchema,
+)

--- a/apps/autorelayer-interop/src/types/index.ts
+++ b/apps/autorelayer-interop/src/types/index.ts
@@ -1,0 +1,25 @@
+import type { z } from 'zod'
+
+import type { GasTankProviderSchema, PendingClaimSchema, PendingClaimsSchema, PendingMessageSchema,PendingMessagesSchema,PendingMessagesWithGasTankSchema,PendingMessageWithGasTankSchema, PendingRelayCostForGasProviderSchema } from '@/schemas/index.js'
+
+export type PendingClaim = z.infer<typeof PendingClaimSchema>
+
+export type PendingClaims = z.infer<typeof PendingClaimsSchema>
+
+export type PendingRelayCostForGasProvider = z.infer<
+  typeof PendingRelayCostForGasProviderSchema
+>
+
+export type PendingMessage = z.infer<typeof PendingMessageSchema>
+
+export type PendingMessages = z.infer<typeof PendingMessagesSchema>
+
+export type GasTankProvider = z.infer<typeof GasTankProviderSchema>
+
+export type PendingMessageWithGasTank = z.infer<
+  typeof PendingMessageWithGasTankSchema
+>
+
+export type PendingMessagesWithGasTank = z.infer<
+  typeof PendingMessagesWithGasTankSchema
+>

--- a/apps/autorelayer-interop/src/utils/sponsoredTargets.ts
+++ b/apps/autorelayer-interop/src/utils/sponsoredTargets.ts
@@ -1,0 +1,22 @@
+import type { Address } from 'viem'
+
+export type SponsoredTarget = {
+  address: Address
+  chainId: bigint
+}
+
+/**
+ * Converts sponsored targets to the format expected by the API
+ * @param sponsoredTargets - Array of sponsored targets
+ * @returns JSON string ready for URL parameters
+ */
+export function serializeSponsoredTargets(
+  sponsoredTargets: SponsoredTarget[],
+): string {
+  return JSON.stringify(
+    sponsoredTargets.map((target) => ({
+      address: target.address,
+      chainId: target.chainId.toString(),
+    })),
+  )
+}

--- a/apps/autorelayer-interop/src/utils/zodHelpers.ts
+++ b/apps/autorelayer-interop/src/utils/zodHelpers.ts
@@ -1,0 +1,12 @@
+import type { ZodError } from 'zod'
+
+/**
+ * Formats Zod validation errors into a readable error message
+ * @param error - The Zod error object
+ * @returns Formatted error message
+ */
+export function formatZodError(error: ZodError): string {
+  return error.errors
+    .map((e) => `{${e.path.join('.')}: ${e.message}}`)
+    .join(', ')
+}


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem-private/issues/392

## Changes
- Updates the relayer config to accept a list of sponsored targets in format `<address>:<chain-id>`
- Fetches pending messages to sponsor using the sponsored targets on the config and relays them through the `L2toL2CrossDomainMessenger`
- Started breaking out `relayer.ts` file into separate files
