### PR TITLE
build(deps): bump next

### DIFF
--- a/apps/dapp-console/package.json
+++ b/apps/dapp-console/package.json
@@ -29,7 +29,7 @@
     "clsx": "^2.0.0",
     "framer-motion": "^11.0.3",
     "mixpanel-browser": "^2.49.0",
-    "next": "14.1.1",
+    "next": "14.2.10",
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /apps/dapp-console directory: [next](https://github.com/vercel/next.js).


Updates `next` from 14.1.1 to 14.2.10
- [Release notes](https://github.com/vercel/next.js/releases)
- [Changelog](https://github.com/vercel/next.js/blob/canary/release.js)
- [Commits](https://github.com/vercel/next.js/compare/v14.1.1...v14.2.10)

---
updated-dependencies:
- dependency-name: next dependency-type: direct:production dependency-group: npm_and_yarn ...

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
