### PR TITLE
migrate to trusted publisher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - setup
       - run:
           name: Install npm with OIDC trusted publishing support
-          command: npm install -g npm@latest
+          command: npm install -g npm@11.12.1
       - run:
           name: Build projects
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
 jobs:
   publish-to-npm:
     docker:
-      - image: cimg/node:20.11
+      - image: cimg/node:22.14
     parameters:
       prepare-snapshot:
         type: boolean
@@ -59,25 +59,17 @@ jobs:
     steps:
       - setup
       - run:
+          name: Install npm with OIDC trusted publishing support
+          command: npm install -g npm@latest
+      - run:
           name: Build projects
           environment:
             NPM_TOKEN: nada
           command: pnpm nx run-many --target=build
       - run:
-          name: Check NPM Token
+          name: Obtain OIDC token for npm trusted publishing
           command: |
-            if [ -z "${NPM_TOKEN}" ]; then
-              echo "NPM_TOKEN is not set. Please set it in CircleCI project settings."
-              exit 1
-            fi
-      - run:
-          name: Configure NPM Token and Registry
-          command: |
-            npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-
-      - run:
-          name: Verify NPM Token
-          command: npm whoami
+            echo "export NPM_ID_TOKEN=$(circleci run oidc get --claims '{\"aud\": \"npm:registry.npmjs.org\"}')" >> "$BASH_ENV"
 
       - when:
           condition:
@@ -114,7 +106,7 @@ workflows:
       - publish-to-npm:
           name: Publish new versions
           context:
-            - circleci-repo-ecosystem # for GITHUB_TOKEN_GOVERNANCE && NPM_TOKEN
+            - circleci-repo-ecosystem # for GITHUB_TOKEN_GOVERNANCE
           filters:
             branches:
               only: main
@@ -123,7 +115,7 @@ workflows:
           name: Publish snapshot versions
           prepare-snapshot: true
           context:
-            - circleci-repo-ecosystem # for GITHUB_TOKEN_GOVERNANCE && NPM_TOKEN
+            - circleci-repo-ecosystem # for GITHUB_TOKEN_GOVERNANCE
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,11 @@ version: 2.1
 
 orbs:
   nx: nrwl/nx@1.7.0
-  utils: ethereum-optimism/circleci-utils@1.0.17
-
+  utils: ethereum-optimism/circleci-utils@1.0.27
 
 commands:
   prepare-snapshot:
-    description: 'Prepare the snapshot name'
+    description: "Prepare the snapshot name"
     steps:
       - run:
           name: Setup snapshot name
@@ -24,7 +23,7 @@ commands:
           command: pnpm release:version:snapshot
 
   setup:
-    description: 'Setup Node.js environment with pnpm and nx'
+    description: "Setup Node.js environment with pnpm and nx"
     steps:
       - utils/checkout-with-mise # Install dependencies
       - run:
@@ -79,8 +78,8 @@ jobs:
 
       - utils/changesets:
           createGithubReleases: false
-          publish: 'pnpm release:publish'
-          version: 'pnpm release:version'
+          publish: "pnpm release:publish"
+          version: "pnpm release:version"
 
   check:
     docker:
@@ -121,4 +120,6 @@ workflows:
               only: main
   check-workflow:
     jobs:
-      - check
+      - check:
+          context:
+            - circleci-repo-readonly-authenticated-github-token # for GITHUB_TOKEN (mise GitHub API auth)


### PR DESCRIPTION
This pull request updates the CircleCI configuration to support npm trusted publishing using OpenID Connect (OIDC) and removes the reliance on static NPM tokens. It also updates the Node.js version used for publishing, bumps the `circleci-utils` orb version, and makes minor formatting improvements.

**CI/CD: npm trusted publishing and OIDC integration**
* Replaces static `NPM_TOKEN` authentication with OIDC-based authentication for npm trusted publishing, including a new step to obtain an OIDC token and removing NPM token checks and configuration. (`.circleci/config.yml`)
* Updates the job context comments to reflect that `NPM_TOKEN` is no longer required. (`.circleci/config.yml`) [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L117-R108) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L126-R125)

**Dependency and environment updates**
* Updates the Node.js Docker image from `cimg/node:20.11` to `cimg/node:22.14` for the `publish-to-npm` job. (`.circleci/config.yml`)
* Bumps the `ethereum-optimism/circleci-utils` orb from version `1.0.17` to `1.0.27`. (`.circleci/config.yml`)

**Formatting and minor improvements**
* Changes single quotes to double quotes for consistency in command descriptions and steps. (`.circleci/config.yml`) [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L27-R26) [[2]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L90-R82)