### PR TITLE
fix(relayer): fix ponder BigInt serialization and fix GasProvider relay grouping

### DIFF
--- a/.changeset/curly-buses-draw.md
+++ b/.changeset/curly-buses-draw.md
@@ -1,0 +1,6 @@
+---
+'@eth-optimism/autorelayer-interop': patch
+'@eth-optimism/ponder-interop': patch
+---
+
+Fix BigInt serialization on ponder api and fix GasProvider concurrency bug

--- a/apps/autorelayer-interop/src/config/relayerConfig.ts
+++ b/apps/autorelayer-interop/src/config/relayerConfig.ts
@@ -2,8 +2,8 @@ import type { Address, PublicClient, WalletClient } from 'viem'
 
 export interface RelayerConfig {
   ponderInteropApi: string
-  clients: Record<number, PublicClient>
-  walletClients: Record<number, WalletClient>
+  clients: Record<string, PublicClient>
+  walletClients: Record<string, WalletClient>
   sponsoredTargets?: Array<{ address: Address; chainId: bigint }>
   gasTankAddress?: Address
 }

--- a/apps/autorelayer-interop/src/schemas/index.ts
+++ b/apps/autorelayer-interop/src/schemas/index.ts
@@ -5,16 +5,16 @@ export const PendingClaimSchema = z.object({
   relayReceipt: z.object({
     messageHash: z.string().refine(isHex, 'invalid message hash'),
     origin: z.string().refine(isAddress, 'invalid origin'),
-    blockNumber: z.number(),
-    logIndex: z.number(),
-    timestamp: z.number(),
-    chainId: z.number(),
+    blockNumber: z.coerce.bigint(),
+    logIndex: z.coerce.bigint(),
+    timestamp: z.coerce.bigint(),
+    chainId: z.coerce.bigint(),
     logPayload: z.string().refine(isHex, 'invalid log payload'),
     gasProvider: z.string().refine(isAddress, 'invalid gas provider'),
-    gasProviderChainId: z.number(),
+    gasProviderChainId: z.coerce.bigint(),
     relayer: z.string().refine(isAddress, 'invalid relayer'),
-    relayCost: z.number(),
-    relayedAt: z.number(),
+    relayCost: z.coerce.bigint(),
+    relayedAt: z.coerce.bigint(),
     nestedMessageHashes: z.array(
       z.string().refine(isHex, 'invalid nested message hash'),
     ),
@@ -28,9 +28,9 @@ export const PendingRelayCostForGasProviderSchema = z
     gasProviderAddress: z
       .string()
       .refine(isAddress, 'invalid gas provider address'),
-    gasProviderChainId: z.number(),
-    totalPendingRelayCost: z.coerce.number(),
-    pendingReceiptsCount: z.number(),
+    gasProviderChainId: z.coerce.bigint(),
+    totalPendingRelayCost: z.coerce.bigint(),
+    pendingReceiptsCount: z.coerce.bigint(),
   })
   .nullable()
 
@@ -38,30 +38,30 @@ export const PendingMessageSchema = z.object({
   // Identifier
   messageHash: z.string().refine(isHex, 'invalid message hash'),
   // Message Direction
-  source: z.number(),
-  destination: z.number(),
+  source: z.coerce.bigint(),
+  destination: z.coerce.bigint(),
   target: z.string().refine(isAddress, 'invalid target'),
   txOrigin: z.string().refine(isAddress, 'invalid transaction origin'),
   // ExecutingMessage
-  logIndex: z.number(),
+  logIndex: z.coerce.bigint(),
   logPayload: z.string().refine(isHex, 'invalid log payload'),
-  timestamp: z.number(),
-  blockNumber: z.number(),
+  timestamp: z.coerce.bigint(),
+  blockNumber: z.coerce.bigint(),
   transactionHash: z.string().refine(isHash, 'invalid transaction hash'),
 })
 
 export const PendingMessagesSchema = z.array(PendingMessageSchema)
 
 export const GasTankProviderSchema = z.object({
-  gasTankChainId: z.number(),
-  gasProviderBalance: z.number(),
+  gasTankChainId: z.coerce.bigint(),
+  gasProviderBalance: z.coerce.bigint(),
   gasProviderAddress: z
     .string()
     .refine(isAddress, 'invalid gas provider address'),
   pendingWithdrawal: z
     .object({
-      amount: z.number(),
-      initiatedAt: z.number(),
+      amount: z.coerce.bigint(),
+      initiatedAt: z.coerce.bigint(),
     })
     .optional(),
 })

--- a/apps/ponder-interop/src/api/index.ts
+++ b/apps/ponder-interop/src/api/index.ts
@@ -21,12 +21,12 @@ import type { Address } from 'viem'
 import { isAddress } from 'viem'
 
 type GasProvider = {
-  gasTankChainId: number
-  gasProviderBalance: number
+  gasTankChainId: bigint
+  gasProviderBalance: bigint
   gasProviderAddress: string
   pendingWithdrawal?: {
-    amount: number
-    initiatedAt: number
+    amount: bigint
+    initiatedAt: bigint
   }
 }
 
@@ -123,7 +123,7 @@ app.get('/messages/pending', async (c) => {
 
   const messages = result
     .map((m) => m.l2_to_l2_cdm_sent_messages)
-    .map((m) => replaceBigInts(m, (x) => Number(x)))
+    .map((m) => replaceBigInts(m, (x) => String(x)))
 
   return c.json(messages)
 })
@@ -153,7 +153,7 @@ app.get('/messages/:account/pending', async (c) => {
 
   const messages = result
     .map((m) => m.l2_to_l2_cdm_sent_messages)
-    .map((m) => replaceBigInts(m, (x) => Number(x)))
+    .map((m) => replaceBigInts(m, (x) => String(x)))
 
   return c.json(messages)
 })
@@ -179,13 +179,13 @@ app.get('/messages/pending/gas-tank', async (c) => {
     (acc, m) => {
       const messageId = m.message.messageIdentifierHash
       const gasTankInfo = {
-        gasTankChainId: Number(m.gasTankChainId),
-        gasProviderBalance: Number(m.gasProviderBalance),
+        gasTankChainId: m.gasTankChainId,
+        gasProviderBalance: m.gasProviderBalance,
         gasProviderAddress: m.gasProviderAddress,
         pendingWithdrawal: m.pendingWithdrawal
           ? {
-              amount: Number(m.pendingWithdrawal?.amount),
-              initiatedAt: Number(m.pendingWithdrawal?.initiatedAt),
+              amount: m.pendingWithdrawal?.amount,
+              initiatedAt: m.pendingWithdrawal?.initiatedAt,
             }
           : undefined,
       }
@@ -210,7 +210,7 @@ app.get('/messages/pending/gas-tank', async (c) => {
 
   const messages = Object.values(groupedMessages)
 
-  return c.json(messages.map((m) => replaceBigInts(m, (x) => Number(x))))
+  return c.json(messages.map((m) => replaceBigInts(m, (x) => String(x))))
 })
 
 app.get('/messages/pending/claims', async (c) => {
@@ -222,7 +222,7 @@ app.get('/messages/pending/claims', async (c) => {
 
   const result = await getPendingClaimsQuery(relayers)
 
-  return c.json(result.map((m) => replaceBigInts(m, (x) => Number(x))))
+  return c.json(result.map((m) => replaceBigInts(m, (x) => String(x))))
 })
 
 /**
@@ -256,7 +256,7 @@ app.get('/messages/pending/claims/:gasProvider/:chainId', async (c) => {
     return c.json({ error: 'Multiple gas providers found' }, 500)
   }
 
-  return c.json(replaceBigInts(result[0], (x) => Number(x)))
+  return c.json(replaceBigInts(result[0], (x) => String(x)))
 })
 
 function parseChainId(chainIdParam: string): bigint | null {


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/ecosystem-private/issues/409

## Changes
- Updates all ponder api endpoints to serialize `BigInt`s as `String` instead of `Number`
  - `String` should be used when serializing `BigInt`s in order to avoid potential overflows
- Fixes bug in message relaying where pending messages were not being properly grouped by their gas provider
  - `GasProvider`s were being grouped using a `Map`, however this did not have the intended outcome because equality with a `Map` is determined using reference equality and for the `GasProvider` shallow equality is needed. In order to fix, the `Map` was changed to a `Record` with a unique key for each `GasProvider`